### PR TITLE
Add strict serialization

### DIFF
--- a/Yaml-Serializable/include/configuration-validation.h
+++ b/Yaml-Serializable/include/configuration-validation.h
@@ -1,9 +1,49 @@
+/**********************************************************************************************
+ © 2020. Triad National Security, LLC. All rights reserved.
+ This program was produced under U.S. Government contract 89233218CNA000001 for Los Alamos
+ National Laboratory (LANL), which is operated by Triad National Security, LLC for the U.S.
+ Department of Energy/National Nuclear Security Administration. All rights in the program are
+ reserved by Triad National Security, LLC, and the U.S. Department of Energy/National Nuclear
+ Security Administration. The Government is granted for itself and others acting on its behalf a
+ nonexclusive, paid-up, irrevocable worldwide license in this material to reproduce, prepare
+ derivative works, distribute copies to the public, perform publicly and display publicly, and
+ to permit others to do so.
+ This program is open source under the BSD-3 License.
+ Redistribution and use in source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this list of
+ conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials
+ provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder nor the names of its contributors may be used
+ to endorse or promote products derived from this software without specific prior
+ written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ Author: Kevin Welsh (kwelsh@lanl.gov)
+ **********************************************************************************************/
+
 #ifndef CONFIGURATION_VALIDATION_H
 #define CONFIGURATION_VALIDATION_H
 
 #include <set>
 #include <string>
 #include <filesystem>
+#include <utility>
 
 namespace Yaml {
     struct ConfigurationException : std::runtime_error {
@@ -67,6 +107,18 @@ namespace Yaml {
         if(!std::filesystem::exists(path))
             throw ConfigurationException("Could not find file: " + abs_path);
         return abs_path;
+    }
+
+
+    inline void validate_subset(Node& a, Node& b) {
+        for (auto kv = b.Begin(); kv != b.End(); kv++) {
+            std::string key = std::get<0>(*kv);
+            Node value = std::get<1>(*kv);
+
+            if (a[key].IsNone()) {
+                throw ConfigurationException("Found unexpected field: " + key);
+            }
+        }
     }
 }
 

--- a/Yaml-Serializable/include/yaml-serializable.h
+++ b/Yaml-Serializable/include/yaml-serializable.h
@@ -1,3 +1,42 @@
+/**********************************************************************************************
+ © 2020. Triad National Security, LLC. All rights reserved.
+ This program was produced under U.S. Government contract 89233218CNA000001 for Los Alamos
+ National Laboratory (LANL), which is operated by Triad National Security, LLC for the U.S.
+ Department of Energy/National Nuclear Security Administration. All rights in the program are
+ reserved by Triad National Security, LLC, and the U.S. Department of Energy/National Nuclear
+ Security Administration. The Government is granted for itself and others acting on its behalf a
+ nonexclusive, paid-up, irrevocable worldwide license in this material to reproduce, prepare
+ derivative works, distribute copies to the public, perform publicly and display publicly, and
+ to permit others to do so.
+ This program is open source under the BSD-3 License.
+ Redistribution and use in source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this list of
+ conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials
+ provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder nor the names of its contributors may be used
+ to endorse or promote products derived from this software without specific prior
+ written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ Author: Kevin Welsh (kwelsh@lanl.gov)
+ **********************************************************************************************/
+
 #ifndef YAML_SERIALIZABLE_H
 #define YAML_SERIALIZABLE_H
 
@@ -93,7 +132,7 @@ namespace Yaml {
      * object.
     */
     template<typename T>
-    T from_file(std::string filename) {
+    T from_file(const std::string& filename) {
         Node node;
         // Pass c_str to get the file reading functionality.
         // If its a string it will just parse it directly.
@@ -103,7 +142,44 @@ namespace Yaml {
         return v;
     }
 
+    /**
+     * Load a YAML SERIALIZABLE object from a string. 
+     * Throws a Yaml::ConfigurationException if fields in the string representation
+     * were not used when creating the object.
+    */
+    template<typename T>
+    T from_string_strict(const std::string& s) {
+        Node node;
+        Parse(node, s);
+        T v;
+        deserialize(v, node);
 
+        Node re_serialized;
+        serialize(v, re_serialized);
+        validate_subset(re_serialized, node);
+        return v;
+    }
+
+    /**
+     * Load a YAML SERIALIZABLE object from a file. 
+     * Throws a Yaml::ConfigurationException if fields in the string representation
+     * were not used when creating the object.
+    */
+    template<typename T>
+    T from_file_strict(const std::string& filename) {
+        Node node;
+        // Pass c_str to get the file reading functionality.
+        // If its a string it will just parse it directly.
+        Parse(node, filename.c_str());
+        T v;
+        deserialize(v, node);
+
+        Node re_serialized;
+        serialize(v, re_serialized);
+        validate_subset(re_serialized, node);
+        return v;
+    }
+    
     template<typename T>
     void validate_required_fields(Yaml::Node& node) { }
 }


### PR DESCRIPTION
PR #74 lost functionality for guarding against "extra" yaml fields in the input file. This is a useful validation mechanism to guard against typos/incorrect specification.

However, our Simulation_Parameters are structured via class inheritance. We support in the serializer by [de]serializing the base class first and the [de]serializing the derived class. Additionally, there are sections of our code that intentionally deserialize the input options multiple times with different classes. If we build the overspecification guards automatically into the deserializer, these workflows would become significantly more complicated.

So instead, I chose to allow the API consumer to decide whether or not the string should be deserialized in a "strict" mode or not.

### Existing API:
* Yaml::from_string
* Yaml::from_file

### New API:
* Yaml::from_string_strict
* Yaml::from_file_strict

The new "strict" functions will throw a Yaml::ConfigurationException if a key is found in the input that doesn't correspond to a field in the target struct. This is achieved by first deserializing the object as normal, but then _re-serializing_ the struct and confirming that the input Yaml object is a subset of the re-serialized object. By recursively checking the nodes, we enforce that nested structures are deserialized strictly if the parent structure is with only one re-serialization step.


To make proper use of this, we will need to consolidate our parameters structs into a single end-point per application.