### PR TITLE
update evpfft gui to include a python entry point

### DIFF
--- a/Anaconda-Packages/evpfft-gui/build.sh
+++ b/Anaconda-Packages/evpfft-gui/build.sh
@@ -1,2 +1,0 @@
-cd python/EVPFFT-GUI
-$PYTHON setup.py install

--- a/Anaconda-Packages/evpfft-gui/meta.yaml
+++ b/Anaconda-Packages/evpfft-gui/meta.yaml
@@ -7,6 +7,10 @@ source:
   # - git_url: https://github.com/lanl/Fierro.git
   #   depth: 1
 
+build:
+  number: 1
+  script: cd python/EVPFFT-GUI/; python setup.py install
+
 requirements:
   host:
     - python

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,4 +1,5 @@
 dist
 *.egg-info
+*.egg
 __pycache__
 *.DS_Store

--- a/python/EVPFFT-GUI/setup.py
+++ b/python/EVPFFT-GUI/setup.py
@@ -17,4 +17,9 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'tests', 'tests.*']),
     include_package_data=True,
     install_requires=install_requires,
+    entry_points={
+        'console_scripts' : [
+            'evpfft-gui = evpfft_gui.gui:main'
+        ]
+    }
 )


### PR DESCRIPTION
Added 

```python
  entry_points={
      'console_scripts' : [
          'evpfft-gui = evpfft_gui.gui:main'
      ]
  }
```

to the setup.py python package definition for EVPFFT-GUI. Installing this package now creates an executable script "evpfft-gui" that you can use on the command line to launch it.