### PR TITLE
removed all compile time arrays

### DIFF
--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -50,9 +50,6 @@ Which gives the following output:
 
 ```
 Required arguments:
-  -x, --x-dim    <value>    x dimension of RVE 
-  -y, --y-dim    <value>    y dimension of RVE 
-  -z, --z-dim    <value>    z dimension of RVE 
   -f, --infile   <path>     input file (full path)
 ...
 ```
@@ -67,7 +64,7 @@ We have provided example input files in the `example_input_files` directory. In 
 With all these files available you can now run EVPFFT as:
 
 ```
-mpirun -np 4 evpfft --x-dim=8 --y-dim=8 --z-dim=8 --infile=example_evpfft_standalone_inputfile.txt
+mpirun -np 4 evpfft --infile=example_evpfft_standalone_inputfile.txt
 ```
 
 # Using EVPFFT with Fierro
@@ -110,25 +107,13 @@ The EVPFFT `CMakeLists.txt` uses the following default values to build EVPFFT:
 ```
   TWO_SIGN_SLIP_SYSTEMS: OFF
   NON_SCHMID_EFFECTS: OFF
-  NPHMX: 1
-  NMODMX: 1
-  NTWMMX: 1
-  NSYSMX: 12
   ABSOLUTE_NO_OUTPUT: OFF
   ENABLE_PROFILE: OFF
 ```
 
-To change these default options include the `-D OPTION=<value>` in the `cmake` option, E.g. `-D NSYSMX=24` in the `build_evpfft.sh`.
+To change these default options include the `-D OPTION=<value>` in the `cmake` option, E.g. `-D ABSOLUTE_NO_OUTPUT=ON` in the `build_evpfft.sh`.
 
 # Using EVPFFT for Lattice Structure Homogenization
-
-To use EVPFFT for lattice structure homogenization compile with the following flags
-```
-  -D NPHMX=2
-  -D NMODMX=0
-  -D NTWMMX=0
-  -D NSYSMX=0
-```
 
 Example for input files needed to run EVPFFT for lattice structure homogenization is shown in `example_input_files/lattice_input_files`. In that file you will see how to set up evpft input file, elastic and plastic parameter files.
 
@@ -136,7 +121,7 @@ Provide a `STRUCTURED_POINTS` vtk file type that contains information about whic
 
 Run EVPFFT as:
 ```
-  mpirun -n 1 --bind-to core evpfft -x 32 -y 32 -z 32 -m 2 -f evpfft_lattice_input.txt
+  mpirun -n 1 -f evpfft_lattice_input.txt -m 2
 ```
 the `-m 2` option tells EVPFFT to use the vtk lattice file microstructure file type.
 

--- a/src/EVPFFT/example_input_files/example_evpfft_fierro_inputfile.txt
+++ b/src/EVPFFT/example_input_files/example_evpfft_fierro_inputfile.txt
@@ -1,3 +1,5 @@
+1 1 1 12               NPHMX, NMODMX, NTWMMX, NSYSMX
+8 8 8                  x-dim, y-dim, z-dim
 1                      number of phases (nph)                         
 1.  1.  1.             RVE dimensions (delt)
 * name and path of microstructure file (filetext)                                

--- a/src/EVPFFT/example_input_files/example_evpfft_standalone_inputfile.txt
+++ b/src/EVPFFT/example_input_files/example_evpfft_standalone_inputfile.txt
@@ -1,3 +1,5 @@
+1 1 1 12               NPHMX, NMODMX, NTWMMX, NSYSMX
+8 8 8                  x-dim, y-dim, z-dim
 1                      number of phases (nph)                         
 1.  1.  1.             RVE dimensions (delt)
 * name and path of microstructure file (filetext)                                

--- a/src/EVPFFT/example_input_files/lattice_input_files/evpfft_lattice_input.txt
+++ b/src/EVPFFT/example_input_files/lattice_input_files/evpfft_lattice_input.txt
@@ -1,3 +1,5 @@
+2 0 0 0               NPHMX, NMODMX, NTWMMX, NSYSMX
+32 32 32               x-dim, y-dim, z-dim
 2                      number of phases (nph)                         
 1.  1.  1.             RVE dimensions (delt)
 * name and path of microstructure file (filetext)                                

--- a/src/EVPFFT/src/CMakeLists.txt
+++ b/src/EVPFFT/src/CMakeLists.txt
@@ -26,20 +26,12 @@ endif(NOT CMAKE_BUILD_TYPE)
 # Set default values for EVPFFT options
 set(DEFAULT_TWO_SIGN_SLIP_SYSTEMS OFF)
 set(DEFAULT_NON_SCHMID_EFFECTS OFF)
-set(DEFAULT_NPHMX 1)
-set(DEFAULT_NMODMX 1)
-set(DEFAULT_NTWMMX 1)
-set(DEFAULT_NSYSMX 12)
 set(DEFAULT_ABSOLUTE_NO_OUTPUT OFF)
 set(DEFAULT_ENABLE_PROFILING OFF)
 
 # User-configurable options
 set(TWO_SIGN_SLIP_SYSTEMS ${DEFAULT_TWO_SIGN_SLIP_SYSTEMS} CACHE BOOL "Enable two sign slip systems")
 set(NON_SCHMID_EFFECTS ${DEFAULT_NON_SCHMID_EFFECTS} CACHE BOOL "Enable non-Schmid effects")
-set(NPHMX ${DEFAULT_NPHMX} CACHE STRING "Maximum number of phases")
-set(NMODMX ${DEFAULT_NMODMX} CACHE STRING "Maximum number of active SL+TW modes in any phase")
-set(NTWMMX ${DEFAULT_NTWMMX} CACHE STRING "Maximum number of active twin modes in any phase")
-set(NSYSMX ${DEFAULT_NSYSMX} CACHE STRING "Maximum number of active SL+TW systems in any phase")
 set(ABSOLUTE_NO_OUTPUT ${DEFAULT_ABSOLUTE_NO_OUTPUT} CACHE BOOL "Enable ABSOLUTE_NO_OUTPUT")
 set(ENABLE_PROFILING ${DEFAULT_ENABLE_PROFILING} CACHE BOOL "Enable profiling each function in EVPFFT")
 # ...
@@ -48,18 +40,9 @@ set(ENABLE_PROFILING ${DEFAULT_ENABLE_PROFILING} CACHE BOOL "Enable profiling ea
 message("EVPFFT will be built With those CMAKE options:")
 message("  TWO_SIGN_SLIP_SYSTEMS: ${TWO_SIGN_SLIP_SYSTEMS}")
 message("  NON_SCHMID_EFFECTS: ${NON_SCHMID_EFFECTS}")
-message("  NPHMX: ${NPHMX}")
-message("  NMODMX: ${NMODMX}")
-message("  NTWMMX: ${NTWMMX}")
-message("  NSYSMX: ${NSYSMX}")
 message("  ABSOLUTE_NO_OUTPUT: ${ABSOLUTE_NO_OUTPUT}")
 message("  ENABLE_PROFILING: ${ENABLE_PROFILING}")
 
-# Use the options in your CMake configuration as needed
-add_definitions(-DNPHMX=${NPHMX}
-                 -DNMODMX=${NMODMX}
-                 -DNTWMMX=${NTWMMX}
-                 -DNSYSMX=${NSYSMX})
 
 if(TWO_SIGN_SLIP_SYSTEMS)
   add_definitions(-DTWO_SIGN_SLIP_SYSTEMS=1)
@@ -95,6 +78,7 @@ set( Sources
      main.cpp
      command_line_args.cpp
      evpfft.cpp
+     allocate_memory.cpp
      utilities.cpp
      math_functions.cpp
      chg_basis.cpp

--- a/src/EVPFFT/src/allocate_memory.cpp
+++ b/src/EVPFFT/src/allocate_memory.cpp
@@ -1,0 +1,147 @@
+#include "evpfft.h"
+
+void EVPFFT::allocate_memory()
+{
+
+  fft = std::make_shared<FFT3D_R2C<heffte_backend,real_t>>(mpi_comm, std::array<int,3>{npts1_g,npts2_g,npts3_g});
+
+  npts1 = fft->localRealBoxSizes[my_rank][0];
+  npts2 = fft->localRealBoxSizes[my_rank][1];
+  npts3 = fft->localRealBoxSizes[my_rank][2];
+  local_start1 = fft->localRealBoxes[my_rank].low[0];
+  local_start2 = fft->localRealBoxes[my_rank].low[1];
+  local_start3 = fft->localRealBoxes[my_rank].low[2];
+  local_end1 = fft->localRealBoxes[my_rank].high[0];
+  local_end2 = fft->localRealBoxes[my_rank].high[1];
+  local_end3 = fft->localRealBoxes[my_rank].high[2];
+  wgt = real_t(1.0) / real_t(npts1_g*npts2_g*npts3_g);
+
+  npts1_g_cmplx = fft->globalComplexBoxSize[0];
+  npts2_g_cmplx = fft->globalComplexBoxSize[0];
+  npts3_g_cmplx = fft->globalComplexBoxSize[0];
+  npts1_cmplx = fft->localComplexBoxSizes[my_rank][0];
+  npts2_cmplx = fft->localComplexBoxSizes[my_rank][1];
+  npts3_cmplx = fft->localComplexBoxSizes[my_rank][2];
+  local_start1_cmplx = fft->localComplexBoxes[my_rank].low[0];
+  local_start2_cmplx = fft->localComplexBoxes[my_rank].low[1];
+  local_start3_cmplx = fft->localComplexBoxes[my_rank].low[2];
+  local_end1_cmplx = fft->localComplexBoxes[my_rank].high[0];
+  local_end2_cmplx = fft->localComplexBoxes[my_rank].high[1];
+  local_end3_cmplx = fft->localComplexBoxes[my_rank].high[2];
+
+  udot  = MatrixTypeRealDual (3,3);
+  dsim = MatrixTypeRealHost (3,3);
+  scauchy = MatrixTypeRealHost (3,3);
+  sdeviat = MatrixTypeRealHost (3,3);
+  tomtot = MatrixTypeRealDual (3,3);
+  delt = MatrixTypeRealHost (3);
+
+  disgradmacro = MatrixTypeRealDual (3,3);
+  ddisgradmacro = MatrixTypeRealDual (3,3);
+  scauav = MatrixTypeRealHost (3,3);
+  ddisgradmacroacum = MatrixTypeRealHost (3,3);
+  velmax = MatrixTypeRealHost (3);
+  iudot = MatrixTypeIntHost (3,3);
+  idsim = MatrixTypeIntHost (6);
+  iscau = MatrixTypeIntHost (6);
+
+  dnca = MatrixTypeRealDual (3,NSYSMX,NPHMX);
+  dbca = MatrixTypeRealDual (3,NSYSMX,NPHMX);
+  schca = MatrixTypeRealDual (5,NSYSMX,NPHMX);
+  tau = MatrixTypeRealDual (NSYSMX,3,NPHMX);
+  hard = MatrixTypeRealDual (NSYSMX,NSYSMX,NPHMX);
+  thet = MatrixTypeRealDual (NSYSMX,2,NPHMX);
+  nrs = MatrixTypeIntDual (NSYSMX,NPHMX);
+  gamd0 = MatrixTypeRealDual (NSYSMX,NPHMX);
+#ifdef NON_SCHMID_EFFECTS
+  dtca = MatrixTypeRealHost (3,NSYSMX,NPHMX);
+  cns = MatrixTypeRealHost (5,NMODMX,NPHMX);
+  schcnon = MatrixTypeRealDual (5,NSYSMX,NPHMX);
+#endif
+
+  twsh = MatrixTypeRealHost (NSYSMX,NPHMX);
+  nsm = MatrixTypeIntHost (NMODMX,NPHMX);
+  nmodes = MatrixTypeIntHost (NPHMX);
+  nsyst = MatrixTypeIntDual (NPHMX);
+  ntwmod = MatrixTypeIntHost (NPHMX);
+  ntwsys = MatrixTypeIntHost (NPHMX);
+  isectw = MatrixTypeIntHost (NSYSMX,NPHMX);
+  icryst = MatrixTypeStringHost (NPHMX);
+
+  igas = MatrixTypeIntDual (NPHMX);
+
+  cc = MatrixTypeRealHost (3,3,3,3,NPHMX);
+  c0 = MatrixTypeRealDual (3,3,3,3);
+  s0 = MatrixTypeRealDual (3,3,3,3);
+  c066 = MatrixTypeRealDual (6,6);
+
+  scauav1 = MatrixTypeRealHost (3,3);
+
+  xk_gb = MatrixTypeRealDual (npts1);
+  yk_gb = MatrixTypeRealDual (npts2);
+  zk_gb = MatrixTypeRealDual (npts3);
+
+  sg = MatrixTypeRealDual (3, 3, npts1, npts2, npts3);
+  disgrad = MatrixTypeRealDual (3, 3, npts1, npts2, npts3);
+  velgrad = MatrixTypeRealDual (3, 3, npts1, npts2, npts3);
+  edotp = MatrixTypeRealDual (3, 3, npts1, npts2, npts3);
+  cg66 = MatrixTypeRealDual (6, 6, npts1, npts2, npts3);
+  ept = MatrixTypeRealDual (3, 3, npts1, npts2, npts3);
+  ag = MatrixTypeRealDual (3, 3, npts1, npts2, npts3);
+  crss = MatrixTypeRealDual (NSYSMX, 2, npts1, npts2, npts3);
+  sch = MatrixTypeRealDual (5, NSYSMX, npts1, npts2, npts3);
+#ifdef NON_SCHMID_EFFECTS
+  schnon = MatrixTypeRealDual (5, NSYSMX, npts1, npts2, npts3);
+#endif
+
+  gamdot = MatrixTypeRealDual (NSYSMX, npts1, npts2, npts3);
+  gacumgr = MatrixTypeRealDual (npts1, npts2, npts3);
+  //trialtau = MatrixTypeRealDual (NSYSMX, 2, npts1, npts2, npts3);
+  xkin = MatrixTypeRealDual (NSYSMX, npts1, npts2, npts3);
+
+  ph_array = MatrixTypeRealHost (npts1, npts2, npts3);
+  th_array = MatrixTypeRealHost (npts1, npts2, npts3);
+  om_array = MatrixTypeRealHost (npts1, npts2, npts3);
+  jphase = MatrixTypeIntDual (npts1, npts2, npts3);
+  jgrain = MatrixTypeIntHost (npts1, npts2, npts3);
+
+  work = MatrixTypeRealDual (3, 3, npts1, npts2, npts3);
+  workim = MatrixTypeRealDual (3, 3, npts1_cmplx, npts2_cmplx, npts3_cmplx);
+  data = MatrixTypeRealDual (npts1, npts2, npts3);
+  data_cmplx = MatrixTypeRealDual (2, npts1_cmplx, npts2_cmplx, npts3_cmplx);
+
+  epav = MatrixTypeRealHost (3,3);
+  edotpav = MatrixTypeRealHost (3,3);
+  disgradmacroactual = MatrixTypeRealHost (3,3);
+  disgradmacrot = MatrixTypeRealHost (3,3);
+  velgradmacro = MatrixTypeRealHost (3,3);
+
+  // for fierro linking
+  M66 = MatrixTypeRealHost (6,6);
+  edotp_avg = MatrixTypeRealHost (3,3);
+  dedotp66_avg = MatrixTypeRealHost (6,6);
+  cg66_avg = MatrixTypeRealHost (6,6);
+  sg66_avg = MatrixTypeRealHost (6,6);
+  udotAcc = MatrixTypeRealHost (3,3);
+
+  //... For file management
+  mpi_io_real_t = std::make_shared<Manager_MPI_IO<real_t,MPI_ORDER_FORTRAN>>
+    (mpi_comm, fft->globalRealBoxSize, fft->localRealBoxSizes[my_rank], fft->localRealBoxes[my_rank].low, 3, 0);
+
+  mpi_io_int = std::make_shared<Manager_MPI_IO<int,MPI_ORDER_FORTRAN>>
+    (mpi_comm, fft->globalRealBoxSize, fft->localRealBoxSizes[my_rank], fft->localRealBoxes[my_rank].low, 3, 0);
+
+  micro_writer = std::make_shared<MicroOutputWriter<MPI_ORDER_FORTRAN>>
+    (mpi_comm, hdf5_filename.c_str(), 3, fft->globalRealBoxSize.data(), fft->localRealBoxSizes[my_rank].data(),
+     fft->localRealBoxes[my_rank].low.data());
+  //...
+
+
+  // Device memory space
+  rss = MatrixTypeRealDevice (NSYSMX, npts1, npts2, npts3);
+  rss1 = MatrixTypeRealDevice (NSYSMX, npts1, npts2, npts3);
+  rss2 = MatrixTypeRealDevice (NSYSMX, npts1, npts2, npts3);
+
+  set_some_voxels_arrays_to_zero();
+  return;
+}

--- a/src/EVPFFT/src/command_line_args.cpp
+++ b/src/EVPFFT/src/command_line_args.cpp
@@ -8,11 +8,8 @@ CommandLineArgs::CommandLineArgs()
 
 void CommandLineArgs::parse_command_line(int argc, char *argv[])
 {
-    const char* const short_opts = "x:y:z:f:m:e:g:p:u:h";
-    const option long_opts[] = {{"x-dim", required_argument, nullptr, 'x'},
-                                {"y-dim", required_argument, nullptr, 'y'},
-                                {"z-dim", required_argument, nullptr, 'z'},
-                                {"infile", required_argument, nullptr, 'f'},
+    const char* const short_opts = "f:m:e:g:p:u:h";
+    const option long_opts[] = {{"infile", required_argument, nullptr, 'f'},
                                 {"micro-filetype", required_argument, nullptr, 'm'},
                                 {"euler-angles", required_argument, nullptr, 'e'},
                                 {"feature-ids", required_argument, nullptr, 'g'},
@@ -30,17 +27,6 @@ void CommandLineArgs::parse_command_line(int argc, char *argv[])
 
         switch (opt)
         {
-        case 'x': 
-          nn[0] = atoi(optarg);
-          break;
-
-        case 'y': 
-          nn[1] = atoi(optarg); 
-          break;
-
-        case 'z': 
-          nn[2] = atoi(optarg);
-          break;
 
         case 'f':
           input_filename = optarg;
@@ -85,11 +71,7 @@ void CommandLineArgs::parse_command_line(int argc, char *argv[])
 
 void CommandLineArgs::check_cmd_args()
 {
-    if (nn[0] == 0 or 
-        nn[1] == 0 or 
-        nn[2] == 0 or
-        input_filename.size() == 0)
-    {
+    if (input_filename.size() == 0) {
       print_help();
     }
 
@@ -107,13 +89,10 @@ void CommandLineArgs::check_cmd_args()
 void CommandLineArgs::print_help()
 {
 std::cout << "Required arguments:\n"
-             "  -x, --x-dim    <value>    x dimension of RVE\n"
-             "  -y, --y-dim    <value>    y dimension of RVE\n"
-             "  -z, --z-dim    <value>    z dimension of RVE\n"
-             "  -f, --infile   <path>     input file (full path)\n"
+            "  -f, --infile   <path>     input file (full path)\n"
              "\n"
              "Optional arguments:\n"
-             "  -m, --micro-filetype <value>    microstructure file type (0: ASCII, 1: HDF5)\n"
+             "  -m, --micro-filetype <value>    microstructure file type (0: ASCII, 1: HDF5, 2: VTK)\n"
              "  -e, --euler-angles   <path>     full path to euler angles dataset in HDF5 file\n"
              "  -g, --feature-ids    <path>     full path to feature ids dataset in HDF5 file\n"
              "  -p, --phase-ids      <path>     full path to phase ids dataset in HDF5 file\n"
@@ -122,10 +101,10 @@ std::cout << "Required arguments:\n"
              "\n"
             "Examples:\n"
              "  Los Alamos FFT ASCII microstructure filetype:\n"
-             "    ./executable -x 16 -y 16 -z 16 -f <inputfile_path>\n"
-             "    ./executable --x-dim=16 --y-dim=16 --z-dim=16 --infile=<inputfile_path>\n"
+             "    ./executable -f <inputfile_path>\n"
+             "    ./executable --infile=<inputfile_path>\n"
              "  HDF5 microstructure filetype:\n"
-             "    ./executable -x 16 -y 16 -z 16 -f <inputfile_path> -m 1 -e <eulerAngles_path> -g <featureIds_path> -p <phaseIds_path> -u 1\n";
+             "    ./executable -f <inputfile_path> -m 1 -e <eulerAngles_path> -g <featureIds_path> -p <phaseIds_path> -u 1\n";
     
    exit(1);
 }

--- a/src/EVPFFT/src/command_line_args.h
+++ b/src/EVPFFT/src/command_line_args.h
@@ -5,7 +5,6 @@
 
 struct CommandLineArgs
 {
-    std::array<int,3> nn = {0,0,0};
     std::string input_filename; // name and path of input file (./fft.in)
 
     // micro_filetype = 0 means classic Los Alamos FFT ASCII microstructure filetype

--- a/src/EVPFFT/src/data_crystal.cpp
+++ b/src/EVPFFT/src/data_crystal.cpp
@@ -47,12 +47,6 @@ void EVPFFT::data_crystal(int iph, const std::string & filecryspl)
   }
   CLEAR_LINE(ur1);
 
-  if (nmodes(iph) > NMODMX) {
-    printf("nmodes IN PHASE %d IS %d, which exceeds NMODMX=%d\n", iph, nmodes(iph), NMODMX);
-    printf("Recompile EVPFFT with -DNMODMX=<max_nmode>\n");
-    exit(1);
-  }
-
   ntwmod(iph) = 0;
   nsyst.host(iph)  = 0;
   ntwsys(iph) = 0;
@@ -136,12 +130,6 @@ void EVPFFT::data_crystal(int iph, const std::string & filecryspl)
       nsm(kount,iph) = nsmx;
       if (twshx != 0) ntwmod(iph) = ntwmod(iph) + 1;
 
-      if (ntwmod(iph) > NTWMMX) {
-        printf("NTWMOD IN PHASE %d IS %d, which exceeds NTWMMX=%d\n", iph, ntwmod(iph), NTWMMX);
-        printf("Recompile EVPFFT with -DNTWMMX=<max_ntwmod>\n");
-        exit(1);
-      }
-
 #ifdef NON_SCHMID_EFFECTS
     //===============non_schmid_effects ===================================    
     // NOTE: the reading sequence here might be wrong.
@@ -163,13 +151,6 @@ void EVPFFT::data_crystal(int iph, const std::string & filecryspl)
         nsyst.host(iph) = nsyst.host(iph) + 1;
         nsysx = nsyst.host(iph);
         if (twshx != 0) ntwsys(iph) = ntwsys(iph) + 1;
-
-        if (nsyst.host(iph) > NSYSMX) {
-          printf("NSYST IN PHASE %d IS %d, which exceeds NSYSMX=%d\n", iph, nsyst.host(iph), NSYSMX);
-          printf("Recompile EVPFFT with -DNSYSMX=<max_nsyst>\n");
-          exit(1);
-        }
-
 
         //
         //   DEFINES RATE SENSITIVITY AND CRSS FOR EACH SYSTEM IN THE MODE

--- a/src/EVPFFT/src/evpfft.h
+++ b/src/EVPFFT/src/evpfft.h
@@ -24,32 +24,37 @@ public:
   ChgBasis cb;
   std::shared_ptr<FFT3D_R2C<heffte_backend,real_t>> fft;
 
-  const int npts1_g;   // global array size in x dim.
-  const int npts2_g;   // global array size in y dim.
-  const int npts3_g;   // global array size in z dim.
-  const int npts1;     // local per rank array size in x dim.
-  const int npts2;     // local per rank array size in y dim.
-  const int npts3;     // local per rank array size in z dim.
-  const int local_start1; // start index of local array in x dim.
-  const int local_start2; // start index of local array in y dim.
-  const int local_start3; // start index of local array in z dim.
-  const int local_end1;   // end index of local array in x dim.
-  const int local_end2;   // end index of local array in y dim.
-  const int local_end3;   // end index of local array in z dim.
-  const real_t wgt;
+  int npts1_g;   // global array size in x dim.
+  int npts2_g;   // global array size in y dim.
+  int npts3_g;   // global array size in z dim.
+  int npts1;     // local per rank array size in x dim.
+  int npts2;     // local per rank array size in y dim.
+  int npts3;     // local per rank array size in z dim.
+  int local_start1; // start index of local array in x dim.
+  int local_start2; // start index of local array in y dim.
+  int local_start3; // start index of local array in z dim.
+  int local_end1;   // end index of local array in x dim.
+  int local_end2;   // end index of local array in y dim.
+  int local_end3;   // end index of local array in z dim.
+  real_t wgt;
 
-  const int npts1_g_cmplx;   // complex global array size in x dim.
-  const int npts2_g_cmplx;   // complex global array size in y dim.
-  const int npts3_g_cmplx;   // complex global array size in z dim.
-  const int npts1_cmplx;     // complex local per rank array size in x dim.
-  const int npts2_cmplx;     // complex local per rank array size in y dim.
-  const int npts3_cmplx;     // complex local per rank array size in z dim.
-  const int local_start1_cmplx; // complex start index of local array in x dim.
-  const int local_start2_cmplx; // complex start index of local array in y dim.
-  const int local_start3_cmplx; // complex start index of local array in z dim.
-  const int local_end1_cmplx;   // complex end index of local array in x dim.
-  const int local_end2_cmplx;   // complex end index of local array in y dim.
-  const int local_end3_cmplx;   // complex end index of local array in z dim.
+  int npts1_g_cmplx;   // complex global array size in x dim.
+  int npts2_g_cmplx;   // complex global array size in y dim.
+  int npts3_g_cmplx;   // complex global array size in z dim.
+  int npts1_cmplx;     // complex local per rank array size in x dim.
+  int npts2_cmplx;     // complex local per rank array size in y dim.
+  int npts3_cmplx;     // complex local per rank array size in z dim.
+  int local_start1_cmplx; // complex start index of local array in x dim.
+  int local_start2_cmplx; // complex start index of local array in y dim.
+  int local_start3_cmplx; // complex start index of local array in z dim.
+  int local_end1_cmplx;   // complex end index of local array in x dim.
+  int local_end2_cmplx;   // complex end index of local array in y dim.
+  int local_end3_cmplx;   // complex end index of local array in z dim.
+
+  int NPHMX;    //Maximum number of phases
+  int NMODMX;   //Maximum number of active SL+TW modes in any phase
+  int NTWMMX;   //Maximum number of active twin modes in any phase
+  int NSYSMX;   //Maximum number of active SL+TW systems in any phase
 
   MatrixTypeRealDual udot;
   MatrixTypeRealHost dsim;
@@ -100,10 +105,8 @@ public:
   int nelem;
   int iphbot;
   int iphtop;
-  int ngr;
   
   const real_t pi;
-  int jran;
 
   real_t error;
   real_t fact2;
@@ -135,7 +138,6 @@ public:
   real_t svm1;
   MatrixTypeRealHost scauav1;
 
-  const int num_crystals; //# OF Crystals (grains) in the input texture
   MatrixTypeRealHost eth;
   int ithermo;
 
@@ -196,10 +198,17 @@ public:
   double dtAcc;
 
   // For file management
+  std::string hdf5_filename;
   OutputFileManager ofile_mgr;
   std::shared_ptr<Manager_MPI_IO<real_t,MPI_ORDER_FORTRAN>> mpi_io_real_t;
   std::shared_ptr<Manager_MPI_IO<int,MPI_ORDER_FORTRAN>> mpi_io_int;
   std::shared_ptr<MicroOutputWriter<MPI_ORDER_FORTRAN>> micro_writer;
+
+  // Device memory space
+  MatrixTypeRealDevice  rss;
+  MatrixTypeRealDevice rss1;
+  MatrixTypeRealDevice rss2;
+
 //-----------------------------------------------
 // End Of EVPFFT Data Members
 //-----------------------------------------------
@@ -221,6 +230,7 @@ public:
   void evolve();
   void check_macrostress();
   void print_vel_grad();
+  void allocate_memory();
 
   void set_some_voxels_arrays_to_zero();
   void init_ept();

--- a/src/EVPFFT/src/vpsc_input.cpp
+++ b/src/EVPFFT/src/vpsc_input.cpp
@@ -51,21 +51,16 @@ void EVPFFT::vpsc_input()
   ur0.open(cmd.input_filename);
   check_that_file_is_open(ur0, cmd.input_filename.c_str());
 
-  // SEED FOR RANDOM NUMBER GENERATOR (RAN2) (USED FOR TWINNING AND RX)
-  jran = -1;
+  ur0 >> NPHMX >> NMODMX >> NTWMMX >> NSYSMX; CLEAR_LINE(ur0);
+  ur0 >> npts1_g >> npts2_g >> npts3_g; CLEAR_LINE(ur0);
+
+  allocate_memory();
+
   ur0 >> nph; CLEAR_LINE(ur0);
 
   // THE FOLLOWING REQUIRED FOR SEVERAL ROUTINES WITH 'do iph=iphbot,iphtop'
   iphbot = 1;
   iphtop = nph;
-
-  if (nph > NPHMX) {
-    printf("\n number of phases nph=%d, exceeds max. multiphase dimens, NPHMX=%d !! \n", nph, NPHMX);
-    printf("--> Recompile EVPFFT with -DNPHMX=<max_nph>\n");
-    exit(1);
-  }
-
-  ngr = npts1 * npts2 * npts3;
 
   // RVE DIMENSIONS
   ur0 >> delt(1) >> delt(2) >> delt(3); CLEAR_LINE(ur0);
@@ -198,6 +193,7 @@ void EVPFFT::vpsc_input()
 
   ur0 >> ithermo; CLEAR_LINE(ur0);
   if (ithermo == 1) {
+    int num_crystals = 200000; // maximum number of crystals/grains
     eth = MatrixTypeRealHost (3,3,num_crystals);
 
     ur0 >> filethermo; CLEAR_LINE(ur0);


### PR DESCRIPTION
Removed compile time arrays and evpfft can be compiled without the need for 
  -D NPHMX
  -D NMODMX
  -D NTWMMX
  -D NSYSMX
in the cmake flag. instead these variables can be passed into the input file.