### PR TITLE
Evpfft dimension fix

### DIFF
--- a/python/EVPFFT-GUI/evpfft_gui/ui_EVPFFT_GUI_V10.py
+++ b/python/EVPFFT-GUI/evpfft_gui/ui_EVPFFT_GUI_V10.py
@@ -981,6 +981,7 @@ class Ui_MainWindow(object):
         self.BApplyBC.clicked.connect(lambda: self.ToolSettings.setCurrentIndex(3))
         self.BSolverSettings.clicked.connect(lambda: self.ToolSettings.setCurrentIndex(4))
         self.BViewResults.clicked.connect(lambda: self.ToolSettings.setCurrentIndex(5))
+        self.VoxelResolution = (1., 1., 1.)
         
         # Upload Geometry
         def geometry_upload_click():
@@ -1047,7 +1048,7 @@ class Ui_MainWindow(object):
                 else:
                     pvsimple.Delete(self.threshold)
                 
-                fierro_voxelizer.create_voxel_vtk(
+                self.VoxelResolution = fierro_voxelizer.create_voxel_vtk(
                     b3_filename[0],
                     VTK_OUTPUT,
                     int(self.INNumberOfVoxelsX.text()),
@@ -1171,7 +1172,8 @@ class Ui_MainWindow(object):
             evpfft_lattice_input.write(modes)
             dimensions = str(int(self.INNumberOfVoxelsX.text())) + ' ' + str(int(self.INNumberOfVoxelsY.text())) + ' ' + str(int(self.INNumberOfVoxelsZ.text())) + '               x-dim, y-dim, z-dim\n'
             evpfft_lattice_input.write(dimensions)
-            nph_delt = '2                      number of phases (nph)\n' + '1.  1.  1.             RVE dimensions (delt)\n' + '* name and path of microstructure file (filetext)\n'
+            dx, dy, dz = self.VoxelResolution
+            nph_delt = '2                      number of phases (nph)\n' + f'{dx:.4f} {dy:.4f} {dz:.4f}             RVE dimensions (delt)\n' + '* name and path of microstructure file (filetext)\n'
             evpfft_lattice_input.write(nph_delt)
             evpfft_lattice_input.write(f'{VTK_OUTPUT}\n')
             phases = '*INFORMATION ABOUT PHASE #1\n' + '1                          igas(iph)\n' + '* name and path of single crystal files (filecryspl, filecrysel) (dummy if igas(iph)=1)\n' + 'dummy\n' + 'dummy\n' + '*INFORMATION ABOUT PHASE #2\n' + '0                          igas(iph)\n' + '* name and path of single crystal files (filecryspl, filecrysel) (dummy if igas(iph)=1)\n' + f'{PLASTIC_PARAMETERS}\n' + f'{ELASTIC_PARAMETERS}\n'

--- a/python/Voxelizer/CMakeLists.txt
+++ b/python/Voxelizer/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.17)
 project(stl-to-voxel-py)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../src/Voxelizer ./Voxelizer)

--- a/src/Voxelizer/include/stl-to-voxelvtk.h
+++ b/src/Voxelizer/include/stl-to-voxelvtk.h
@@ -1,7 +1,8 @@
 #pragma once
+#include <tuple>
 
 namespace Voxelizer {
-    void create_voxel_vtk(
+    std::tuple<double, double, double> create_voxel_vtk(
         const char* stl_file_path, const char* vtk_file_path, 
         int gridX, int gridY, int gridZ,
         bool use_index_space);

--- a/src/Voxelizer/src/main.cpp
+++ b/src/Voxelizer/src/main.cpp
@@ -1,5 +1,7 @@
 #include "stl-to-voxelvtk.h"
 #include <string>
+#include <iostream>
+#include <tuple>
 
 int main(int argc, char *argv[]) {
     // ***** USER-DEFINED INPUTS *****
@@ -10,8 +12,11 @@ int main(int argc, char *argv[]) {
     int gridZ = std::stoi(argv[5]); // voxel resolution z-direction
     bool use_index_space = (argc < 7) || std::stoi(argv[6]); // whether to output global or local coordinates
     
-    Voxelizer::create_voxel_vtk(stl_file_path, vtk_file_path, gridX, gridY, gridZ, use_index_space);
+    auto resolution = Voxelizer::create_voxel_vtk(stl_file_path, vtk_file_path, gridX, gridY, gridZ, use_index_space);
 
+    std::cout << "Voxel mesh created with resolution: (" 
+        << std::get<0>(resolution) << "," << std::get<1>(resolution) << "," << std::get<2>(resolution) << ")." 
+        << std::endl;
     return 0;
 }
 

--- a/src/Voxelizer/src/stl-to-voxelvtk.cpp
+++ b/src/Voxelizer/src/stl-to-voxelvtk.cpp
@@ -40,7 +40,7 @@ void compute_normal(float* normal, float* a, float* b, float* c) {
     normal[2] =  (ba[0] * ca[1] - ba[1] * ca[0]);
 }
 
-void Voxelizer::create_voxel_vtk(
+std::tuple<double, double, double> Voxelizer::create_voxel_vtk(
         const char* stl_file_path, const char* vtk_file_path, 
         int gridX, int gridY, int gridZ,
         bool use_index_space) {
@@ -139,6 +139,7 @@ void Voxelizer::create_voxel_vtk(
     std::cout << "Total Time: " << duration.count() << " milliseconds" << std::endl;
 
     printf("\nfinished\n\n");
+    return {nodex(1) - nodex(0), nodey(1) - nodey(0), nodez(1) - nodez(0)};
 }
 
 // ==============================================================


### PR DESCRIPTION
Previously we would always invoke evpfft with relative volume element dimensions: "1. 1. 1.". However, these were never the dimensions, and because of how the voxelizer works (discretizing based on desired number of voxels, not desired voxel size) the actual dimensions were ~unknown and arbitrary.

To fix this we return the dx, dy, and dz from `Voxelizer::create_voxel_vtk` as a tuple. The fierro CLI will just print this out, while the EVPFFT-GUI will actually use those values to make the input file.