### PR TITLE
Mesh builder

### DIFF
--- a/src/CLI/include/FierroParallelBackends.hpp
+++ b/src/CLI/include/FierroParallelBackends.hpp
@@ -5,19 +5,6 @@
 #include <string>
 #include <fstream>
 
-/**
- * Check to see if a file exists on the system.
- * Technically this will return false if it exists but you don't have permission.
-*/
-bool file_exists(std::string fname) {
-    std::fstream f(fname.c_str());
-    return f.good();
-}
-
-std::string absolute_fp(std::string fname) {
-    return std::string(std::filesystem::absolute(fname));
-}
-
 struct ParallelBackend: public FierroBackend {
     ParallelBackend(std::string name) 
         : FierroBackend(name) { }
@@ -53,11 +40,13 @@ struct ParallelBackend: public FierroBackend {
      * @return Return code of the executable.
     */
     int invoke() {
+        if (!exec_path.has_value())
+            throw std::runtime_error("Cannot invoke executable without absolute path.");
         auto err = this->validate_arguments();
         if (err.has_value()) throw ArgumentException(err.value());
 
         std::string input_file = this->command->get<std::string>("config");
-        std::string sys_command = this->name + " " + input_file;
+        std::string sys_command = this->exec_path.value().string() + " " + input_file;
 
         return system(sys_command.c_str());
     }

--- a/src/CLI/include/MeshBuilderBackend.hpp
+++ b/src/CLI/include/MeshBuilderBackend.hpp
@@ -1,0 +1,89 @@
+#ifndef MESH_BUILDER_BACKENDS_H
+#define MESH_BUILDER_BACKENDS_H
+
+#include "backend.hpp"
+#include "argparse/argparse.hpp"
+#include <string>
+#include <fstream>
+
+struct MeshBuilderBackend: public FierroBackend {
+    MeshBuilderBackend() : FierroBackend("fierro-mesh-builder") {
+        this->command = std::shared_ptr<argparse::ArgumentParser>(
+            new argparse::ArgumentParser("mesh-builder")
+        );
+        
+        this->command->add_argument("-c", "config")
+            .help("The `.yaml` configuration to run fierro with.`") 
+            .action(absolute_fp);
+        this->command->add_argument("--box-help")
+            .help("Set this flag to print out an example box mesh configuration file.")
+            .default_value(false)
+            .implicit_value(true);
+        this->command->add_argument("--cylinder-help")
+            .help("Set this flag to print out an example cylinder mesh configuration file.")
+            .default_value(false)
+            .implicit_value(true);;
+        this->command->add_description("Build rectangular or cylindrical mesh in 2 or 3 dimensions. Useful for setting up test problems.");
+    }
+
+    /** 
+     * Check that the arguments of the CLI are valid and make sense.
+     * 
+     * Checks for explicit/implicit logical consistency.
+     * Checks that the mesh file is real and readable.
+     *      Does not check that it is correctly formatted.
+     * 
+     * @return An optional error. If the empty, the arguments are valid.
+     * 
+    */
+    std::optional<std::string> validate_arguments() {
+        std::string msg = "";
+        auto parser = this->command;
+        if (this->command->is_used("box-help") || this->command->is_used("cylinder-help"))
+            return {};
+
+        if (!parser->is_used("config"))
+            msg = "A value for config is required";
+        else if (!file_exists(parser->get<std::string>("config"))) {
+            msg = "Unable to find configuration: " + parser->get<std::string>("config");
+        }
+        
+        if (msg.length() > 0) {
+            return std::optional(msg);
+        }
+        return {};
+    }
+    
+    /**
+     * Invoke the backend executable.
+     * Will throw an ArgumentException if the arguments aren't valid.
+     * 
+     * @return Return code of the executable.
+    */
+    int invoke() {
+        if (!exec_path.has_value())
+            throw std::runtime_error("Cannot invoke executable without absolute path.");
+        auto err = this->validate_arguments();
+        if (err.has_value()) throw ArgumentException(err.value());
+
+        std::string sys_command;
+        if (this->command->get<bool>("box-help")) 
+            sys_command = this->exec_path.value().string() + " Box";
+        else if (this->command->get<bool>("cylinder-help"))
+            sys_command = this->exec_path.value().string() + " Cylinder";
+        else {
+            std::string input_file = this->command->get<std::string>("config");
+            sys_command = this->exec_path.value().string() + " " + input_file;
+        }
+
+        return system(sys_command.c_str());
+    }
+
+    void add_common_options() {
+        this->command->add_argument("config")
+            .help("The `.yaml` configuration to run fierro with.`")
+            .action(absolute_fp);
+    }
+};
+
+#endif

--- a/src/CLI/include/backend.hpp
+++ b/src/CLI/include/backend.hpp
@@ -3,11 +3,27 @@
 
 #include <string>
 #include <vector>
+#include <fstream>
+#include <optional>
 #include <filesystem>
 #include "argparse/argparse.hpp"
 #include "argument_exception.hpp"
 
-bool can_exec(const std::filesystem::path& fp) {
+
+/**
+ * Check to see if a file exists on the system.
+ * Technically this will return false if it exists but you don't have permission.
+*/
+inline bool file_exists(std::string fname) {
+    std::fstream f(fname.c_str());
+    return f.good();
+}
+
+inline std::string absolute_fp(std::string fname) {
+    return std::string(std::filesystem::absolute(fname));
+}
+
+inline bool can_exec(const std::filesystem::path& fp) {
     auto entry = std::filesystem::directory_entry(fp);
     return (
         entry.exists()
@@ -16,33 +32,40 @@ bool can_exec(const std::filesystem::path& fp) {
     );
 }
 
+static std::vector<std::filesystem::path>& get_paths() {
+    std::string path = std::getenv("PATH");
+    static std::vector<std::filesystem::path> result;
+    if (result.size() > 0) return result;
+    result.push_back(std::filesystem::canonical("/proc/self/exe").parent_path());
+    result.push_back(std::filesystem::path("."));
+
+    size_t i = 0;
+    // Windows uses ";" as a delimeter, but we don't support windows yet.
+    while ((i = path.find(":")) != std::string::npos) {
+        result.push_back(std::filesystem::path(path.substr(0, i)));
+        path.erase(0, i + 1);
+    }
+    return result;
+}
+
 struct FierroBackend {
     std::string name = "";
     std::shared_ptr<argparse::ArgumentParser> command;
-    FierroBackend(std::string name): name(name) { }
-
-    bool exists() {
-        std::string path = std::getenv("PATH");
-        auto result = std::vector<std::filesystem::path>();
-        result.push_back(std::filesystem::canonical("/proc/self/exe").parent_path());
-        result.push_back(std::filesystem::path("."));
-
-        size_t i = 0;
-        // Windows uses ";" as a delimeter, but we don't support windows yet.
-        while ((i = path.find(":")) != std::string::npos) {
-            result.push_back(std::filesystem::path(path.substr(0, i)));
-            path.erase(0, i + 1);
-        }
-
-        return this->exists(result);
+    std::optional<std::filesystem::path> exec_path{};
+    FierroBackend(std::string name): name(name) {
+        exec_path = find();
     }
 
-    bool exists(const std::vector<std::filesystem::path>& paths) {
+    std::optional<std::filesystem::path> find() {
+        return this->find(get_paths());
+    }
+
+    std::optional<std::filesystem::path> find(const std::vector<std::filesystem::path>& paths) {
         for(const auto & path : paths) {
             auto potential_path = path / this->name;
-            if (can_exec(potential_path)) return true;
+            if (can_exec(potential_path)) return {potential_path};
         }
-        return false;
+        return {};
     }
 
     virtual int invoke() = 0;

--- a/src/CLI/src/main.cpp
+++ b/src/CLI/src/main.cpp
@@ -1,5 +1,6 @@
 #include "backend.hpp"
 #include "FierroParallelBackends.hpp"
+#include "MeshBuilderBackend.hpp"
 #include "argparse/argparse.hpp"
 #include "argument_exception.hpp"
 #include <filesystem>
@@ -10,13 +11,14 @@
 
 std::vector<std::shared_ptr<FierroBackend>> BACKENDS {
     std::shared_ptr<FierroBackend>(new ParallelExplicit()),
-    std::shared_ptr<FierroBackend>(new ParallelImplicit())
+    std::shared_ptr<FierroBackend>(new ParallelImplicit()),
+    std::shared_ptr<FierroBackend>(new MeshBuilderBackend())
 };
 
 std::vector<std::shared_ptr<FierroBackend>> find_fierro_backends() {
     auto found = std::vector<std::shared_ptr<FierroBackend>>();
     for(auto backend : BACKENDS) {
-        if(backend->exists()) found.push_back(backend);
+        if(backend->exec_path.has_value()) found.push_back(backend);
     }
 
     return found;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,3 +65,5 @@ endif()
 
 add_subdirectory(CLI)
 
+add_subdirectory(Mesh-Builder)
+

--- a/src/Mesh-Builder/CMakeLists.txt
+++ b/src/Mesh-Builder/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.17)
+project(mesh-builder)
+
+SET(CMAKE_CXX_STANDARD 17)
+
+add_library(mesh_builder src/MeshBuilder.cpp src/EnsightIO.cpp src/VtkIO.cpp)
+target_link_libraries(mesh_builder PUBLIC yaml_serializable)
+target_include_directories(mesh_builder PUBLIC include)
+
+add_executable(fierro-mesh-builder src/main.cpp)
+target_link_libraries(fierro-mesh-builder PUBLIC 
+    yaml_serializable
+    mesh_builder
+)
+
+install(
+  TARGETS fierro-mesh-builder
+)

--- a/src/Mesh-Builder/CMakeLists.txt
+++ b/src/Mesh-Builder/CMakeLists.txt
@@ -16,3 +16,15 @@ target_link_libraries(fierro-mesh-builder PUBLIC
 install(
   TARGETS fierro-mesh-builder
 )
+
+if (TEST) 
+  add_executable(mesh-builder-tests test/test.cpp)
+  target_link_libraries(
+      mesh-builder-tests
+      GTest::gtest_main
+      mesh_builder
+  )
+
+  include(GoogleTest)
+  gtest_discover_tests(mesh-builder-tests)
+endif()

--- a/src/Mesh-Builder/include/IOUtilities.h
+++ b/src/Mesh-Builder/include/IOUtilities.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <filesystem>
+#include <string>
+
+namespace IOUtilities {
+    /**
+     * Ensures that a directory exists. 
+    */
+    inline void mkdir(std::string path) {
+        path = std::filesystem::absolute(path);
+        if (!std::filesystem::exists(path)) std::filesystem::create_directories(path);
+    }
+}

--- a/src/Mesh-Builder/include/Mesh.h
+++ b/src/Mesh-Builder/include/Mesh.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "matar.h"
+
+namespace {
+    template<typename T>
+    inline bool carray_eq(const mtr::CArray<T>& lhs, const mtr::CArray<T>& rhs) {
+        if (lhs.order() != rhs.order()) return false;
+        if (lhs.size() != rhs.size()) return false;
+
+        for (size_t i = 0; i < lhs.size(); i++)
+            if (lhs.pointer()[i] != rhs.pointer()[i])
+                return false;
+                
+        return true;
+    }
+}
+
+struct Mesh {
+    mtr::CArray<double> points;
+    mtr::CArray<int> element_point_index;
+    mtr::CArray<int> element_types;
+    int num_dim;
+    int p_order;
+
+
+    bool validate() {
+        return (num_dim == 2 || num_dim == 3)
+        && (element_point_index.dims(0) == element_types.dims(0))
+        && (points.dims(1) == num_dim)
+        && (element_types.order() == 1);
+    }
+
+    bool operator==(const Mesh& rhs) const {
+        return (num_dim == rhs.num_dim)
+        && (carray_eq(points, rhs.points))
+        && (carray_eq(element_point_index, rhs.element_point_index));
+    }
+    bool operator!=(const Mesh& rhs) const {
+        return !operator==(rhs);
+    }
+};

--- a/src/Mesh-Builder/include/Mesh.h
+++ b/src/Mesh-Builder/include/Mesh.h
@@ -22,7 +22,6 @@ struct Mesh {
     int num_dim;
     int p_order;
 
-
     bool validate() {
         return (num_dim == 2 || num_dim == 3)
         && (element_point_index.dims(0) == element_types.dims(0))

--- a/src/Mesh-Builder/include/MeshBuilder.h
+++ b/src/Mesh-Builder/include/MeshBuilder.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "Mesh.h"
+#include <memory>
+#include "MeshBuilderInput.h"
+
+namespace MeshBuilder {
+    Mesh build_mesh(std::shared_ptr<MeshBuilderInput> input);
+}

--- a/src/Mesh-Builder/include/MeshBuilderInput.h
+++ b/src/Mesh-Builder/include/MeshBuilderInput.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "yaml-serializable.h"
+#include <vector>
+#include <iostream>
+#include <cmath>
+
+#define PI 3.141592653589793
+
+namespace {
+    inline bool all_equal(std::vector<size_t> values) {
+        if (values.size() == 0) return true;
+        size_t v = values[0];
+        for (auto ov : values)
+            if (ov != v)
+                return false;
+        return true;
+    }
+}
+
+SERIALIZABLE_ENUM(MeshType,
+    Box,
+    Cylinder
+)
+
+SERIALIZABLE_ENUM(FileType,
+    Ensight,
+    VTK
+)
+
+struct MeshBuilderInput 
+    : Yaml::TypeDiscriminated<MeshBuilderInput, MeshType>, 
+      Yaml::ValidatedYaml, 
+      Yaml::DerivedFields {
+
+    FileType file_type = FileType::VTK;
+    std::string name = "mesh";
+    std::vector<double> origin {0., 0., 0.};
+};
+YAML_ADD_REQUIRED_FIELDS_FOR(MeshBuilderInput, type, file_type, origin)
+IMPL_YAML_SERIALIZABLE_FOR(MeshBuilderInput, type, name, file_type, origin)
+
+
+struct Input_Rectilinear
+    : MeshBuilderInput::Register<Input_Rectilinear, MeshType::Box> {
+
+    Input_Rectilinear() { type = MeshType::Box; }
+
+    std::vector<double> length {1, 1, 1};
+    std::vector<int> num_elems {5, 5, 5};
+    size_t p_order = 1;
+
+    // Non-serialized fields
+    std::vector<int> num_points;
+    std::vector<double> delta;
+    int total_elems;
+    int total_points;
+    std::vector<double> lower_bound;
+    std::vector<double> upper_bound;
+
+    // Non-serialized fields
+    int num_dims;
+    
+    void derive_delta() {
+        for (size_t i = 0; i < std::min(length.size(), num_elems.size()); i++) {
+            delta[i] = (upper_bound[i] - lower_bound[i]) / (double)(p_order * num_elems[i]);
+        }
+    }
+
+    void derive() {
+        num_dims = origin.size();
+
+        lower_bound = {0, 0, 0};
+        upper_bound = length;
+        delta.resize(std::min(length.size(), num_elems.size()));
+        derive_delta();
+        
+        for (auto nm : num_elems)
+            num_points.push_back(p_order * nm + 1);
+        
+        total_elems = 1;
+        total_points = 1;
+        for (size_t i = 0; i < num_elems.size(); i++) {
+            total_elems *= num_elems[i];
+            total_points *= num_points[i];
+        }
+
+        // Embed in 3D for easier downstream code.
+        if (num_dims == 2) {
+            num_elems.push_back(1);
+            num_points.push_back(1);
+        }
+    }
+
+    void validate() {
+        if (num_dims != 2 && num_dims != 3) 
+            throw Yaml::ConfigurationException("Detected number of dimensions must be either 2 or 3.");
+            
+        if (!all_equal({length.size(), num_elems.size(), origin.size()}))
+            throw Yaml::ConfigurationException(
+                "You must specify the same number of values for `length`, `num_elems` and `origin`."
+            );
+    }
+};
+YAML_ADD_REQUIRED_FIELDS_FOR(Input_Rectilinear, length, num_elems)
+IMPL_YAML_SERIALIZABLE_WITH_BASE(Input_Rectilinear, MeshBuilderInput, length, num_elems, length, num_elems, p_order)
+
+struct Input_Cylinder
+    : Input_Rectilinear, MeshBuilderInput::Register<Input_Cylinder, MeshType::Cylinder> {
+    
+    Input_Cylinder() { type = MeshType::Cylinder; }
+
+    double inner_radius = 0.;
+    double start_angle  = 0.;
+
+    // Non-serialized fields
+    bool cyclic = false;
+
+    void derive() {
+        cyclic = std::fabs(length[1] - 360) < 1e-8;
+        if (cyclic)
+            num_points[1] -= 1;
+
+        total_points = 1;
+        for (size_t i = 0; i < num_elems.size(); i++) {
+            total_points *= num_points[i];
+        }
+        
+        start_angle    *= PI / 180.;
+        length[1]      *= PI / 180.;
+        upper_bound[1] *= PI / 180.;
+        
+        lower_bound[0] += inner_radius;
+        upper_bound[0] += inner_radius;
+        lower_bound[1] += start_angle;
+        upper_bound[1] += start_angle;
+        derive_delta();
+    }
+
+    void validate() {
+        if (length[1] < 0 || length[1] > 360)
+            throw Yaml::ConfigurationException("The angular lenght of the cylinder must be in [0, 360]");
+    }
+};
+IMPL_YAML_SERIALIZABLE_WITH_BASE(Input_Cylinder, Input_Rectilinear, inner_radius, start_angle)

--- a/src/Mesh-Builder/include/MeshIO.h
+++ b/src/Mesh-Builder/include/MeshIO.h
@@ -19,11 +19,11 @@ namespace MeshIO {
         VTK
     };
 
-    Mesh read_vtk(std::string filename);
-    void write_vtk(std::string filename, const Mesh& mesh);
+    Mesh read_vtk(std::string filename, bool verbose=false);
+    void write_vtk(std::string filename, const Mesh& mesh, bool verbose=false);
 
-    Mesh read_ensight(std::string filename);
-    void write_ensight(std::string filename, const Mesh& mesh);
+    Mesh read_ensight(std::string filename, bool verbose=false);
+    void write_ensight(std::string filename, const Mesh& mesh, bool verbose=false);
 
     namespace _Impl {
         inline std::vector<std::string> split(std::string s, std::string delimiter) {

--- a/src/Mesh-Builder/include/MeshIO.h
+++ b/src/Mesh-Builder/include/MeshIO.h
@@ -1,0 +1,82 @@
+#pragma once
+#include "Mesh.h"
+#include <string>
+#include <vector>
+
+namespace {
+    inline bool hasEnding(const std::string &fullString, const std::string &ending) {
+        if (fullString.length() >= ending.length()) {
+            return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+        } else {
+            return false;
+        }
+    }
+}
+
+namespace MeshIO {
+    enum class FileType {
+        EnSight,
+        VTK
+    };
+
+    Mesh read_vtk(std::string filename);
+    void write_vtk(std::string filename, const Mesh& mesh);
+
+    Mesh read_ensight(std::string filename);
+    void write_ensight(std::string filename, const Mesh& mesh);
+
+    namespace _Impl {
+        inline std::vector<std::string> split(std::string s, std::string delimiter) {
+            size_t pos_start = 0, pos_end, delim_len = delimiter.length();
+            std::string token;
+            std::vector<std::string> res;
+
+            while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos) {
+                token = s.substr(pos_start, pos_end - pos_start);
+                pos_start = pos_end + delim_len;
+                res.push_back(token);
+            }
+
+            res.push_back(s.substr(pos_start));
+            return res;
+        }
+
+        /**
+         * \brief Reorder the columns of an array given a bijective mapping `order`.
+         * 
+         * Given an n x m matrix, `mat`, reorder the columns of `mat` such that 
+         * column j -> order[j].
+        */
+        template<typename T>
+        inline void redorder_columns(mtr::CArray<T>& mat, const int* order) {
+            std::vector<T> temp;
+            temp.resize(mat.dims(1));
+            for (size_t i = 0; i < mat.dims(0); i++) {
+                for (size_t j = 0; j < temp.size(); j++)
+                    temp[order[j]] = mat(i, j);
+                
+                for (size_t j = 0; j < temp.size(); j++)
+                    mat(i, j) = temp[j];
+            }
+        }
+        
+    
+        inline std::vector<int> construct_inverse(const std::vector<int>& map) {
+            std::vector<int> inv;
+            inv.resize(map.size());
+            for (size_t i = 0; i < inv.size(); i++)
+                inv[map[i]] = i;
+            return inv;
+        }
+
+        static const std::vector<int>& ijk_to_fea() {
+            static const std::vector<int> map { 0, 1, 3, 2, 4, 5, 7, 6 };
+            return map;
+        }
+        
+        static const std::vector<int>& fea_to_ijk() {
+            static const std::vector<int> map = construct_inverse(ijk_to_fea());
+            return map;
+        }
+    }
+}

--- a/src/Mesh-Builder/include/MeshIO.h
+++ b/src/Mesh-Builder/include/MeshIO.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Mesh.h"
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -20,7 +21,9 @@ namespace MeshIO {
     };
 
     Mesh read_vtk(std::string filename, bool verbose=false);
+    Mesh read_vtk(std::istream& in, bool verbose=false);
     void write_vtk(std::string filename, const Mesh& mesh, bool verbose=false);
+    void write_vtk(std::ostream& out, const Mesh& mesh);
 
     Mesh read_ensight(std::string filename, bool verbose=false);
     void write_ensight(std::string filename, const Mesh& mesh, bool verbose=false);

--- a/src/Mesh-Builder/include/VtkIO.h
+++ b/src/Mesh-Builder/include/VtkIO.h
@@ -1,0 +1,152 @@
+#include <vector>
+
+namespace {
+    /**
+     * \brief Given (i,j,k) coordinates within the Lagrange hex, return an offset into the local connectivity (PointIds) array.
+     *
+     * The \a order parameter must point to an array of 3 integers specifying the order
+     * along each axis of the hexahedron.
+     */
+    inline int ijk_to_lagrange_hex(int i, int j, int k, const int* order) {
+        bool ibdy = (i == 0 || i == order[0]);
+        bool jbdy = (j == 0 || j == order[1]);
+        bool kbdy = (k == 0 || k == order[2]);
+        // How many boundaries do we lie on at once?
+        int nbdy = (ibdy ? 1 : 0) + (jbdy ? 1 : 0) + (kbdy ? 1 : 0);
+
+        if (nbdy == 3) // Vertex DOF
+        {              // ijk is a corner node. Return the proper index (somewhere in [0,7]):
+            return (i ? (j ? 2 : 1) : (j ? 3 : 0)) + (k ? 4 : 0);
+        }
+
+        int offset = 8;
+        if (nbdy == 2) // Edge DOF
+        {
+            if (!ibdy)
+            { // On i axis
+            return (i - 1) + (j ? order[0] + order[1] - 2 : 0) + (k ? 2 * (order[0] + order[1] - 2) : 0) +
+                offset;
+            }
+            if (!jbdy)
+            { // On j axis
+            return (j - 1) + (i ? order[0] - 1 : 2 * (order[0] - 1) + order[1] - 1) +
+                (k ? 2 * (order[0] + order[1] - 2) : 0) + offset;
+            }
+            // !kbdy, On k axis
+            offset += 4 * (order[0] - 1) + 4 * (order[1] - 1);
+            return (k - 1) + (order[2] - 1) * (i ? (j ? 3 : 1) : (j ? 2 : 0)) + offset;
+        }
+
+        offset += 4 * (order[0] + order[1] + order[2] - 3);
+        if (nbdy == 1) // Face DOF
+        {
+            if (ibdy) // On i-normal face
+            {
+            return (j - 1) + ((order[1] - 1) * (k - 1)) + (i ? (order[1] - 1) * (order[2] - 1) : 0) +
+                offset;
+            }
+            offset += 2 * (order[1] - 1) * (order[2] - 1);
+            if (jbdy) // On j-normal face
+            {
+            return (i - 1) + ((order[0] - 1) * (k - 1)) + (j ? (order[2] - 1) * (order[0] - 1) : 0) +
+                offset;
+            }
+            offset += 2 * (order[2] - 1) * (order[0] - 1);
+            // kbdy, On k-normal face
+            return (i - 1) + ((order[0] - 1) * (j - 1)) + (k ? (order[0] - 1) * (order[1] - 1) : 0) +
+            offset;
+        }
+
+        // nbdy == 0: Body DOF
+        offset += 2 * (
+            (order[1] - 1) * (order[2] - 1) + 
+            (order[2] - 1) * (order[0] - 1) +
+            (order[0] - 1) * (order[1] - 1)
+        );
+        return offset + 
+            (i - 1) + (order[0] - 1) * (
+                (j - 1) + (order[1] - 1) * (
+                    (k - 1)));
+    }
+
+    inline int ijk_to_lagrange_quad(int i, int j, const int* order) {
+        bool ibdy = (i == 0 || i == order[0]);
+        bool jbdy = (j == 0 || j == order[1]);
+        // How many boundaries do we lie on at once?
+        int nbdy = (ibdy ? 1 : 0) + (jbdy ? 1 : 0);
+
+        if (nbdy == 2) // Vertex DOF
+        {              // ijk is a corner node. Return the proper index (somewhere in [0,7]):
+            return (i ? (j ? 2 : 1) : (j ? 3 : 0));
+        }
+
+        int offset = 4;
+        if (nbdy == 1) // Edge DOF
+        {
+            if (!ibdy)
+            { // On i axis
+            return (i - 1) + (j ? order[0] - 1 + order[1] - 1 : 0) + offset;
+            }
+            if (!jbdy)
+            { // On j axis
+            return (j - 1) + (i ? order[0] - 1 : 2 * (order[0] - 1) + order[1] - 1) + offset;
+            }
+        }
+
+        offset += 2 * (order[0] - 1 + order[1] - 1);
+        // nbdy == 0: Face DOF
+        return offset + (i - 1) + (order[0] - 1) * ((j - 1));
+    }
+
+    inline std::vector<int> ijk_to_lagrange_hex(const int p_order) {
+        static std::vector<int> map;
+
+        int order[3] = {p_order, p_order, p_order};
+        for (int k = 0; k <= p_order; k++)
+            for (int j = 0; j <= p_order; j++)
+                for (int i = 0; i <= p_order; i++)
+                    map.push_back(ijk_to_lagrange_hex(i, j, k, order));
+        
+        return map;
+    }
+
+    inline std::vector<int> lagrange_hex_to_ijk(const int p_order) {
+        return MeshIO::_Impl::construct_inverse(ijk_to_lagrange_hex(p_order));
+    }
+
+    inline std::vector<int> ijk_to_lagrange_quad(const int p_order) {
+        std::vector<int> map;
+
+        int order[3] = {p_order, p_order};
+        for (int j = 0; j <= p_order; j++)
+            for (int i = 0; i <= p_order; i++)
+                map.push_back(ijk_to_lagrange_quad(i, j, order));
+        
+        return map;
+    }
+
+    inline std::vector<int> lagrange_quad_to_ijk(const int p_order) {
+        return MeshIO::_Impl::construct_inverse(ijk_to_lagrange_quad(p_order));
+    }
+}
+
+namespace VtkIO {
+    inline bool is_lagrange_ordered(int vtkCellType) {
+        return (vtkCellType >= 68) && (vtkCellType <= 74);
+    }
+
+    inline std::vector<int> lagrange_to_ijk(const int num_dim, const int p_order) {
+        switch (num_dim) {
+        case 2:
+            return lagrange_quad_to_ijk(p_order);
+        case 3:
+            return lagrange_hex_to_ijk(p_order);
+        default:
+            throw std::runtime_error("Invalid number of dimensions: " + num_dim);
+        }
+    }
+
+    inline std::vector<int> ijk_to_lagrange(const int num_dim, const int p_order) {
+        return MeshIO::_Impl::construct_inverse(lagrange_to_ijk(num_dim, p_order));
+    }
+}

--- a/src/Mesh-Builder/src/EnsightIO.cpp
+++ b/src/Mesh-Builder/src/EnsightIO.cpp
@@ -1,0 +1,137 @@
+#include "MeshIO.h"
+#include "IOUtilities.h"
+#include "matar.h"
+
+namespace {
+    std::string get_format_string(const Mesh& mesh) {
+        switch (mesh.num_dim) {
+            case 2:
+                return "quad4";
+                break;
+            case 3:
+                return "hexa8";
+                break;
+            default:
+                throw std::runtime_error("Unsupported number of dimensions: " + mesh.num_dim);
+        }
+    }
+
+    /**
+     * Writes the .geo file for a mesh.
+     * Currently fixed to write *.00001.geo.
+     * 
+     * Contains the point coordinates along with the connectivity of the mesh.
+    */
+    void write_geometry(const char* name, const Mesh& mesh) {
+        FILE* out = fopen(name, "w");
+        
+        fprintf(out, "This is the 1st description line of the EnSight Gold geometry file\n");
+        fprintf(out, "This is the 2nd description line of the EnSight Gold geometry file\n");
+        fprintf(out, "node id assign\n");
+        fprintf(out, "element id assign\n");
+        
+        fprintf(out, "part\n");
+        fprintf(out, "%10d\n",1);
+        fprintf(out, "Mesh\n");
+        fprintf(out, "coordinates\n");
+        fprintf(out, "%10ld\n", mesh.points.dims(0));
+        
+        for (size_t j = 0; j < 3; j++) {
+            for (size_t i = 0; i < mesh.points.dims(0); i++) {
+                fprintf(out , "%12.5e\n", j < mesh.points.dims(1) ? mesh.points(i, j) : 0.0);  
+            }
+        }
+        
+        fprintf(out, "%s", (get_format_string(mesh) + "\n").c_str());
+        fprintf(out, "%10ld\n", mesh.element_point_index.dims(0));
+        
+        auto& map = MeshIO::_Impl::fea_to_ijk();
+        for (size_t i = 0; i < mesh.element_point_index.dims(0); i++) {
+            for (size_t j = 0; j < mesh.element_point_index.dims(1); j++)
+                fprintf(out, "%10d", mesh.element_point_index(i, map[j]) + 1); // EnSight array indexing starts at 1
+            fprintf(out, "\n");
+        }
+        
+        fclose(out);
+    }
+
+    /**
+     * Writes the .var file for the mesh.
+     * Currently just writes dummy data at the node level.
+     * TODO: Have this write mesh properties once the mesh properties are set.
+    */
+    void write_variables(const char* name, const Mesh& mesh) {
+        FILE* out = fopen(name, "w");
+        fprintf(out, "Per_elem scalar values\n");
+        fprintf(out, "part\n");
+        fprintf(out, "%10d\n", 1);
+
+        fprintf(out, "%s\n", get_format_string(mesh).c_str());
+        
+        // TODO: Pull from actual mesh data here.
+        for (size_t i = 0; i < mesh.element_point_index.dims(0); i++) {
+            fprintf(out, "%12.5e\n", 1.);
+        }
+        
+        fclose(out);
+    }
+
+    /**
+     * Writes the metadata file for the ensight mesh.
+     * Just points data/*.*****.geo and data/*.*****.var
+     * 
+     * Doesn't support any time series mesh data.
+    */
+    void write_case(const char* name, const std::string& mesh_name, const Mesh& mesh) {
+
+        FILE* out = fopen(name, "w");
+        
+        fprintf(out, "FORMAT\n");
+        fprintf(out, "type: ensight gold\n");
+        fprintf(out, "GEOMETRY\n");
+        fprintf(out, "model: data/%s.*****.geo\n", mesh_name.c_str());
+        fprintf(out, "VARIABLE\n");
+        fprintf(out, "scalar per element: mat_index data/%s.*****.var\n", mesh_name.c_str());
+        
+        // TODO: Allow for mutliple timestamps
+        fprintf(out, "TIME\n");
+        fprintf(out, "time set: 1\n");
+        fprintf(out, "number of steps: %4d\n", 1);
+        fprintf(out, "filename start number: 1\n");
+        fprintf(out, "filename increment: 1\n");
+        fprintf(out, "time values: \n");
+        fprintf(out, "%12.5e\n", 0.);
+        
+        fclose(out);
+    }
+}
+
+Mesh MeshIO::read_ensight(std::string filename) {
+    throw std::runtime_error("Unimplemented");
+}
+
+void MeshIO::write_ensight(std::string filename, const Mesh& mesh) {
+    if (mesh.p_order > 1)
+        throw std::runtime_error("Cannot write a high order mesh to Ensight format.");
+
+    char name[100];
+    std::string fp;
+    
+    IOUtilities::mkdir("ensight/data");
+
+    // 1 is required because Ensight dump 1 is the t=0 dump
+    sprintf(name, "%s.%05d.geo", filename.c_str(), 1);
+    fp = std::filesystem::path("ensight") / "data" / name;
+    std::cout << fp << std::endl;
+    write_geometry(fp.c_str(), mesh);
+    
+    sprintf(name, "%s.%05d.var", filename.c_str(), 1);
+    fp = std::filesystem::path("ensight") / "data" / name;
+    std::cout << fp << std::endl;
+    write_variables(fp.c_str(), mesh);
+    
+    sprintf(name, "%s.case", filename.c_str());
+    fp = std::filesystem::path("ensight") / name;
+    std::cout << fp << std::endl;
+    write_case(fp.c_str(), filename, mesh);
+}

--- a/src/Mesh-Builder/src/EnsightIO.cpp
+++ b/src/Mesh-Builder/src/EnsightIO.cpp
@@ -106,11 +106,11 @@ namespace {
     }
 }
 
-Mesh MeshIO::read_ensight(std::string filename) {
+Mesh MeshIO::read_ensight(std::string filename, bool verbose) {
     throw std::runtime_error("Unimplemented");
 }
 
-void MeshIO::write_ensight(std::string filename, const Mesh& mesh) {
+void MeshIO::write_ensight(std::string filename, const Mesh& mesh, bool verbose) {
     if (mesh.p_order > 1)
         throw std::runtime_error("Cannot write a high order mesh to Ensight format.");
 
@@ -122,16 +122,19 @@ void MeshIO::write_ensight(std::string filename, const Mesh& mesh) {
     // 1 is required because Ensight dump 1 is the t=0 dump
     sprintf(name, "%s.%05d.geo", filename.c_str(), 1);
     fp = std::filesystem::path("ensight") / "data" / name;
-    std::cout << fp << std::endl;
+    if (verbose)
+        std::cout << "Creating file: " << fp << std::endl;
     write_geometry(fp.c_str(), mesh);
     
     sprintf(name, "%s.%05d.var", filename.c_str(), 1);
     fp = std::filesystem::path("ensight") / "data" / name;
-    std::cout << fp << std::endl;
+    if (verbose)
+        std::cout << "Creating file: " << fp << std::endl;
     write_variables(fp.c_str(), mesh);
     
     sprintf(name, "%s.case", filename.c_str());
     fp = std::filesystem::path("ensight") / name;
-    std::cout << fp << std::endl;
+    if (verbose)
+        std::cout << "Creating file: " << fp << std::endl;
     write_case(fp.c_str(), filename, mesh);
 }

--- a/src/Mesh-Builder/src/MeshBuilder.cpp
+++ b/src/Mesh-Builder/src/MeshBuilder.cpp
@@ -1,0 +1,268 @@
+
+//==============================================================================
+/*
+
+ mesh-builder.cpp
+ 
+ This function builds a mesh
+ -------------------------------------------------------------------------------
+ 
+ Created by Nathaniel on 12/13/22.
+ 
+ 
+ Finite Element local point numbering for a Hexahedral
+ 
+ 
+    7--------6
+   /|       /|
+  / |      / |
+ 4--------5  |
+ |  |     |  |
+ |  |     |  |
+ |  3-----|--2
+ | /      | /
+ |/       |/
+ 0--------1
+ 
+ 
+ The number of a Hexahedral element using i,j,k is
+ 
+ 
+    6--------7
+   /|       /|
+  / |      / |
+ 2--------3  |
+ |  |     |  |
+ |  |     |  |
+ |  4-----|--5
+ | /      | /
+ |/       |/
+ 0--------1
+ 
+ 
+ 
+ The number of a quad element using FE convention is
+ 
+ 
+        y
+       /
+      /
+
+    3--------2
+   /        /
+  /        /
+ 0--------1  ---> x
+
+
+The number of a quad element using i,j is
+
+        y
+       /
+      /
+ 
+    2--------3
+   /        /
+  /        /
+ 0--------1  ---> x
+
+ 
+ */
+//==============================================================================
+//
+//  if building standalone
+//
+//     g++ --std=c++17 mesh-builder.cpp Yaml.cpp
+//
+//==============================================================================
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+#include <stdio.h>
+#include <math.h>
+#include <vector>
+#include <map>
+#include <exception>
+
+#include "matar.h"
+#include "yaml-serializable.h"
+#include "MeshBuilderInput.h"
+#include "MeshBuilder.h"
+#include "MeshIO.h"
+#include "Mesh.h"
+
+#include <cmath>
+
+using namespace mtr;
+
+//==============================================================================
+//   Functions
+//==============================================================================
+
+// -------------------------------------------------------
+// This gives the index value of the point or the elem
+// the elem = i + (j)*(num_points_i-1) + (k)*(num_points_i-1)*(num_points_j-1)
+// the point = i + (j)*num_points_i + (k)*num_points_i*num_points_j
+//--------------------------------------------------------
+//
+// Returns a global id for a given i,j,k
+int get_id(int i, int j, int k, int num_i, int num_j) {
+   return i + j*num_i + k*num_i*num_j;
+}
+
+//==============================================================================
+//    Main
+//==============================================================================
+
+Mesh build_rectilinear(const Input_Rectilinear& input) {
+    int num_points_in_elem = std::pow(input.p_order + 1, input.num_dims);
+
+    std::cout << "Creating a " << input.num_dims << "D box mesh." << std::endl;
+    
+    // --- mesh node ordering ---
+    // Convert ijk index system to the finite element numbering convention
+    // for vertices in elem
+    auto convert_point_number = CArray <int> (8);
+    convert_point_number(0) = 0;
+    convert_point_number(1) = 1;
+    convert_point_number(2) = 3;
+    convert_point_number(3) = 2;
+    convert_point_number(4) = 4;
+    convert_point_number(5) = 5;
+    convert_point_number(6) = 7;
+    convert_point_number(7) = 6;
+            
+    
+    auto mesh = Mesh();
+    mesh.num_dim = input.num_dims;
+    mesh.points = CArray <double> (input.total_points, input.num_dims);
+    mesh.element_point_index = CArray <int> (input.total_elems, num_points_in_elem);
+    
+    // --- Build nodes ---
+    // populate the point data structures
+    for (int k = 0; k < input.num_points[2]; k++) {
+        for (int j = 0; j < input.num_points[1]; j++){
+            for (int i = 0; i < input.num_points[0]; i++){
+                // global id for the point
+                int point_id = get_id(i, j, k, input.num_points[0], input.num_points[1]);
+                
+                // store the point coordinates
+                mesh.points(point_id, 0) = input.lower_bound[0] + (double)i*input.delta[0];
+                mesh.points(point_id, 1) = input.lower_bound[1] + (double)j*input.delta[1];
+                if (input.num_dims == 3)
+                    mesh.points(point_id, 2) = input.lower_bound[2] + (double)k*input.delta[2];
+            }
+        }
+    }
+
+    // --- Build elems  ---
+    int p_order = input.p_order;
+    // populate the elem center data structures
+    for (size_t k = 0; k < input.num_elems[2]; k++) {
+        for (size_t j = 0; j < input.num_elems[1]; j++){
+            for (size_t i = 0; i < input.num_elems[0]; i++){
+                // global id for the elem
+                size_t elem_id = get_id(i, j, k, input.num_elems[0], input.num_elems[1]);
+                
+                // store the point IDs for this elem where the range is
+                // (i:(i+1)*Pn_order, j:(j+1)*Pn_order, k:(k+1)*Pn_order) for a Pn hexahedron
+                size_t point_id_local = 0;
+                size_t i_offset = i * p_order,
+                       j_offset = j * p_order,
+                       k_offset = k * p_order;
+
+                for (size_t k_local = 0; k_local <= p_order; k_local++) {
+                    for (size_t j_local = 0; j_local <= p_order; j_local++) {
+                        for (size_t i_local = 0; i_local <= p_order; i_local++) {
+                            // Modulus is included to allow for 
+                            // cyclic connectivity structures.
+                            int point_id = get_id(
+                                (i_local + i_offset) % input.num_points[0], 
+                                (j_local + j_offset) % input.num_points[1], 
+                                (k_local + k_offset) % input.num_points[2],
+                                input.num_points[0], input.num_points[1]
+                            );
+                            mesh.element_point_index(elem_id, point_id_local) = point_id;
+                            point_id_local++;
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+    mesh.p_order = input.p_order;
+    mesh.element_types = mtr::CArray<int>(mesh.element_point_index.dims(0));
+    int element_type = -1;
+    if (input.p_order == 1) {
+        if (mesh.num_dim == 2)
+            element_type = 9;  // Linear Quad
+        if (mesh.num_dim == 3)
+            element_type = 12; // Linear Hex
+    } else if (input.p_order > 1) {
+        if (mesh.num_dim == 2)
+            element_type = 70;  // Lagrange Quadrilateral 
+        if (mesh.num_dim == 3)
+            element_type = 72;  // Lagrange Hexahedron 
+    }
+
+    if (element_type < 0)
+        throw std::runtime_error(
+            "Could not determine element type. mesh.num_dim: "
+            + std::to_string(mesh.num_dim) 
+            + ", input.p_order: " + std::to_string(input.p_order) + "."
+        );
+
+    for (size_t i = 0; i < mesh.element_point_index.dims(0); i++)
+        mesh.element_types(i) = element_type;
+
+    return mesh;
+}
+
+/**
+ * \brief Given a mesh in cylindrical space, convert it to a mesh in rectilinear space.
+ * 
+ * The coordinates of the points before this function are <r, theta, z>.
+ * The coordinates of the points after this function are <x, y, z>.
+*/
+void cylinder_transform(Mesh& mesh, const Input_Cylinder& input) {
+    for (size_t i = 0; i < mesh.points.dims(0); i++) {
+        double r_i = mesh.points(i, 0);
+        double theta = mesh.points(i, 1);
+        mesh.points(i, 0) = input.origin[0] + r_i * cos(theta);
+        mesh.points(i, 1) = input.origin[1] + r_i * sin(theta);
+    }
+}
+
+/**
+ * \brief Translates a mesh a distance `tx` along its axes.
+*/
+void translate(Mesh& mesh, const std::vector<double>& tx) {
+    for (size_t i = 0; i < mesh.points.dims(0); i++)
+        for (size_t j = 0; j < mesh.points.dims(1); j++)
+            mesh.points(i, j) += tx[j];
+}
+
+/**
+ * \brief Builds a mesh from a mesh builder input file.
+*/
+Mesh MeshBuilder::build_mesh(std::shared_ptr<MeshBuilderInput> input) {
+    Mesh mesh;
+    switch (input->type) {
+    case MeshType::Box:
+        mesh = build_rectilinear(*std::dynamic_pointer_cast<Input_Rectilinear>(input));
+        break;
+    case MeshType::Cylinder:
+        mesh = build_rectilinear(*std::dynamic_pointer_cast<Input_Rectilinear>(input));
+        cylinder_transform(mesh, *std::dynamic_pointer_cast<Input_Cylinder>(input));
+        break;
+    default:
+        throw std::runtime_error("Unsupported mesh shape.");
+    }
+
+    translate(mesh, input->origin);
+
+    return mesh;
+}

--- a/src/Mesh-Builder/src/MeshBuilder.cpp
+++ b/src/Mesh-Builder/src/MeshBuilder.cpp
@@ -117,22 +117,6 @@ int get_id(int i, int j, int k, int num_i, int num_j) {
 
 Mesh build_rectilinear(const Input_Rectilinear& input) {
     int num_points_in_elem = std::pow(input.p_order + 1, input.num_dims);
-
-    std::cout << "Creating a " << input.num_dims << "D box mesh." << std::endl;
-    
-    // --- mesh node ordering ---
-    // Convert ijk index system to the finite element numbering convention
-    // for vertices in elem
-    auto convert_point_number = CArray <int> (8);
-    convert_point_number(0) = 0;
-    convert_point_number(1) = 1;
-    convert_point_number(2) = 3;
-    convert_point_number(3) = 2;
-    convert_point_number(4) = 4;
-    convert_point_number(5) = 5;
-    convert_point_number(6) = 7;
-    convert_point_number(7) = 6;
-            
     
     auto mesh = Mesh();
     mesh.num_dim = input.num_dims;

--- a/src/Mesh-Builder/src/VtkIO.cpp
+++ b/src/Mesh-Builder/src/VtkIO.cpp
@@ -212,7 +212,7 @@ namespace {
     }
 }
 
-Mesh MeshIO::read_vtk(std::string filename) {
+Mesh MeshIO::read_vtk(std::string filename, bool verbose) {
     std::ifstream in(filename);
     auto mesh = Mesh();
 
@@ -260,11 +260,14 @@ Mesh MeshIO::read_vtk(std::string filename) {
     return mesh;
 }
 
-void MeshIO::write_vtk(std::string filename, const Mesh& mesh) {
+void MeshIO::write_vtk(std::string filename, const Mesh& mesh, bool verbose) {
     IOUtilities::mkdir("vtk");
     auto path = std::filesystem::path("vtk") / (filename + ".vtk");
 
     FILE* out = fopen(path.c_str(), "w");
+    if (verbose)
+        std::cout << "Creating file: " << path.string() << std::endl;
+        
     write_geometry(out, mesh);
     write_nodal_variables(out, mesh);
     write_vector_variables(out, mesh);

--- a/src/Mesh-Builder/src/VtkIO.cpp
+++ b/src/Mesh-Builder/src/VtkIO.cpp
@@ -1,0 +1,273 @@
+#include "MeshIO.h"
+#include "Mesh.h"
+#include "IOUtilities.h"
+#include <fstream>
+#include <vector>
+#include <filesystem>
+#include <sstream>
+#include "VtkIO.h"
+
+namespace {
+    void write_geometry(FILE* out, const Mesh& mesh) {
+        fprintf(out, "# vtk DataFile Version 2.0\n");  // part 2
+        fprintf(out, "Mesh for Fierro\n");             // part 2
+        fprintf(out, "ASCII \n");                      // part 3
+        fprintf(out, "DATASET UNSTRUCTURED_GRID\n\n"); // part 4
+        
+        fprintf(out, "POINTS %ld float\n", mesh.points.dims(0));
+
+        // write all components of the point coordinates
+        for (size_t i = 0; i < mesh.points.dims(0); i++){
+            fprintf(out, 
+                "%f %f %f\n",
+                mesh.points(i, 0),
+                mesh.points(i, 1),
+                mesh.num_dim > 2 ? mesh.points(i, 2) : 0.
+            );
+        }
+        
+        /*
+        ---------------------------------------------------------------------------
+        Write the elems
+        ---------------------------------------------------------------------------
+        */
+        int num_elems = mesh.element_point_index.dims(0);
+        fprintf(out, "\n");
+        fprintf(out, "CELLS %d %ld\n", num_elems, num_elems + num_elems * mesh.element_point_index.dims(1));  
+        // size=all printed values
+        
+        auto lagrange_map = VtkIO::lagrange_to_ijk(mesh.num_dim, mesh.p_order);
+        auto& linear_map = MeshIO::_Impl::fea_to_ijk();
+
+        // write all global point numbers for this elem
+        for (size_t i=0; i < num_elems; i++) {
+            int num_points_in_elem = mesh.element_point_index.dims(1);
+            
+            // Print number of points in the element
+            fprintf(out, "%d ", num_points_in_elem);
+            for (size_t j = 0; j < num_points_in_elem; j++) {
+                size_t j_reordered;
+                if (VtkIO::is_lagrange_ordered(mesh.element_types(i)))
+                    j_reordered = lagrange_map[j];
+                else
+                    j_reordered = linear_map[j];
+                fprintf(out, "%d ", mesh.element_point_index(i, j_reordered));
+            }
+            fprintf(out, "\n");
+        }
+        
+        fprintf(out, "\n");
+        fprintf(out, "CELL_TYPES %d \n", num_elems);
+        for (size_t i = 0; i < num_elems; i++) {
+            fprintf(out, "%d \n", mesh.element_types(i));
+        }
+    }
+
+    void write_nodal_variables(FILE* out, const Mesh& mesh) {
+        size_t num_points = mesh.points.dims(0);
+        fprintf(out, "\n");
+        fprintf(out, "POINT_DATA %ld \n", num_points);
+        fprintf(out, "SCALARS point_var float 1\n"); // the 1 is number of scalar components [1:4]
+        fprintf(out, "LOOKUP_TABLE default\n");
+
+        // TODO: Eventually allow for mesh data here.
+        for (size_t i = 0; i < num_points; i++) {
+            fprintf(out, "%f\n", (double)i);
+        }
+    }
+
+    void write_vector_variables(FILE* out, const Mesh& mesh) {
+        fprintf(out, "\n");
+        fprintf(out, "VECTORS point_vec float\n");
+        // TODO: Pull from real mesh data.
+        for (size_t i = 0; i < mesh.points.dims(0); i++) {
+            double var1=0;
+            double var2=1;
+            double var3=2;
+            fprintf(out, "%f %f %f\n", var1, var2, var3);
+        }
+    }
+
+    void write_element_variables(FILE* out, const Mesh& mesh) {
+        size_t num_elems = mesh.element_point_index.dims(0);
+        fprintf(out, "\n");
+        fprintf(out, "CELL_DATA %ld \n", num_elems);
+        fprintf(out, "SCALARS elem_var float 1\n"); // the 1 is number of scalar components [1:4]
+        fprintf(out, "LOOKUP_TABLE default\n");
+        for (size_t i = 0; i < num_elems; i++) {
+            fprintf(out, "%f\n", (double)i);
+        }
+        
+        fprintf(out, "\n");
+        fprintf(out, "SCALARS elem_var2 float 1\n"); // the 1 is number of scalar components [1:4]
+        fprintf(out, "LOOKUP_TABLE default\n");
+        for (size_t i = 0; i < num_elems; i++) {
+            fprintf(out, "%f\n", -(double)i);
+        }
+    }
+
+    template<typename T>
+    mtr::CArray<T> vec_to_array(const std::vector<std::vector<T>>& vec) {
+        if (vec.size() == 0)
+            return mtr::CArray<T>();
+        
+        auto array = mtr::CArray<T>(vec.size(), vec[0].size());
+        for (size_t i = 0; i < vec.size(); i++) {
+            const auto& row = vec[i];
+            if (row.size() != array.dims(1))
+                throw std::runtime_error("Cannot load ragged arrays.");
+            for (size_t j = 0; j < row.size(); j++) {
+                array(i, j) = row[j];
+            }
+        }
+
+        return array;
+    }
+
+    template<typename T>
+    std::vector<T> parse_line(const std::string& line) {
+        std::vector<T> result;
+        std::stringstream ss(line);
+        while (!ss.eof()) {
+            T v;
+            ss >> v;
+            result.push_back(v);
+        }
+        return result;
+    }
+
+    template<typename T>
+    void for_n_lines(std::ifstream& in, const size_t n, T f) {
+        std::string line;
+        for (size_t i = 0; i < n; i++) {
+            std::getline(in, line);
+            f(i, line);
+        }
+    }
+
+    template<typename T>
+    std::vector<std::vector<T>> read_2darray(std::ifstream& in, const size_t length) {
+        std::vector<std::vector<T>> data;
+        for_n_lines(in, length, [&](const size_t i, const std::string& line) {
+            data.push_back(parse_line<T>(line));
+        });
+        return data;
+    } 
+
+    template<typename T>
+    mtr::CArray<T> read_1darray(std::ifstream& in, const size_t length) {
+        mtr::CArray<T> data = mtr::CArray<int>(length);
+        for_n_lines(in, length, [&](const size_t i, const std::string& line) {
+            data(i) = parse_line<T>(line)[0];
+        });
+        return data;
+    }
+
+    bool read_points(std::ifstream& in, const std::vector<std::string>& header_tokens, Mesh& mesh) {
+        if (header_tokens[0] != "POINTS" || header_tokens[2] != "float")
+            return false;
+        
+        int num_points = stoi(header_tokens[1]);
+        if (num_points <= 0)
+            return false;
+
+        auto points = read_2darray<double>(in, num_points);
+        if (points.size() == 0)
+            return false;
+        
+        mesh.points = vec_to_array(points);
+        mesh.num_dim = mesh.points.dims(1);
+        return true;
+    }
+
+    bool read_cells(std::ifstream& in, const std::vector<std::string>& header_tokens, Mesh& mesh) {
+        if (header_tokens[0] != "CELLS")
+            return false;
+        
+        int num_elems = stoi(header_tokens[1]);
+        if (num_elems <= 0)
+            return false;
+
+        auto elem_point_index = read_2darray<int>(in, num_elems);
+        if (elem_point_index.size() == 0)
+            return false;
+        
+        for (auto& row : elem_point_index)
+            row.erase(row.begin()); // First column is points per element.
+        
+        mesh.element_point_index = vec_to_array(elem_point_index);
+        return true;
+    }
+
+    bool read_cell_types(std::ifstream& in, const std::vector<std::string>& header_tokens, Mesh& mesh) {
+        if (header_tokens[0] != "CELLS")
+            return false;
+        
+        int num_elems = stoi(header_tokens[1]);
+        if (num_elems <= 0)
+            return false;
+        
+        mesh.element_types = read_1darray<int>(in, num_elems);
+        return true;
+    }
+}
+
+Mesh MeshIO::read_vtk(std::string filename) {
+    std::ifstream in(filename);
+    auto mesh = Mesh();
+
+    bool found_points     = false,
+         found_cells      = false,
+         found_cell_types = false;
+
+    while (!in.eof()) {
+        std::string line;
+        std::getline(in, line);
+
+        if (line.length() == 0)
+            continue;
+
+        std::vector<std::string> tokens = _Impl::split(line, " ");
+
+        if (read_points(in, tokens, mesh))
+            found_points = true;
+        else if (read_cells(in, tokens, mesh))
+            found_cells = true;
+        else if (read_cell_types(in, tokens, mesh))
+            found_cell_types = true;
+    }
+
+    in.close();
+
+    if (!mesh.validate()) {
+        throw std::runtime_error("Invalid mesh constructed.");
+    }
+    
+    if (mesh.element_types.dims(0) > 0) {
+        if (VtkIO::is_lagrange_ordered(mesh.element_types(0))) {
+            _Impl::redorder_columns(
+                mesh.element_point_index,
+                VtkIO::ijk_to_lagrange(mesh.num_dim, mesh.p_order).data()
+            );
+        } else {
+            _Impl::redorder_columns(
+                mesh.element_point_index, 
+                _Impl::ijk_to_fea().data()
+            );
+        }
+    }
+    
+    return mesh;
+}
+
+void MeshIO::write_vtk(std::string filename, const Mesh& mesh) {
+    IOUtilities::mkdir("vtk");
+    auto path = std::filesystem::path("vtk") / (filename + ".vtk");
+
+    FILE* out = fopen(path.c_str(), "w");
+    write_geometry(out, mesh);
+    write_nodal_variables(out, mesh);
+    write_vector_variables(out, mesh);
+    write_element_variables(out, mesh);
+    fclose(out);
+}

--- a/src/Mesh-Builder/src/main.cpp
+++ b/src/Mesh-Builder/src/main.cpp
@@ -35,10 +35,10 @@ int main(int argc, char *argv[]) {
 
     switch (input->file_type) {
         case FileType::Ensight:
-            MeshIO::write_ensight(input->name, mesh);
+            MeshIO::write_ensight(input->name, mesh, true);
             break;
         case FileType::VTK:
-            MeshIO::write_vtk(input->name, mesh);
+            MeshIO::write_vtk(input->name, mesh, true);
             break;
     }
     return 0;

--- a/src/Mesh-Builder/src/main.cpp
+++ b/src/Mesh-Builder/src/main.cpp
@@ -1,0 +1,45 @@
+
+#include <iostream>
+#include "MeshBuilder.h"
+#include "MeshIO.h"
+
+static std::string ERR_MSG = 
+R"(
+**********************************
+ ERROR:
+ Please supply a YAML input, 
+    ./mesh-builder input.yaml
+**********************************
+)";
+int main(int argc, char *argv[]) {
+    if (argc == 1) {
+        std::cout << ERR_MSG << std::endl;
+        return 1;
+    }
+
+    std::string command = argv[1];
+    if (command == "Box") {
+        std::cout << "Example box input file: " << std::endl;
+        std::cout << Yaml::to_string(Input_Rectilinear()) << std::endl;
+        return 0;
+    } else if (command == "Cylinder") {
+        std::cout << "Example cylinder input file: " << std::endl;
+        std::cout << Yaml::to_string(Input_Cylinder()) << std::endl;
+        return 0;
+    }
+    
+    std::shared_ptr<MeshBuilderInput> input;
+    Yaml::from_file_strict(argv[1], input);
+
+    Mesh mesh = MeshBuilder::build_mesh(input);
+
+    switch (input->file_type) {
+        case FileType::Ensight:
+            MeshIO::write_ensight(input->name, mesh);
+            break;
+        case FileType::VTK:
+            MeshIO::write_vtk(input->name, mesh);
+            break;
+    }
+    return 0;
+}

--- a/src/Mesh-Builder/test/test.cpp
+++ b/src/Mesh-Builder/test/test.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+#include "MeshBuilder.h"
+#include "MeshBuilderInput.h"
+#include "MeshIO.h"
+#include <string>
+#include <sstream>
+
+TEST(MeshBuilderInput, BoxDeserialization) {
+    std::string input = R"(
+    type: Box
+    file_type: VTK
+    p_order: 1
+    length: [1, 1, 1]
+    num_elems: [10, 10, 10]
+    origin: [0, 0, 0]
+    )";
+
+
+    std::shared_ptr<MeshBuilderInput> in;
+    Yaml::from_string_strict(input, in);
+
+
+    Mesh mesh = MeshBuilder::build_mesh(in);
+
+    EXPECT_EQ(mesh.p_order, 1);
+    EXPECT_EQ(mesh.element_point_index.dims(0), 10*10*10);
+    EXPECT_EQ(mesh.element_point_index.dims(1), 8);
+    EXPECT_EQ(in->type, MeshType::Box);
+}
+
+TEST(MeshBuilderInput, CylinderDeserialization) {
+    std::string input = R"(
+    type: Cylinder
+    file_type: VTK
+    p_order: 1
+    length: [1, 1, 1]
+    num_elems: [10, 10, 10]
+    origin: [0, 0, 0]
+    inner_radius: 0.1
+    start_angle: 1
+    )";
+
+
+    std::shared_ptr<MeshBuilderInput> in;
+    Yaml::from_string_strict(input, in);
+
+    Mesh mesh = MeshBuilder::build_mesh(in);
+
+    EXPECT_EQ(mesh.p_order, 1);
+    EXPECT_EQ(mesh.element_point_index.dims(0), 10*10*10);
+    EXPECT_EQ(mesh.element_point_index.dims(1), 8);
+    EXPECT_EQ(in->type, MeshType::Cylinder);
+}
+
+
+TEST(MeshBuilder, WriteRead) {
+    std::string input = R"(
+    type: Cylinder
+    file_type: VTK
+    p_order: 1
+    length: [1, 1, 1]
+    num_elems: [1, 1, 1]
+    origin: [0, 0, 0]
+    inner_radius: 0.1
+    start_angle: 1
+    )";
+
+    std::shared_ptr<MeshBuilderInput> in;
+    Yaml::from_string_strict(input, in);
+    
+    Mesh mesh = MeshBuilder::build_mesh(in);
+    std::stringstream buffer;
+
+    MeshIO::write_vtk(buffer, mesh);
+
+    Mesh read_back = MeshIO::read_vtk(buffer);
+
+    EXPECT_EQ(mesh.num_dim, read_back.num_dim);
+    for (size_t i = 0; i < mesh.points.dims(0); i++)
+        for (size_t j = 0; j < mesh.points.dims(1); j++)
+            EXPECT_NEAR(mesh.points(i, j), read_back.points(i, j), 1e-5);
+    for (size_t i = 0; i < mesh.element_point_index.dims(0); i++)
+        for (size_t j = 0; j < mesh.element_point_index.dims(1); j++)
+            EXPECT_EQ(mesh.element_point_index(i, j), read_back.element_point_index(i, j));
+}

--- a/src/Parallel-Solvers/Parallel-Explicit/CMakeLists.txt
+++ b/src/Parallel-Solvers/Parallel-Explicit/CMakeLists.txt
@@ -9,7 +9,6 @@ include_directories(Dynamic_Elastic_Solver)
 #include_directories(Eulerian_Solver)
 include_directories(Topology_Optimization)
 include_directories(..)
-include_directories(${CMAKE_SOURCE_DIR}/Implicit-Lagrange)
 add_executable(fierro-parallel-explicit main.cpp Explicit_Solver.cpp outputs.cpp)
 
 if (CUDA)

--- a/src/Yaml-Serializable/include/type-discrimination.h
+++ b/src/Yaml-Serializable/include/type-discrimination.h
@@ -71,7 +71,7 @@ namespace Yaml {
         }
 
         template<typename T, DiscriminationType DiscriminationValue>
-        struct Register : Base {
+        struct Register : virtual Base {
             static bool registerT() {
                 if (TypeDiscriminated::data().count(DiscriminationValue) != 0)
                     throw ConfigurationException(


### PR DESCRIPTION
This PR takes the functionality that was previously in lanl/ELEMENTS/mesh_tools/mesh_builder.cpp and integrates it into the Fierro repo + fierro CLI.


## Bug Fixes
* The previous implementation on the ELEMENTS repo incorrectly handled reading high order VTK meshes. Nathaniel had this fix on his local branch, but didn't push it.

* The previous implementation didn't correctly handle full cylinders (not that it was necessarily expected to). If a cylinder covered the full 360 degrees, it would not connect the ends cyclically, and instead have duplicate points and unconnected elements.

* Yaml-serialization didn't correctly support multiple inheritance when using type discriminators. Now it does. 
* Yaml.cpp only technically supports YAML V1.0, which doesn't include inline. bracket closed lists. (e.g. [1, 2, 3]). Yaml-Serializable now patches this and considers whether or not the string is actually a list. If it is in brackets, it will do some simple depth 0 parsing of the inner contents to attempt to conform it to the desired type. This doesn't handle everything, but it does handle simple lists of strings or numbers.
* * This still always outputs things line by line, as I didn't really want to try to figure out what the best data presentation was automatically.

## Changes to previous implementation
### Inputs
The deserialization of the input YAML file has been updated to the new yaml-serializable paradigm. Uses type discrimination to switch between cylinder and box inputs. An example of the new input format follows:

```yaml
type: Box
file_type: Ensight
p_order: 1
length: [1, 1, 1]
num_elems: [10, 10, 10]
origin: [0, 0, 0]
```

And for cylinders:
```yaml
type: Cylinder
file_type: Ensight
p_order: 1
length: [1, 1, 1]
num_elems: [10, 10, 10]
origin: [0, 0, 0]
inner_radius: 1
start_angle: 40
```

### Class Sturcture
Instead of a one off application, the new MeshBuilder interface is structured to output a "Mesh" class. The Mesh class currently only has basic necessary information, but is planned to be the more robust, high order mesh class in the future. This allows us to directly generate a mesh from the inputs and avoid writing it to a file to pipe it downstream.

### IO Processing
We now have the ability to stream the IO to any char stream, not just an OS file. This is useful for testing, where you don't really want to make a file.

### Cylinders
Now support 3D cylinders.
Additionally, the cylinder and box generating code are now one. The cylinder generates a box and then performs a cylindrical coordinate transform on the points of the box mesh.



## Tests
A couple of simple test cases have been created. Basic properties of both cylinder meshes and box meshes are tested. As well as equivalence of writing and reading back a high order mesh.

Test cases involving the Fierro pipeline will come once we integrate the mesh builder directly into Fierro. Right now, you have to build a mesh and then pipe it in separately.

