### PR TITLE
depth 1 for all clones, and some changes to EVPFFT folder

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,1 +1,3 @@
 Trilinos
+hdf5
+heffte

--- a/scripts/hdf5-install.sh
+++ b/scripts/hdf5-install.sh
@@ -3,7 +3,7 @@
 # Check if the 'hdf5' directory exists and is not empty in the parent directory; if not, clone it
 if [ ! -d "${HDF5_SOURCE_DIR}" ]; then
   echo "Directory 'hdf5' does not exist in '${libdir}', downloading 'hdf5'...."
-  git clone https://github.com/HDFGroup/hdf5.git ${HDF5_SOURCE_DIR}
+  git clone --depth 1 https://github.com/HDFGroup/hdf5.git ${HDF5_SOURCE_DIR}
 else
   echo "Directory 'hdf5' exists in '${libdir}', skipping 'hdf5' download"
 fi

--- a/scripts/heffte-install.sh
+++ b/scripts/heffte-install.sh
@@ -9,7 +9,7 @@ echo "Heffte build type will be: $heffte_build_type"
 # Check if the 'heffte' directory exists and is not empty in the parent directory; if not, clone it
 if [ ! -d "${HEFFTE_SOURCE_DIR}" ]; then
   echo "Directory 'heffte' does not exist in '${libdir}', downloading 'heffte'...."
-  git clone https://github.com/icl-utk-edu/heffte.git ${HEFFTE_SOURCE_DIR}
+  git clone --depth 1 https://github.com/icl-utk-edu/heffte.git ${HEFFTE_SOURCE_DIR}
 else
   echo "Directory 'heffte' exists in '${HEFFTE_SOURCE_DIR}', skipping 'heffte' download"
 fi

--- a/scripts/trilinos-install.sh
+++ b/scripts/trilinos-install.sh
@@ -11,7 +11,7 @@ echo "Trilinos Kokkos Build Type: $kokkos_build_type"
 if [ ! -d "${TRILINOS_SOURCE_DIR}" ]
 then
   echo "Directory Trilinos does not exist, downloading Trilinos...."
-  git clone https://github.com/trilinos/Trilinos.git ${TRILINOS_SOURCE_DIR}
+  git clone --depth 1 https://github.com/trilinos/Trilinos.git ${TRILINOS_SOURCE_DIR}
 fi
 
 #check if Trilinos build directory exists, create Trilinos/build if it doesn't

--- a/src/EVPFFT/scripts/install-scripts/install_hdf5.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_hdf5.sh
@@ -45,7 +45,7 @@ PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 HDF5_DIR="$PARENT_DIR/hdf5"
 if [ ! -d "$HDF5_DIR" ]; then
   echo "Directory 'hdf5' does not exist in '$PARENT_DIR', downloading 'hdf5'...."
-  git clone https://github.com/HDFGroup/hdf5.git "$HDF5_DIR"
+  git clone --depth 1 https://github.com/HDFGroup/hdf5.git "$HDF5_DIR"
 else
   echo "Directory 'hdf5' exists in '$PARENT_DIR', skipping 'hdf5' download"
 fi

--- a/src/EVPFFT/scripts/install-scripts/install_heffte.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_heffte.sh
@@ -70,7 +70,7 @@ PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 HEFFTE_DIR="$PARENT_DIR/heffte"
 if [ ! -d "$HEFFTE_DIR" ]; then
   echo "Directory 'heffte' does not exist in '$PARENT_DIR', downloading 'heffte'...."
-  git clone https://github.com/icl-utk-edu/heffte.git "$HEFFTE_DIR"
+  git clone --depth 1 https://github.com/icl-utk-edu/heffte.git "$HEFFTE_DIR"
 else
   echo "Directory 'heffte' exists in '$PARENT_DIR', skipping 'heffte' download"
 fi

--- a/src/EVPFFT/scripts/install-scripts/install_kokkos.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_kokkos.sh
@@ -70,7 +70,7 @@ PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 KOKKOS_DIR="$PARENT_DIR/kokkos"
 if [ ! -d "$KOKKOS_DIR" ]; then
   echo "Directory 'kokkos' does not exist in '$PARENT_DIR', downloading 'kokkos'...."
-  git clone https://github.com/kokkos/kokkos.git "$KOKKOS_DIR"
+  git clone --depth 1 https://github.com/kokkos/kokkos.git "$KOKKOS_DIR"
 else
   echo "Directory 'kokkos' exists in '$PARENT_DIR', skipping 'kokkos' download"
 fi

--- a/src/EVPFFT/scripts/install-scripts/install_matar.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_matar.sh
@@ -73,7 +73,7 @@ PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 MATAR_DIR="$PARENT_DIR/MATAR"
 if [ ! -d "$MATAR_DIR" ]; then
   echo "Directory 'MATAR' does not exist in '$PARENT_DIR', downloading 'MATAR'...."
-  git clone https://github.com/lanl/MATAR.git "$MATAR_DIR"
+  git clone --depth 1 https://github.com/lanl/MATAR.git "$MATAR_DIR"
 else
   echo "Directory 'MATAR' exists in '$PARENT_DIR', skipping 'MATAR' download"
 fi

--- a/src/EVPFFT/src/Fierro-EVPFFT-Link/UserEOSModel.cpp
+++ b/src/EVPFFT/src/Fierro-EVPFFT-Link/UserEOSModel.cpp
@@ -3,6 +3,7 @@
 KOKKOS_FUNCTION
 UserEOSModel::UserEOSModel(
   const DCArrayKokkos <material_t> &material,
+  const DCArrayKokkos <double> &state_vars,
   const DCArrayKokkos <double> &global_vars,
   const DCArrayKokkos <double> &elem_user_output_vars,
   const size_t mat_id,
@@ -22,6 +23,7 @@ int UserEOSModel::calc_sound_speed(
   const DViewCArrayKokkos <double> &elem_stress,
   const size_t elem_gid,
   const size_t mat_id,
+  const DCArrayKokkos <double> &state_vars,
   const DCArrayKokkos <double> &global_vars,
   const DCArrayKokkos <double> &elem_user_output_vars,
   const DViewCArrayKokkos <double> &elem_sspd,
@@ -38,6 +40,7 @@ int UserEOSModel::calc_pressure(
   const DViewCArrayKokkos <double> &elem_stress,
   const size_t elem_gid,
   const size_t mat_id,
+  const DCArrayKokkos <double> &state_vars,
   const DCArrayKokkos <double> &global_vars,
   const DCArrayKokkos <double> &elem_user_output_vars,
   const DViewCArrayKokkos <double> &elem_sspd,

--- a/src/EVPFFT/src/Fierro-EVPFFT-Link/UserEOSModel.h
+++ b/src/EVPFFT/src/Fierro-EVPFFT-Link/UserEOSModel.h
@@ -10,6 +10,7 @@ public:
   KOKKOS_FUNCTION
   UserEOSModel(
     const DCArrayKokkos <material_t> &material,
+    const DCArrayKokkos <double> &state_vars,
     const DCArrayKokkos <double> &global_vars,
     const DCArrayKokkos <double> &elem_user_output_vars,
     const size_t mat_id,
@@ -24,6 +25,7 @@ public:
     const DViewCArrayKokkos <double> &elem_stress,
     const size_t elem_gid,
     const size_t mat_id,
+    const DCArrayKokkos <double> &state_vars,
     const DCArrayKokkos <double> &global_vars,
     const DCArrayKokkos <double> &elem_user_output_vars,
     const DViewCArrayKokkos <double> &elem_sspd,
@@ -36,6 +38,7 @@ public:
     const DViewCArrayKokkos <double> &elem_stress,
     const size_t elem_gid,
     const size_t mat_id,
+    const DCArrayKokkos <double> &state_vars,
     const DCArrayKokkos <double> &global_vars,
     const DCArrayKokkos <double> &elem_user_output_vars,
     const DViewCArrayKokkos <double> &elem_sspd,

--- a/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.cpp
+++ b/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.cpp
@@ -7,6 +7,7 @@ MPI_Comm evpfft_mpi_comm = MPI_COMM_NULL;
 KOKKOS_FUNCTION
 UserStrengthModel::UserStrengthModel(
   const DCArrayKokkos <material_t> &material,
+  const DCArrayKokkos <double> &state_vars,
   const DCArrayKokkos <double> &global_vars,
   const DCArrayKokkos <double> &elem_user_output_vars,
   const size_t mat_id,
@@ -51,6 +52,7 @@ int UserStrengthModel::calc_stress(
   const DViewCArrayKokkos <double> &elem_stress,
   const size_t elem_gid,
   const size_t mat_id,
+  const DCArrayKokkos <double> &state_vars,
   const DCArrayKokkos <double> &global_vars,
   const DCArrayKokkos <double> &elem_user_output_vars,
   const DViewCArrayKokkos <double> &elem_sspd,

--- a/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.h
+++ b/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.h
@@ -10,6 +10,7 @@ public:
   KOKKOS_FUNCTION
   UserStrengthModel(
     const DCArrayKokkos <material_t> &material,
+    const DCArrayKokkos <double> &state_vars,
     const DCArrayKokkos <double> &global_vars,
     const DCArrayKokkos <double> &elem_user_output_vars,
     const size_t mat_id,
@@ -24,6 +25,7 @@ public:
     const DViewCArrayKokkos <double> &elem_stress,
     const size_t elem_gid,
     const size_t mat_id,
+    const DCArrayKokkos <double> &state_vars,
     const DCArrayKokkos <double> &global_vars,
     const DCArrayKokkos <double> &elem_user_output_vars,
     const DViewCArrayKokkos <double> &elem_sspd,

--- a/src/EVPFFT/src/data_grain.cpp
+++ b/src/EVPFFT/src/data_grain.cpp
@@ -144,7 +144,7 @@ void EVPFFT::data_grain(const std::string & filetext)
       s066(i,j) = c066.host(i,j);
     }
   }
-  invert_matrix(s066.pointer(),6);
+  invert_matrix <6> (s066.pointer());
 
   cb.chg_basis_3(c066.host_pointer(), c0.host_pointer(), 3, 6, cb.B_basis_host_pointer());
   cb.chg_basis_3(s066.pointer(), s0.host_pointer(), 3, 6, cb.B_basis_host_pointer());

--- a/src/EVPFFT/src/evpal.cpp
+++ b/src/EVPFFT/src/evpal.cpp
@@ -84,7 +84,7 @@ void EVPFFT::evpal(int imicro)
         }
       }
 
-      invert_matrix(sg66.pointer(), 6);
+      invert_matrix <6> (sg66.pointer());
 
       // TODO: optimize indexing of this loop
       for (int ii = 1; ii <= 3; ii++) {
@@ -243,7 +243,7 @@ void EVPFFT::evpal(int imicro)
           } // end for ii
 
 #if 0  
-          int error_flag = invert_matrix(xjacobinv.pointer(), 6);
+          int error_flag = invert_matrix <6> (xjacobinv.pointer());
 
           // TODO: optimize indexing of this loop
           for (int ii = 1; ii <= 6; ii++) {
@@ -350,7 +350,7 @@ void EVPFFT::evpal(int imicro)
     }
   }
 
-  invert_matrix(sg66_avg.pointer(), 6);
+  invert_matrix <6> (sg66_avg.pointer());
 
   // copy edotp_avg_view into edotp_avg
   for (int ii = 1; ii <= 3; ii++) {

--- a/src/EVPFFT/src/inverse_the_greens.cpp
+++ b/src/EVPFFT/src/inverse_the_greens.cpp
@@ -66,7 +66,7 @@ void EVPFFT::inverse_the_greens()
         }
       }
 
-      invert_matrix(a.pointer(), 3);
+      invert_matrix <3> (a.pointer());
 
       // TODO: optimize indexing of this loop 
       for (int p = 1; p <= 3; p++) {

--- a/src/EVPFFT/src/main.cpp
+++ b/src/EVPFFT/src/main.cpp
@@ -118,7 +118,7 @@ void EVPFFT::solve(real_t* vel_grad, real_t* stress, real_t dt, size_t cycle, si
         M66(ii,jj) = sg66_avg(ii,jj) + dedotp66_avg(ii,jj) * dt;
       }
     }
-    invert_matrix(M66.pointer(), 6);
+    invert_matrix <6> (M66.pointer());
 
     MatrixTypeRealHost M3333(3,3,3,3);
     cb.chg_basis_3(M66.pointer(), M3333.pointer(), 3, 6, cb.B_basis_host_pointer());

--- a/src/EVPFFT/src/math_functions.cpp
+++ b/src/EVPFFT/src/math_functions.cpp
@@ -26,55 +26,6 @@ void add_rows(double *matrix, int src_row, int dest_row, double factor, int n) {
     }
 }
 
-KOKKOS_FUNCTION
-int invert_matrix(double *matrix, int n) {
-    int error_flag=0;
-    double *identity = new double[n*n];
-    if (identity == NULL) {
-        printf("Error: Failed to allocate memory for identity matrix.\n");
-        return 1;
-    }
-
-    // Initialize identity matrix
-    for (int i = 0; i < n; i++) {
-        for (int j = 0; j < n; j++) {
-            *(identity + i * n + j) = (i == j) ? 1.0 : 0.0;
-        }
-    }
-
-    // Perform Gauss-Jordan elimination
-    for (int i = 0; i < n; i++) {
-        if (*(matrix + i * n + i) == 0) {
-            //printf("Error: Matrix is not invertible.\n");
-            delete [] identity;
-            return error_flag;
-        }
-
-        double pivot = *(matrix + i * n + i);
-        scale_row(matrix, i, 1.0 / pivot, n);
-        scale_row(identity, i, 1.0 / pivot, n);
-
-        for (int j = 0; j < n; j++) {
-            if (j != i) {
-                double factor = -*(matrix + j * n + i);
-                add_rows(matrix, i, j, factor, n);
-                add_rows(identity, i, j, factor, n);
-            }
-        }
-    }
-
-    // Copy the inverted matrix to the input matrix pointer
-    for (int i = 0; i < n; i++) {
-        for (int j = 0; j < n; j++) {
-            *(matrix + i * n + j) = *(identity + i * n + j);
-        }
-    }
-
-    delete [] identity;
-    error_flag = 0;
-    return error_flag;
-}
-// End New Gauss-Jordan elimination matrix inverse functions
 
 KOKKOS_FUNCTION
 int solve_linear_system(double* A, double* b, int n) {

--- a/src/EVPFFT/src/math_functions.h
+++ b/src/EVPFFT/src/math_functions.h
@@ -9,10 +9,73 @@ KOKKOS_FUNCTION
 T PowIntExpo(T base, int exponent);
 
 KOKKOS_FUNCTION
-int invert_matrix(double *matrix, int n);
+void swap_rows(double *matrix, int row1, int row2, int n);
+ 
+KOKKOS_FUNCTION
+void scale_row(double *matrix, int row, double factor, int n);
+
+KOKKOS_FUNCTION
+void add_rows(double *matrix, int src_row, int dest_row, double factor, int n);
+
+template<int n>
+KOKKOS_FUNCTION
+int invert_matrix(double *matrix);
 
 KOKKOS_FUNCTION
 int solve_linear_system(double* A, double* b, int n);
+
+
+
+template<int n>
+KOKKOS_FUNCTION
+int invert_matrix(double *matrix)
+{
+    int error_flag=0;
+    double identity[n*n];
+    if (identity == NULL) {
+        printf("Error: Failed to allocate memory for identity matrix.\n");
+        return 1;
+    }
+
+    // Initialize identity matrix
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < n; j++) {
+            *(identity + i * n + j) = (i == j) ? 1.0 : 0.0;
+        }
+    }
+
+    // Perform Gauss-Jordan elimination
+    for (int i = 0; i < n; i++) {
+        if (*(matrix + i * n + i) == 0) {
+            //printf("Error: Matrix is not invertible.\n");
+            return error_flag;
+        }
+
+        double pivot = *(matrix + i * n + i);
+        scale_row(matrix, i, 1.0 / pivot, n);
+        scale_row(identity, i, 1.0 / pivot, n);
+
+        for (int j = 0; j < n; j++) {
+            if (j != i) {
+                double factor = -*(matrix + j * n + i);
+                add_rows(matrix, i, j, factor, n);
+                add_rows(identity, i, j, factor, n);
+            }
+        }
+    }
+
+    // Copy the inverted matrix to the input matrix pointer
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < n; j++) {
+            *(matrix + i * n + j) = *(identity + i * n + j);
+        }
+    }
+
+    error_flag = 0;
+    return error_flag;
+}
+// End New Gauss-Jordan elimination matrix inverse functions
+
 
 // Optimized pow for integer exponents only
 template<typename T>

--- a/src/EVPFFT/src/write_micro_state.cpp
+++ b/src/EVPFFT/src/write_micro_state.cpp
@@ -149,7 +149,7 @@ void EVPFFT::calculate_eel(MatrixTypeRealDual &eel)
           }
         }
 
-        invert_matrix(cg66aux.pointer(), 6);
+        invert_matrix <6> (cg66aux.pointer());
           
         cb.chg_basis_3(cg66aux.pointer(), cinvg.pointer(), 3, 6, cb.B_basis_device_pointer());
 


### PR DESCRIPTION
Since we don't need the history of the repos we clone, I have limited the clones to depth of 1
`git clone --depth 1`
This should save some memory of the cloned repos.

Also, I made the `invert_matrix` function in EVPFFT a templated function because GPUs don't like `new`.

Finally, updated the EVPFFT user material interface to be up to date with Fierro.