### PR TITLE
Don't throw on the device

### DIFF
--- a/src/Parallel-Solvers/Simulation_Parameters/Geometry.h
+++ b/src/Parallel-Solvers/Simulation_Parameters/Geometry.h
@@ -2,6 +2,8 @@
 
 #include "yaml-serializable.h"
 #include "matar.h"
+#include <assert.h>
+
 using namespace mtr;
 
 SERIALIZABLE_ENUM(VOLUME_TYPE,
@@ -53,7 +55,7 @@ struct Volume : Yaml::ValidatedYaml {
     double get_volume() {
       switch(type) {
       case VOLUME_TYPE::global:
-        throw std::runtime_error("Cannot evaluate the volume of an unbounded region.");
+        assert(0); // Cannot evaluate the volume fo an unbounded region.
 
       case VOLUME_TYPE::box:
         return (x2 - x1) * (y2 - y1) * (z2 - z1);
@@ -66,7 +68,8 @@ struct Volume : Yaml::ValidatedYaml {
         return (4.0 / 3.0) * M_PI * (std::pow(radius2, 3) - std::pow(radius1, 3));
       
       default:
-        throw std::runtime_error("Unsupported volume type: " + to_string(type));
+        assert(0); // Unsupported volume type.
+        return 0; // Compiler complains that execution can fall out of void func.
       }
     }
     


### PR DESCRIPTION
Can't compile CUDA code with a throw in it. 

Instead of just _not_ throwing though, which leaves secret incorrect behavior, I am opting to assert(0) instead. This will output an error message to stderr upon host synchronization. I do not believe it actually throws an exception on synchronization, though.

asserting 0 on the device will leave the device memory in an invalid state (i.e. other threads are not guaranteed to resolve correctly). At least we will see that something is wrong and which kernel caused it instead of it silently breaking. This is only used in truly invalid scenarios that should not occur.