### PR TITLE
Change default allocation of FEA modules to validation that the user …

### DIFF
--- a/Parallel-Solvers/Implicit-Lagrange/Implicit_Solver.cpp
+++ b/Parallel-Solvers/Implicit-Lagrange/Implicit_Solver.cpp
@@ -847,8 +847,8 @@ void Implicit_Solver::read_mesh_ansys_dat(const char *MESH){
 
   //flag elasticity fea module for boundary/loading conditions readin that remains
   if(!No_Conditions){
-    //look for elasticity module in Simulation Parameters data; if not declared add the module
-    simparam.ensure_module(FEA_MODULE_TYPE::Elasticity);
+    // check that the input file has configured some kind of acceptable module
+    simparam.validate_module_is_specified(FEA_MODULE_TYPE::Elasticity);
     simparam_TO.fea_module_must_read.insert(FEA_MODULE_TYPE::Elasticity);
   }
 

--- a/Parallel-Solvers/Implicit-Lagrange/Simulation_Parameters/Simulation_Parameters_Topology_Optimization.h
+++ b/Parallel-Solvers/Implicit-Lagrange/Simulation_Parameters/Simulation_Parameters_Topology_Optimization.h
@@ -320,7 +320,7 @@ struct Simulation_Parameters_Topology_Optimization : public Simulation_Parameter
     
     auto fea_module = get_TO_module_dependency(type);
     if (fea_module.has_value())
-      ensure_module(fea_module.value());
+      validate_module_is_specified(fea_module.value());
   }
   std::optional<FEA_MODULE_TYPE> get_TO_module_dependency(TO_MODULE_TYPE type) {
     switch (type) {

--- a/Parallel-Solvers/Implicit-Lagrange/Simulation_Parameters/Simulation_Parameters_Topology_Optimization.h
+++ b/Parallel-Solvers/Implicit-Lagrange/Simulation_Parameters/Simulation_Parameters_Topology_Optimization.h
@@ -297,47 +297,58 @@ struct Simulation_Parameters_Topology_Optimization : public Simulation_Parameter
     // instead of this vector stuff.
     for (size_t to_index = 0; to_index < TO_Module_List.size(); to_index++) {
       auto to_module = TO_Module_List[to_index];
-      auto fea_module = get_TO_module_dependency(to_module);
-      if (!fea_module.has_value())
+      auto fea_index = find_TO_module_dependency(to_module);
+      if (!fea_index.has_value())
         continue;
-
-      size_t fea_index = find_module(fea_module.value());
-
-      TO_Module_My_FEA_Module[to_index] = fea_index;
-      FEA_Module_My_TO_Modules[fea_index].push_back(to_index);
+      TO_Module_My_FEA_Module[to_index] = fea_index.value();
+      FEA_Module_My_TO_Modules[fea_index.value()].push_back(to_index);
     }
   }
 
   void validate() {
     validate_unique_vector(TO_Module_List, "Duplicate Topology Optimization Module listed: ");
     validate_unique_vector(FEA_Modules_List, "Duplicate FEA Module listed: ");
+    for (auto t : TO_Module_List) {
+      find_TO_module_dependency(t);
+    }
   }
 
   void add_TO_module(TO_MODULE_TYPE type, FUNCTION_TYPE function_type, std::vector<double> arguments) {
     TO_Module_List.push_back(type);
     TO_Function_Type.push_back(function_type);
     Function_Arguments.push_back(arguments);
-    
-    auto fea_module = get_TO_module_dependency(type);
-    if (fea_module.has_value())
-      validate_module_is_specified(fea_module.value());
   }
-  std::optional<FEA_MODULE_TYPE> get_TO_module_dependency(TO_MODULE_TYPE type) {
+
+  /**
+   * Returns the index of the FEA dependency found in the 
+   * FEA_Module_List vector. 
+   * 
+   * If dependencies are not satisfied, an exception will be thrown.
+   * If there are no dependencies, -1 will be returned.
+  */
+  std::optional<size_t> find_TO_module_dependency(TO_MODULE_TYPE type) {
     switch (type) {
       case TO_MODULE_TYPE::Heat_Capacity_Potential_Minimize:
-        return FEA_MODULE_TYPE::Heat_Conduction;
+        validate_module_is_specified(FEA_MODULE_TYPE::Heat_Conduction);
+        return find_module(FEA_MODULE_TYPE::Heat_Conduction);
       case TO_MODULE_TYPE::Heat_Capacity_Potential_Constraint:
-        return FEA_MODULE_TYPE::Heat_Conduction;
+        validate_module_is_specified(FEA_MODULE_TYPE::Heat_Conduction);
+        return find_module(FEA_MODULE_TYPE::Heat_Conduction);
       case TO_MODULE_TYPE::Mass_Constraint:
-        return FEA_MODULE_TYPE::Inertial;
+        validate_module_is_specified(FEA_MODULE_TYPE::Inertial);
+        return find_module(FEA_MODULE_TYPE::Inertial);
       case TO_MODULE_TYPE::Moment_of_Inertia_Constraint:
-        return FEA_MODULE_TYPE::Inertial;
+        validate_module_is_specified(FEA_MODULE_TYPE::Inertial);
+        return find_module(FEA_MODULE_TYPE::Inertial);
       case TO_MODULE_TYPE::Strain_Energy_Minimize:
-        return FEA_MODULE_TYPE::Elasticity;
+        validate_module_is_specified(FEA_MODULE_TYPE::Elasticity);
+        return find_module(FEA_MODULE_TYPE::Elasticity);
       case TO_MODULE_TYPE::Thermo_Elastic_Strain_Energy_Minimize:
-        return FEA_MODULE_TYPE::Heat_Conduction;
+        validate_module_is_specified(FEA_MODULE_TYPE::Heat_Conduction);
+        return find_module(FEA_MODULE_TYPE::Heat_Conduction);
       case TO_MODULE_TYPE::Strain_Energy_Constraint:
-        return FEA_MODULE_TYPE::Elasticity;
+        validate_module_is_specified(FEA_MODULE_TYPE::Elasticity);
+        return find_module(FEA_MODULE_TYPE::Elasticity);
       default:
         return {};
     }

--- a/Parallel-Solvers/Implicit-Lagrange/example_simple.yaml
+++ b/Parallel-Solvers/Implicit-Lagrange/example_simple.yaml
@@ -25,8 +25,7 @@ fea_modules:
         component_x: 500
         component_y: 0
         component_z: 0
-
-fea_modules:
+  
   - type: Heat_Conduction
     # Dirichlet conditions
     boundary_conditions:

--- a/Parallel-Solvers/Parallel-Explicit/Eulerian_Solver/Simulation_Parameters_Eulerian.h
+++ b/Parallel-Solvers/Parallel-Explicit/Eulerian_Solver/Simulation_Parameters_Eulerian.h
@@ -121,9 +121,10 @@ struct Simulation_Parameters_Eulerian : Simulation_Parameters {
   void derive() {
     derive_kokkos_arrays();
     rk_num_bins = rk_num_stages;
-    ensure_module(FEA_MODULE_TYPE::Eulerian);
   }
-  void validate() { }
+  void validate() {
+    validate_module_is_specified(FEA_MODULE_TYPE::Eulerian);
+  }
 };
 IMPL_YAML_SERIALIZABLE_WITH_BASE(Simulation_Parameters_Eulerian, Simulation_Parameters, 
   time_variables, material_options, region_options, 

--- a/Parallel-Solvers/Parallel-Explicit/Explicit_Solver.cpp
+++ b/Parallel-Solvers/Parallel-Explicit/Explicit_Solver.cpp
@@ -931,9 +931,9 @@ void Explicit_Solver::read_mesh_ansys_dat(const char *MESH){
 
   //flag elasticity fea module for boundary/loading conditions readin that remains
   if(!No_Conditions){
-    //look for elasticity module in Simulation Parameters data; if not declared add the module
+    // check that the input file has configured some kind of acceptable module
+    simparam.validate_module_is_specified(FEA_MODULE_TYPE::Elasticity);
     simparam.fea_module_must_read.insert(FEA_MODULE_TYPE::Elasticity);
-    simparam.ensure_module(FEA_MODULE_TYPE::Elasticity);
     // TODO: What about simparam_dynamic_opt?
   }
 
@@ -1317,7 +1317,7 @@ void Explicit_Solver::setup_optimization_problem(){
     //initialize densities to 1 for now; in the future there might be an option to read in an initial condition for each node
     for(int inode = 0; inode < nlocal_nodes; inode++){
       node_densities_upper_bound(inode,0) = 1;
-      node_densities_lower_bound(inode,0) = simparam_dynamic_opt.optimization_options.density_epsilon;
+      node_densities_lower_bound(inode,0) = simparam_dynamic_opt.optimization_options.value().density_epsilon;
     }
 
     //set lower bounds for nodes on surfaces with boundary and loading conditions
@@ -1395,7 +1395,7 @@ void Explicit_Solver::setup_optimization_problem(){
     vec_array Element_Densities_Lower_Bound("Element Densities_Lower_Bound", rnum_elem, 1);
     for(int ielem = 0; ielem < rnum_elem; ielem++){
       Element_Densities_Upper_Bound(ielem,0) = 1;
-      Element_Densities_Lower_Bound(ielem,0) = simparam_dynamic_opt.optimization_options.density_epsilon;
+      Element_Densities_Lower_Bound(ielem,0) = simparam_dynamic_opt.optimization_options.value().density_epsilon;
     }
 
     //create global vector

--- a/Parallel-Solvers/Parallel-Explicit/SGH_Solver/Simulation_Parameters_SGH.h
+++ b/Parallel-Solvers/Parallel-Explicit/SGH_Solver/Simulation_Parameters_SGH.h
@@ -154,11 +154,11 @@ struct Simulation_Parameters_SGH : Simulation_Parameters {
  
     rk_num_bins = rk_num_stages;
 
-    ensure_module(FEA_MODULE_TYPE::SGH);
-
     derive_default_field_output();
   }
-  void validate() { }
+  void validate() {
+    validate_module_is_specified(FEA_MODULE_TYPE::SGH);
+  }
 };
 IMPL_YAML_SERIALIZABLE_WITH_BASE(Simulation_Parameters_SGH, Simulation_Parameters, 
   time_variables, material_options, region_options,

--- a/Parallel-Solvers/Parallel-Explicit/SGH_Solver/sgh_optimization.cpp
+++ b/Parallel-Solvers/Parallel-Explicit/SGH_Solver/sgh_optimization.cpp
@@ -542,7 +542,7 @@ void FEA_Module_SGH::compute_topology_optimization_adjoint(){
   if(myrank==0)
     std::cout << "Computing adjoint vector " << time_data.size() << std::endl;
 
-  for (int cycle = last_time_step; cycle >= 0; cycle--) {
+  for (long unsigned cycle = last_time_step; cycle >= 0; cycle--) {
     //compute timestep from time data
     global_dt = time_data[cycle+1] - time_data[cycle];
     
@@ -608,7 +608,7 @@ void FEA_Module_SGH::compute_topology_optimization_adjoint_full(){
   if(myrank==0)
     std::cout << "Computing adjoint vector " << time_data.size() << std::endl;
 
-  for (int cycle = last_time_step; cycle >= 0; cycle--) {
+  for (long unsigned cycle = last_time_step; cycle >= 0; cycle--) {
     //compute timestep from time data
     global_dt = time_data[cycle+1] - time_data[cycle];
     
@@ -849,7 +849,7 @@ void FEA_Module_SGH::compute_topology_optimization_gradient(const_vec_array desi
   Kokkos::fence();
 
   //gradient contribution from kinetic energy vMv product.
-  for (int cycle = 0; cycle < last_time_step+1; cycle++) {
+  for (long unsigned cycle = 0; cycle < last_time_step+1; cycle++) {
     //compute timestep from time data
     global_dt = time_data[cycle+1] - time_data[cycle];
     
@@ -963,7 +963,7 @@ void FEA_Module_SGH::compute_topology_optimization_gradient(const_vec_array desi
   Kokkos::fence();
 
   //gradient contribution from Force vector.
-  for (int cycle = 0; cycle < last_time_step+1; cycle++) {
+  for (long unsigned cycle = 0; cycle < last_time_step+1; cycle++) {
     //compute timestep from time data
     global_dt = time_data[cycle+1] - time_data[cycle];
     
@@ -1081,7 +1081,7 @@ void FEA_Module_SGH::compute_topology_optimization_gradient_full(Teuchos::RCP<co
     Kokkos::fence();
 
     //gradient contribution from kinetic energy v(dM/drho)v product.
-    for (int cycle = 0; cycle < last_time_step+1; cycle++) {
+    for (long unsigned cycle = 0; cycle < last_time_step+1; cycle++) {
       //compute timestep from time data
       global_dt = time_data[cycle+1] - time_data[cycle];
       
@@ -1163,7 +1163,7 @@ void FEA_Module_SGH::compute_topology_optimization_gradient_full(Teuchos::RCP<co
     Kokkos::fence();
 
     //gradient contribution from time derivative of adjoint \dot{lambda}(dM/drho)v product.
-    for (int cycle = 0; cycle < last_time_step+1; cycle++) {
+    for (long unsigned cycle = 0; cycle < last_time_step+1; cycle++) {
       //compute timestep from time data
       global_dt = time_data[cycle+1] - time_data[cycle];
       //print

--- a/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Dynamic_Optimization.h
+++ b/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Dynamic_Optimization.h
@@ -104,7 +104,6 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
   double penalty_power = 3.0;
 
   bool nodal_density_flag = true;
-
   
   // Non-serialized fields
   bool helmholtz_filter  = false;
@@ -170,7 +169,7 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
     // instead of this vector stuff.
     for (size_t to_index = 0; to_index < TO_Module_List.size(); to_index++) {
       auto to_module = TO_Module_List[to_index];
-      size_t fea_index = find_module(get_TO_module_dependency(to_module));
+      size_t fea_index = find_TO_module_dependency(to_module);
 
       TO_Module_My_FEA_Module[to_index] = fea_index;
       FEA_Module_My_TO_Modules[fea_index].push_back(to_index);
@@ -185,7 +184,7 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
   void validate() {
     // Check that the FEA module dependencies are satisfied.
     for (auto to_module : TO_Module_List)
-      validate_module_is_specified(get_TO_module_dependency(to_module)); 
+      find_TO_module_dependency(to_module); 
   }
 
   void add_TO_module(TO_MODULE_TYPE type, FUNCTION_TYPE function_type, std::vector<double> arguments) {
@@ -197,18 +196,29 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
     Function_Arguments.push_back(arguments);
   }
 
-  FEA_MODULE_TYPE get_TO_module_dependency(TO_MODULE_TYPE type) {
+  /**
+   * Find the TO module dependency in the FEA_Module_List list.
+   * Returns the index of the dependency satisfier. 
+   * 
+   * Throws a Yaml::ConfigurationException if one does not exist.
+  */
+  size_t find_TO_module_dependency(TO_MODULE_TYPE type) {
     switch (type) {
       case TO_MODULE_TYPE::Kinetic_Energy_Minimize:
-        return FEA_MODULE_TYPE::SGH;
+        validate_one_of_modules_are_specified({FEA_MODULE_TYPE::SGH, FEA_MODULE_TYPE::Dynamic_Elasticity});
+        return find_one_of_module({FEA_MODULE_TYPE::SGH, FEA_MODULE_TYPE::Dynamic_Elasticity});
       case TO_MODULE_TYPE::Heat_Capacity_Potential_Minimize:
-        return FEA_MODULE_TYPE::Heat_Conduction;
+        validate_module_is_specified(FEA_MODULE_TYPE::Heat_Conduction);
+        return find_module(FEA_MODULE_TYPE::Heat_Conduction);
       case TO_MODULE_TYPE::Heat_Capacity_Potential_Constraint:
-        return FEA_MODULE_TYPE::Heat_Conduction;
+        validate_module_is_specified(FEA_MODULE_TYPE::Heat_Conduction);
+        return find_module(FEA_MODULE_TYPE::Heat_Conduction);
       case TO_MODULE_TYPE::Mass_Constraint:
-        return FEA_MODULE_TYPE::Inertial;
+        validate_module_is_specified(FEA_MODULE_TYPE::Inertial);
+        return find_module(FEA_MODULE_TYPE::Inertial);
       case TO_MODULE_TYPE::Moment_of_Inertia_Constraint:
-        return FEA_MODULE_TYPE::Inertial;
+        validate_module_is_specified(FEA_MODULE_TYPE::Inertial);
+        return find_module(FEA_MODULE_TYPE::Inertial);
       default:
         throw Yaml::ConfigurationException(
           "Unsupported optimization module type " + to_string(type)

--- a/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Dynamic_Optimization.h
+++ b/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Dynamic_Optimization.h
@@ -78,6 +78,8 @@ struct Optimization_Options : Yaml::ValidatedYaml, Yaml::DerivedFields {
   bool method_of_moving_asymptotes;
   double simp_penalty_power;
   double density_epsilon;
+
+  void validate() { }
 };
 IMPL_YAML_SERIALIZABLE_FOR(Optimization_Options, 
   optimization_process, optimization_objective, 
@@ -90,7 +92,7 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
   int NB  = 6; // number of boundary patch sets to tag
   int NBD = 2; //number of density boundary conditions
 
-  Optimization_Options optimization_options;
+  std::optional<Optimization_Options> optimization_options;
   
   //When on, all element nodes connected to a boundary condition patch will have their density constrained
   bool thick_condition_boundary = true;
@@ -101,41 +103,37 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
   //Topology Optimization parameters
   double penalty_power = 3.0;
 
+  bool nodal_density_flag = true;
+
   
   // Non-serialized fields
   bool helmholtz_filter  = false;
   double density_epsilon = 0.0001;
   //list of TO functions needed by problem
-  std::vector<TO_MODULE_TYPE> TO_Module_List {
-    TO_MODULE_TYPE::Kinetic_Energy_Minimize
-  };
-  std::vector<FUNCTION_TYPE> TO_Function_Type {
-    FUNCTION_TYPE::OBJECTIVE
-  };
+  std::vector<TO_MODULE_TYPE> TO_Module_List;
+  std::vector<FUNCTION_TYPE> TO_Function_Type;
   std::vector<int> TO_Module_My_FEA_Module;
   std::vector<std::vector<int>> FEA_Module_My_TO_Modules;
   std::vector<std::vector<double>> Function_Arguments;
 
-  // TODO: Implement a real structure here.
-  // Then we can support this stuff.
-  // std::vector<int> Multi_Objective_Modules;
-  // std::vector<real_t> Multi_Objective_Weights;
-  // int nmulti_objective_modules = 0;
-
   //Topology Optimization flags
   bool topology_optimization_on = false;
   bool shape_optimization_on    = false;
-  bool nodal_density_flag       = true;
 
-  void derive() {
-    shape_optimization_on = optimization_options.optimization_process == OPTIMIZATION_PROCESS::shape_optimization;
-    topology_optimization_on = optimization_options.optimization_process == OPTIMIZATION_PROCESS::topology_optimization;
+  void derive_from_optimization_options() {
+    if (!optimization_options.has_value())
+      return;
+    auto options = optimization_options.value();
 
-    TO_Module_List.resize(optimization_options.constraints.size());
-    TO_Function_Type.resize(optimization_options.constraints.size());
-    Function_Arguments.resize(optimization_options.constraints.size());
-    for (size_t i = 0; i < optimization_options.constraints.size(); i++) {
-      auto constraint = optimization_options.constraints[i];
+    shape_optimization_on = options.optimization_process == OPTIMIZATION_PROCESS::shape_optimization;
+    topology_optimization_on = options.optimization_process == OPTIMIZATION_PROCESS::topology_optimization;
+
+    TO_Module_List.resize(options.constraints.size());
+    TO_Function_Type.resize(options.constraints.size());
+    Function_Arguments.resize(options.constraints.size());
+
+    for (size_t i = 0; i < options.constraints.size(); i++) {
+      auto constraint = options.constraints[i];
 
       // TODO: This whole thing is pretty messed up.
       // Both FEA Modules and TO_Modules really need to be structs
@@ -149,16 +147,19 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
       if (constraint.value.has_value())
         Function_Arguments[i] = { constraint.value.value() };
     }
-    
-    // Add this TO module if we added any.
-    if (optimization_options.constraints.size() > 0) {
-      ensure_TO_module(TO_MODULE_TYPE::Kinetic_Energy_Minimize, FUNCTION_TYPE::OBJECTIVE, {});
-    }
-  
-    // Take a pass first to ensure that all necessary modules are loaded.
-    for (auto to_module : TO_Module_List)
-      ensure_module(get_TO_module_dependency(to_module)); 
 
+    switch (options.optimization_objective) {
+      case OPTIMIZATION_OBJECTIVE::minimize_kinetic_energy:
+        add_TO_module(TO_MODULE_TYPE::Kinetic_Energy_Minimize, FUNCTION_TYPE::OBJECTIVE, {});
+        break;
+      default:
+        throw Yaml::ConfigurationException("Unsupported optimization objective " 
+          + to_string(options.optimization_objective)
+        );
+    }
+  }
+
+  void map_TO_to_FEA() {
     // Now we allocate the vectors for each of the currently identified modules.
     TO_Module_My_FEA_Module.resize(TO_Module_List.size());
     FEA_Module_My_TO_Modules.resize(FEA_Modules_List.size());
@@ -175,17 +176,27 @@ struct Simulation_Parameters_Dynamic_Optimization : public Simulation_Parameters
       FEA_Module_My_TO_Modules[fea_index].push_back(to_index);
     }
   }
-  void validate() { }
 
-  void ensure_TO_module(TO_MODULE_TYPE type, FUNCTION_TYPE function_type, std::vector<double> arguments) {
+  void derive() {
+    derive_from_optimization_options();
+    map_TO_to_FEA();
+  }
+
+  void validate() {
+    // Check that the FEA module dependencies are satisfied.
+    for (auto to_module : TO_Module_List)
+      validate_module_is_specified(get_TO_module_dependency(to_module)); 
+  }
+
+  void add_TO_module(TO_MODULE_TYPE type, FUNCTION_TYPE function_type, std::vector<double> arguments) {
     if (std::find(TO_Module_List.begin(), TO_Module_List.end(), type) != TO_Module_List.end())
       return; // Already have it.
     
     TO_Module_List.push_back(type);
     TO_Function_Type.push_back(function_type);
     Function_Arguments.push_back(arguments);
-    ensure_module(get_TO_module_dependency(type)); 
   }
+
   FEA_MODULE_TYPE get_TO_module_dependency(TO_MODULE_TYPE type) {
     switch (type) {
       case TO_MODULE_TYPE::Kinetic_Energy_Minimize:

--- a/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Explicit.h
+++ b/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Explicit.h
@@ -143,8 +143,6 @@ struct Simulation_Parameters_Explicit : Simulation_Parameters {
  
     rk_num_bins = rk_num_stages;
 
-    //ensure_module(FEA_MODULE_TYPE::SGH);
-
     derive_default_field_output();
   }
   void validate() { }

--- a/Parallel-Solvers/Parallel-Explicit/example_simple.yaml
+++ b/Parallel-Solvers/Parallel-Explicit/example_simple.yaml
@@ -16,7 +16,7 @@ input_options:
 
 output_options:
     graphics_step: 0.25
-    output_file_format: vtk 
+    output_file_format: vtk
 
 fea_modules:
   - type: SGH


### PR DESCRIPTION
Previously we did a lot of defaulting of FEA modules. The configuration for those modules was pulled from the default code values defined in the struct. We used to do this in two cases:

1. When we load an FEA module, we make sure it was specified in the in base module list by putting it there. Of course it was, that's how we supposedly got here in the first place.
2. When we look at the Topology Optimization constraints/objectives. They have FEA module dependencies, and we would allocate a default one when it wasn't present.

Now we will throw an error if the user didn't provide any specification for the expected module. Only really changes behavior for case 2, where we will tell the user to go back and specify allocation for an FEA module that the TO module needs.


### Removed API
* ensure_module(FEA_Module_Spec default_spec)

### Added API
* validate_module_is_specified(FEA_MODULE_TYPE) -- Throws an error if the module wasn't specified.
* validate_modules_are_specified(vector<FEA_MODULE_TYPE>) -- Throws an error if **any** of the modules aren't specified.
* validate_one_of_modules_are_specified(vector<FEA_MODULE_TYPE>) -- Throws an error if **none** of the modules are specified.

(If you have a better name for the last one, let me know...)

## Ansys Files
Before we would attempt to allocate a new Elasticity module if the relevant information was provided in the Ansys input file. Then we would read the configuration from the file. Now we throw an error if an Elasticity module is not specified in the input, but elasticity information is present in the file.
