### PR TITLE
Remove hard coded input energy

### DIFF
--- a/Anaconda-Packages/evpfft/cpu/meta.yaml
+++ b/Anaconda-Packages/evpfft/cpu/meta.yaml
@@ -23,16 +23,16 @@ requirements:
   host:
     - openmpi
     - fierro-heffte
-    - fftw=*=mpi_openmpi_hdeb57f9_6
+    - fftw=*=mpi_openmpi_*
     - kokkos
-    - hdf5=*=mpi_openmpi_h457a7a6_3
+    - hdf5=*=mpi_openmpi_*
     - elements
   run:
     - openmpi
     - fierro-heffte
-    - fftw=*=mpi_openmpi_hdeb57f9_6
+    - fftw=*=mpi_openmpi_*
     - kokkos
-    - hdf5=*=mpi_openmpi_h457a7a6_3
+    - hdf5=*=mpi_openmpi_*
     - elements
 
 #TODO: Add tests

--- a/src/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Base.h
+++ b/src/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Base.h
@@ -134,31 +134,51 @@ struct mat_fill_t {
     bool contains(const double* elem_coords) { 
       double radius;
 
-      switch(volume)
-      {
-        case VOLUME_TAG::global:
-          return true;
+      switch(volume) {
+      case VOLUME_TAG::global:
+        return true;
 
-        case VOLUME_TAG::box:
-          return ( elem_coords[0] >= x1 && elem_coords[0] <= x2
-                && elem_coords[1] >= y1 && elem_coords[1] <= y2
-                && elem_coords[2] >= z1 && elem_coords[2] <= z2 );
+      case VOLUME_TAG::box:
+        return ( elem_coords[0] >= x1 && elem_coords[0] <= x2
+              && elem_coords[1] >= y1 && elem_coords[1] <= y2
+              && elem_coords[2] >= z1 && elem_coords[2] <= z2 );
 
-        case VOLUME_TAG::cylinder:
-          radius = sqrt( elem_coords[0]*elem_coords[0] +
-                         elem_coords[1]*elem_coords[1] ); 
-          return ( radius >= radius1
-                && radius <= radius2 );
+      case VOLUME_TAG::cylinder:
+        radius = sqrt( elem_coords[0]*elem_coords[0] +
+                        elem_coords[1]*elem_coords[1] ); 
+        return ( radius >= radius1
+              && radius <= radius2 );
 
-        case VOLUME_TAG::sphere:
-          radius = sqrt( elem_coords[0]*elem_coords[0] +
-                         elem_coords[1]*elem_coords[1] +
-                         elem_coords[2]*elem_coords[2] );
-          return ( radius >= radius1
-                && radius <= radius2 );
-        
-        default:
-          return false;
+      case VOLUME_TAG::sphere:
+        radius = sqrt( elem_coords[0]*elem_coords[0] +
+                        elem_coords[1]*elem_coords[1] +
+                        elem_coords[2]*elem_coords[2] );
+        return ( radius >= radius1
+              && radius <= radius2 );
+      
+      default:
+        return false;
+      }
+    }
+
+    KOKKOS_FUNCTION
+    double get_volume() {
+      switch(volume) {
+      case VOLUME_TAG::global:
+        throw std::runtime_error("Cannot evaluate the volume of an unbounded region.");
+
+      case VOLUME_TAG::box:
+        return (x2 - x1) * (y2 - y1) * (z2 - z1);
+
+      case VOLUME_TAG::cylinder:
+        // 2D cylinder
+        return M_PI * (std::pow(radius2, 2) - std::pow(radius1, 2));
+
+      case VOLUME_TAG::sphere:
+        return (4.0 / 3.0) * M_PI * (std::pow(radius2, 3) - std::pow(radius1, 3));
+      
+      default:
+        throw std::runtime_error("Unsupported volume type: " + to_string(volume));
       }
     }
 };
@@ -188,25 +208,24 @@ struct MaterialFill : Yaml::DerivedFields, Yaml::ValidatedYaml, mat_fill_t {
     }
 
     void derive() {
-      if (volume == VOLUME_TAG::sphere) {
-        if (radius2.has_value()) {
-          if (sie.has_value())
-            std::cerr << "Warning: sie value being overwritten" << std::endl;
-          sie = (963.652344 * std::pow((1.2 / 30.0), 3)) / std::pow(radius2.value(), 3);
-        }
-      }
+      if (sie.has_value() == ie.has_value())
+        throw Yaml::ConfigurationException("Specify values for exactly one of: energy (ie) or specific energy (sie).");
 
       mat_fill_t::radius1 = radius1.value_or(0);
       mat_fill_t::radius2 = radius2.value_or(0);
-      mat_fill_t::sie = sie.value_or(0);
       mat_fill_t::u = u.value_or(0);
       mat_fill_t::v = v.value_or(0);
       mat_fill_t::w = w.value_or(0);
+
+      if (ie.has_value())
+        sie = ie.value()  / (den * get_volume());
+
+      mat_fill_t::sie = sie.value_or(0);
     }
 };
 IMPL_YAML_SERIALIZABLE_FOR(
   MaterialFill, volume, mat_id, 
-  den, sie, velocity, u, v, w, 
+  den, sie, ie, velocity, u, v, w, 
   radius1, radius2, speed
 )
 

--- a/src/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Base.h
+++ b/src/Parallel-Solvers/Parallel-Explicit/Simulation_Parameters_Base.h
@@ -116,52 +116,6 @@ IMPL_YAML_SERIALIZABLE_FOR(Time_Variables, output_time_sequence_level,
   cycle_stop, fuzz, tiny, small
 )
 
-struct volume_t {
-    VOLUME_TAG volume = VOLUME_TAG::sphere;
-    VELOCITY_TYPE velocity = VELOCITY_TYPE::cartesian;
-    double radius1, radius2;
-    double u,v,w;
-    double speed;
-    double sie;
-    double den;
-    
-    // TODO: These aren't set from the YAML at all
-    // They are only set in the test problems.
-    double x1, x2, y1, y2, z1, z2;
-    
-    KOKKOS_FUNCTION
-    bool contains(const double* elem_coords) { 
-      double radius;
-
-      switch(volume)
-      {
-        case VOLUME_TAG::global:
-          return true;
-
-        case VOLUME_TAG::box:
-          return ( elem_coords[0] >= x1 && elem_coords[0] <= x2
-                && elem_coords[1] >= y1 && elem_coords[1] <= y2
-                && elem_coords[2] >= z1 && elem_coords[2] <= z2 );
-
-        case VOLUME_TAG::cylinder:
-          radius = sqrt( elem_coords[0]*elem_coords[0] +
-                         elem_coords[1]*elem_coords[1] ); 
-          return ( radius >= radius1
-                && radius <= radius2 );
-
-        case VOLUME_TAG::sphere:
-          radius = sqrt( elem_coords[0]*elem_coords[0] +
-                         elem_coords[1]*elem_coords[1] +
-                         elem_coords[2]*elem_coords[2] );
-          return ( radius >= radius1
-                && radius <= radius2 );
-        
-        default:
-          return false;
-      }
-    }
-};
-
 struct mat_fill_t {
     size_t mat_id;
     VOLUME_TAG volume = VOLUME_TAG::sphere;
@@ -211,6 +165,7 @@ struct mat_fill_t {
 
 struct MaterialFill : Yaml::DerivedFields, Yaml::ValidatedYaml, mat_fill_t {
     std::optional<double> sie;
+    std::optional<double> ie;
     std::optional<double> u;
     std::optional<double> v;
     std::optional<double> w;

--- a/src/Parallel-Solvers/Parallel-Explicit/example_simple.yaml
+++ b/src/Parallel-Solvers/Parallel-Explicit/example_simple.yaml
@@ -50,7 +50,7 @@ region_options:
     radius1: 0.0
     radius2: 0.0375
     den: 1.0
-    ie: 0.2583
+    ie: 0.25833839995946534
         
     velocity: cartesian
     u: 0.0

--- a/src/Parallel-Solvers/Parallel-Explicit/example_simple.yaml
+++ b/src/Parallel-Solvers/Parallel-Explicit/example_simple.yaml
@@ -50,6 +50,7 @@ region_options:
     radius1: 0.0
     radius2: 0.0375
     den: 1.0
+    ie: 0.2583
         
     velocity: cartesian
     u: 0.0


### PR DESCRIPTION
Previously we left this line in the parameter processing:

```
sie = (963.652344 * std::pow((1.2 / 30.0), 3)) / std::pow(radius2.value(), 3);
```

This is a specific energy that was intended for a specific discretization of the Sedov problem. Not really appropriate for general use, especially *all cylinders/spheres*, which it was used for.

We are no longer defaulting the energy under any circumstances. And we have added an alternative, potentially more intuitive method for specifying the energy. 

### Current SIE value
The current value comes from the analytic solution of the Sedov problem intended to have a peak compression at T~=1. The value 963 * std::pow((1.2 / 30.0), 3)) * 4/3 PI is the total energy contained in the region, which comes out to be ~= 0.2583. 

### IE vs SIE
Now we allow for the specification of SIE or IE from the user. If the user provides a value for IE, we compute the total mass of the region, and divide the energy by that to derive SIE.
This is not possible, however, if we have a "global" region specification. So we only allow this for bounded geometries.