### PR TITLE
Don't distclean if you cant.

### DIFF
--- a/scripts/cmake_build.sh
+++ b/scripts/cmake_build.sh
@@ -30,7 +30,12 @@ fi
 
 # Removing stale build directory
 if [ -d "${FIERRO_BUILD_DIR}" ]; then
-    make -C ${FIERRO_BUILD_DIR} distclean
+    if make -C ${FIERRO_BUILD_DIR} distclean; then
+        echo "";
+    else
+        echo "distclean failed. Removing build directory."
+        rm -r ${FIERRO_BUILD_DIR}
+    fi
 else
     mkdir -p ${FIERRO_BUILD_DIR}
 fi


### PR DESCRIPTION
We are trying to `make distclean` if the fierro build folder exists. But, since we use that build folder for building Elements, it can exist before we actually have ever done any cmake things on it, so we might not have a "distclean" target.

So now just kill the build folder if we can't distclean. 