### PR TITLE
Build script will check lib and lib64 folders for Trilinos

### DIFF
--- a/scripts/cmake_build.sh
+++ b/scripts/cmake_build.sh
@@ -20,7 +20,8 @@ mkdir -p ${FIERRO_BUILD_DIR}
 
 # Configure EVPFFT using CMake
 cmake_options=(
-    -D Trilinos_DIR=${TRILINOS_INSTALL_DIR}/lib/cmake/Trilinos
+    #-D Trilinos_DIR=${TRILINOS_INSTALL_DIR}/lib/cmake/Trilinos
+    -D CMAKE_PREFIX_PATH="${TRILINOS_INSTALL_DIR}/lib/cmake/Trilinos;${TRILINOS_INSTALL_DIR}/lib64/cmake/Trilinos"
 )
 
 if [ "$solver" = "all" ]; then


### PR DESCRIPTION
This is my solution to check both lib or lib64 for Trilinos config files. If anyone has another solution, please go ahead. We need to have this fixed ASAP.