### PR TITLE
Added machine options to EVPFFT/scripts

### DIFF
--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -37,7 +37,7 @@ To build EVPFFT you would need to provide both the `--heffte_build_type` and `--
 source build_evpfft.sh --heffte_build_type=fftw --kokkos_build_type=serial
 ```
 
-This will build EVPFFT in the folder `evpfft_heffte_{fftw}_kokkos_{serial}`. The binary, `evpfft` is found in that folder
+This will build EVPFFT in the folder `evpfft_{fftw}_{serial}`. The binary, `evpfft` is found in that folder
 
 # Using EVPFFT as a standalone program
 

--- a/src/EVPFFT/scripts/install-scripts/install_heffte.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_heffte.sh
@@ -88,19 +88,19 @@ cmake_options=(
     -D BUILD_SHARED_LIBS=ON
 )
 
-if [ "$heffte_build_type" == "fftw" ]; then
+if [ "$heffte_build_type" = "fftw" ]; then
     cmake_options+=(
         #-D Heffte_ENABLE_AVX=ON
         #-D Heffte_ENABLE_AVX512=ON
         -D Heffte_ENABLE_FFTW=ON
         #-D FFTW_ROOT="$FFTW_DIR"
     )
-elif [ "$heffte_build_type" == "cufft" ]; then
+elif [ "$heffte_build_type" = "cufft" ]; then
     cmake_options+=(
         -D Heffte_ENABLE_CUDA=ON
         -D Heffte_DISABLE_GPU_AWARE_MPI=ON
     )
-elif [ "$heffte_build_type" == "rocfft" ]; then
+elif [ "$heffte_build_type" = "rocfft" ]; then
     cmake_options+=(
         -D CMAKE_CXX_COMPILER=hipcc
         -D Heffte_ENABLE_ROCM=ON

--- a/src/EVPFFT/scripts/machines/darwin-env.sh
+++ b/src/EVPFFT/scripts/machines/darwin-env.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -e
+show_help() {
+    echo "Usage: source $(basename "$BASH_SOURCE") [OPTION]"
+    echo "Valid options:"
+    echo "  --env_type=<serial|openmp|pthreads|cuda|hip>"
+    echo "  --help : Display this help message"
+    return 1
+}
+
+# Initialize variables with default values
+env_type=""
+
+# Define arrays of valid options
+valid_env_types=("serial" "openmp" "pthreads" "cuda" "hip")
+
+# Parse command line arguments
+for arg in "$@"; do
+    case "$arg" in
+        --env_type=*)
+            option="${arg#*=}"
+            if [[ " ${valid_env_types[*]} " == *" $option "* ]]; then
+                env_type="$option"
+            else
+                echo "Error: Invalid --env_type specified."
+                show_help
+                return 1
+            fi
+            ;;
+        --help)
+            show_help
+            return 1
+            ;;
+        *)
+            echo "Error: Invalid argument or value specified."
+            show_help
+            return 1
+            ;;
+    esac
+done
+
+# Check if required options are specified
+if [ -z "$env_type" ]; then
+    echo "Error: --env_type are required options."
+    show_help
+    return 1
+fi
+### Load environment modules here
+### Assign names as relevant
+
+mygcc="gcc/9.4.0"
+#myclang="clang/13.0.0"
+mycuda="cuda/11.4.0"
+myrocm="rocm"
+#mympi="mpich/3.3.2-gcc_9.4.0"
+mympi="openmpi/3.1.6-gcc_9.4.0"
+
+module purge
+module load ${mympi}
+if [ "$env_type" = "cuda" ]; then
+    module load ${mygcc}
+    module load ${mycuda}
+elif [ "$env_type" = "hip" ]; then
+    module load ${mygcc}
+    module load ${myrocm}
+else
+    module load ${mygcc}
+fi
+module load cmake
+module -t list

--- a/src/EVPFFT/scripts/machines/mac-env.sh
+++ b/src/EVPFFT/scripts/machines/mac-env.sh
@@ -1,0 +1,11 @@
+# Assign path's to the current software you want to use.
+# These path's will need to be changed based on your computer
+# The default for homebrew should place packages as shown below
+
+export CC=/opt/homebrew/opt/llvm/bin/clang
+export CXX=/opt/homebrew/opt/llvm/bin/clang++
+export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+export OMPI_CC=${CC}
+export OMPI_CXX=${CXX}


### PR DESCRIPTION
I have Added the machine options to EVPFFT/scripts, taken from @djdunning branch, while maintaining the interdependence of the scripts.

I also did some cleanup of the kokkos build types according to his branch.

Additionally, `==` was replaced with `=` where needed to allow comparability with macs