### PR TITLE
Update package manifests

### DIFF
--- a/Anaconda-Packages/voxelizer/meta.yaml
+++ b/Anaconda-Packages/voxelizer/meta.yaml
@@ -15,8 +15,8 @@ requirements:
     - cmake >=3.17.0
     - {{ compiler('c') }} ={{ compiler_version }}
     - {{ compiler('cxx') }} ={{ compiler_version }}
-    - elements
   host:
+    - elements
     - python
     - pybind11
     - setuptools

--- a/python/EVPFFT-GUI/MANIFEST.in
+++ b/python/EVPFFT-GUI/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include evpfft_gui/Icons/** *
+# Distribute elastic_parameters, plastic_parameters and evpff_lattice_input
+include evpfft_gui/*.txt

--- a/python/EVPFFT-GUI/evpfft_gui/elastic_parameters.txt
+++ b/python/EVPFFT-GUI/evpfft_gui/elastic_parameters.txt
@@ -1,2 +1,2 @@
 1                         ISO
-1   1                  YOUNG(MPa),NU (V+R/2)
+19800   0.35                  YOUNG(MPa),NU (V+R/2)


### PR DESCRIPTION
We didn't correctly distribute the "plastic_parameters.txt" file with the evpfft-gui python package. Since we don't actually create that file in the gui program, and we just give it to EVPFFT, its important that actually exists.

So we add those files to the MANIFEST.in, which specifies which non-python files to be included in the package distribution.


Note -- there is a change to elastic_parameters in this commit, but we just overwrite those anyway.