### PR TITLE
Added build_fftw and build_hdf5 options and how to use Anaconda documentation

### DIFF
--- a/src/EVPFFT/.gitignore
+++ b/src/EVPFFT/.gitignore
@@ -10,3 +10,4 @@ hdf5
 heffte
 kokkos
 MATAR
+lib

--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -115,9 +115,6 @@ material_options:
     strength_type: hypo
     strength_run_location: host
     global_vars:
-      - 8 #N1 (EVPFFT RVE X dimension)
-      - 8 #N2 (EVPFFT RVE Y dimension)
-      - 8 #N3 (EVPFFT RVE Z dimension)
       - 0.0001 #udotAccTh (EVPFFT accumulated strain threshold before full solve)
       - 3000000 #[mm/s] (EVPFFT material sound speed)
 ```

--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -13,7 +13,8 @@ EVPFFT depends on the following to build:
 5. [HDF5](https://www.hdfgroup.org/solutions/hdf5/)
 
 
-##Building EVPFFT with Anaconda
+## Building EVPFFT with Anaconda
+
 It is advised to use Anaconda package manager to build EVPFFT as it simplifies systems environment setup and the installation of other dependecies. To build EVPFFT with anaconda:
 
 1. Create an environment and activate:
@@ -38,6 +39,7 @@ make
 ```
 
 ## Building EVPFFT without Anacaonda
+
 To make it easy to build EVPFFT, we have included `scripts/build-scripts/build_evpfft.sh` which when executed will download and install all required dependencies and EVPFFT. The script assumes that the user already has MPI installed.
 
 Run the build script as:

--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -25,10 +25,10 @@ conda activate evpfftEnv
 2. Install EVPFFT dependencies:
 ```
 conda install cxx-compiler -c conda-forge
-conda install “fftw=*=mpi_openmpi*” -c conda-forge
-conda install “hdf5=*=mpi_openmpi*” -c conda-forge
+conda install "fftw=*=mpi_openmpi*" -c conda-forge
+conda install "hdf5=*=mpi_openmpi*" -c conda-forge
 conda install elements -c kwelsh-lanl
-conda install “kokkos=4.1”
+conda install "kokkos=4.1"
 conda install fierro-heffte -c kwelsh-lanl
 conda install cmake
 ```

--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -12,6 +12,32 @@ EVPFFT depends on the following to build:
 4. [HeFFTe](https://github.com/icl-utk-edu/heffte) (FFTW,CUFFT,ROCFFT)
 5. [HDF5](https://www.hdfgroup.org/solutions/hdf5/)
 
+
+##Building EVPFFT with Anaconda
+It is advised to use Anaconda package manager to build EVPFFT as it simplifies systems environment setup and the installation of other dependecies. To build EVPFFT with anaconda:
+
+1. Create an environment and activate:
+```
+conda create --name evpfftEnv
+conda activate evpfftEnv
+```
+2. Install EVPFFT dependencies:
+```
+conda install cxx-compiler -c conda-forge
+conda install “fftw=*=mpi_openmpi*” -c conda-forge
+conda install “hdf5=*=mpi_openmpi*” -c conda-forge
+conda install elements -c kwelsh-lanl
+conda install “kokkos=4.1”
+conda install fierro-heffte -c kwelsh-lanl
+conda install cmake
+```
+3. Build EVPFFT
+```
+cmake /path/to/EVPFFT/src/ -DUSE_FFTW
+make
+```
+
+## Building EVPFFT without Anacaonda
 To make it easy to build EVPFFT, we have included `scripts/build-scripts/build_evpfft.sh` which when executed will download and install all required dependencies and EVPFFT. The script assumes that the user already has MPI installed.
 
 Run the build script as:

--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -29,6 +29,7 @@ Required arguments:
   --kokkos_build_type=<serial|openmp|pthreads|cuda|hip>
 
 Optional arguments:
+  --build_fftw: builds fftw from scratch
   --machine=<darwin|chicoma|linux|mac> (default: none)
   --num_jobs=<number>: Number of jobs for 'make' (default: 1, on Mac use 1)
   --help: Display this help message
@@ -37,10 +38,14 @@ Optional arguments:
 To build EVPFFT you would need to provide both the `--heffte_build_type` and `--kokkos_build_type` options. The command below build EVPFFT using FFTW and Serial version of Kokkos:
 
 ```
-source build_evpfft.sh --heffte_build_type=fftw --kokkos_build_type=serial
+source build_evpfft.sh --heffte_build_type=fftw --kokkos_build_type=serial --build_fftw
 ```
 
-This will build EVPFFT in the folder `evpfft_{fftw}_{serial}`. The binary, `evpfft` is found in that folder
+This will build EVPFFT in the folder `evpfft_{fftw}_{serial}`. The binary, `evpfft` is found in that folder. Note that the `--build_fftw` will build FFTW from scratch. If you do not want to build FFTW from scratch because you already have a version on your system remove the `--build_fftw` option from the command. If your installed FFTW in a directory other than the default linux directories for libraries, then specify the following before running the build script.
+
+```
+export FFTW_ROOT=/path/to/where/FFTW/lib/and/include/folders/are/located
+```
 
 # Using EVPFFT as a standalone program
 

--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -34,7 +34,11 @@ conda install cmake
 ```
 3. Build EVPFFT
 ```
-cmake /path/to/EVPFFT/src/ -DUSE_FFTW
+git clone https://github.com/lanl/Fierro.git
+cd Fierro/src/EVPFFT
+mkdir build
+cd build
+cmake ../src/ -DUSE_FFTW
 make
 ```
 

--- a/src/EVPFFT/README.md
+++ b/src/EVPFFT/README.md
@@ -12,42 +12,26 @@ EVPFFT depends on the following to build:
 4. [HeFFTe](https://github.com/icl-utk-edu/heffte) (FFTW,CUFFT,ROCFFT)
 5. [HDF5](https://www.hdfgroup.org/solutions/hdf5/)
 
+To make it easy to build EVPFFT, we have included `scripts/build-scripts/build_evpfft.sh` which when executed will download and install all required dependencies and EVPFFT. It is important to note that EVPFFT depends on three main libraries which can be time consuming to download from scratch namely, MPI, FFTW (MPI version), and HDF5 (MPI version). Therefore the user is advised to download these packages themselves either using `sudo apt install` of Anaconda package manager.
 
 ## Building EVPFFT with Anaconda
-
-It is advised to use Anaconda package manager to build EVPFFT as it simplifies systems environment setup and the installation of other dependecies. To build EVPFFT with anaconda:
+It is advised to use Anaconda package manager to build EVPFFT as follows:
 
 1. Create an environment and activate:
 ```
 conda create --name evpfftEnv
 conda activate evpfftEnv
 ```
-2. Install EVPFFT dependencies:
+
+2. Install needed packages:
 ```
 conda install cxx-compiler -c conda-forge
+conda install cmake
 conda install "fftw=*=mpi_openmpi*" -c conda-forge
 conda install "hdf5=*=mpi_openmpi*" -c conda-forge
-conda install elements -c kwelsh-lanl
-conda install "kokkos=4.1"
-conda install fierro-heffte -c kwelsh-lanl
-conda install cmake
-```
-3. Build EVPFFT
-```
-git clone https://github.com/lanl/Fierro.git
-cd Fierro/src/EVPFFT
-mkdir build
-cd build
-cmake ../src/ -DUSE_FFTW
-make
 ```
 
-## Building EVPFFT without Anacaonda
-
-To make it easy to build EVPFFT, we have included `scripts/build-scripts/build_evpfft.sh` which when executed will download and install all required dependencies and EVPFFT. The script assumes that the user already has MPI installed.
-
-Run the build script as:
-
+3. Run the build script as:
 ```
 source build_evpfft.sh --help
 ```
@@ -62,6 +46,7 @@ Required arguments:
 
 Optional arguments:
   --build_fftw: builds fftw from scratch
+  --build_hdf5: builds hdf5 from scratch
   --machine=<darwin|chicoma|linux|mac> (default: none)
   --num_jobs=<number>: Number of jobs for 'make' (default: 1, on Mac use 1)
   --help: Display this help message
@@ -70,12 +55,20 @@ Optional arguments:
 To build EVPFFT you would need to provide both the `--heffte_build_type` and `--kokkos_build_type` options. The command below build EVPFFT using FFTW and Serial version of Kokkos:
 
 ```
-source build_evpfft.sh --heffte_build_type=fftw --kokkos_build_type=serial --build_fftw
+source build_evpfft.sh --heffte_build_type=fftw --kokkos_build_type=serial
 ```
 
-This will build EVPFFT in the folder `evpfft_{fftw}_{serial}`. The binary, `evpfft` is found in that folder. Note that the `--build_fftw` will build FFTW from scratch. If you do not want to build FFTW from scratch because you already have a version on your system remove the `--build_fftw` option from the command. If your installed FFTW in a directory other than the default linux directories for libraries, then specify the following before running the build script.
+This will build EVPFFT in the folder `evpfft_{fftw}_{serial}`. The binary, `evpfft` is found in that folder.
+
+## Building EVPFFT without Anaconda
+Install HDF5 (MPI version) and FFTW (MPI version) with `sudo apt install` which will install the libraries in the default location. Then run the build script as above.
+
+If you would like to build HDF5 and FFTW from scratch then use `--build_hdf5` and `--build_fftw` options of the build script.
+
+If you do not want to build HDF5 and FFTW from scratch because you already have a version on your system remove the `--build_hdf5` and `--build_fftw` option from the command. If your installed HDF5 and FFTW are located in a directory other than the default linux directories for libraries, then specify the following before running the build script.
 
 ```
+export HDF5_ROOT=/path/to/where/HDF5/lib/and/include/folders/are/located
 export FFTW_ROOT=/path/to/where/FFTW/lib/and/include/folders/are/located
 ```
 

--- a/src/EVPFFT/scripts/build-scripts/build_evpfft.sh
+++ b/src/EVPFFT/scripts/build-scripts/build_evpfft.sh
@@ -107,10 +107,8 @@ mkdir -p "$LIB_DIR"
 
 # --------setup env for machine
 if [ -n "$machine" ]; then
-    if [ "$machine" != "linux" ]; then
-        MACHINE_SCRIPT="$PARENT_DIR/scripts/machines/${machine}-env.sh"
-        source  "$MACHINE_SCRIPT" --env_type=$kokkos_build_type
-    fi
+    MACHINE_SCRIPT="$PARENT_DIR/scripts/machines/${machine}-env.sh"
+    source  "$MACHINE_SCRIPT" --env_type=$kokkos_build_type
 fi
 
 # --------building heffte

--- a/src/EVPFFT/scripts/build-scripts/build_evpfft.sh
+++ b/src/EVPFFT/scripts/build-scripts/build_evpfft.sh
@@ -139,7 +139,7 @@ EVPFFT_BUILD_DIR="$PARENT_DIR/evpfft_${heffte_build_type}_${kokkos_build_type}"
 HEFFTE_INSTALL_DIR="$LIB_DIR/heffte/install_heffte_$heffte_build_type"
 KOKKOS_INSTALL_DIR="$LIB_DIR/kokkos/install_kokkos_$kokkos_build_type"
 MATAR_INSTALL_DIR="$LIB_DIR/MATAR/install_MATAR_$kokkos_build_type"
-HDF5_INSTALL_DIR="$LIB_DIR/hdf5/install"
+HDF5_INSTALL_DIR="$LIB_DIR/hdf5/install_hdf5"
 
 
 # Configure EVPFFT using CMake

--- a/src/EVPFFT/scripts/build-scripts/build_evpfft.sh
+++ b/src/EVPFFT/scripts/build-scripts/build_evpfft.sh
@@ -8,6 +8,7 @@ show_help() {
     echo " "
     echo "Optional arguments:"
     echo "  --build_fftw: builds fftw from scratch"
+    echo "  --build_hdf5: builds hdf5 from scratch"
     echo "  --machine=<darwin|chicoma|linux|mac> (default: none)"
     echo "  --num_jobs=<number>: Number of jobs for 'make' (default: 1, on Mac use 1)"
     echo "  --help: Display this help message"
@@ -21,6 +22,7 @@ kokkos_build_type=""
 machine=""
 num_jobs=1
 build_fftw=0
+build_hdf5=0
 
 # Define arrays of valid options
 valid_heffte_build_types=("fftw" "cufft" "rocfft")
@@ -50,8 +52,11 @@ for arg in "$@"; do
                 return 1
             fi
             ;;
-        --build_fftw)  # New option without a value
+        --build_fftw)
             build_fftw=1
+            ;;
+        --build_hdf5)
+            build_hdf5=1
             ;;
         --machine=*)
             option="${arg#*=}"
@@ -124,8 +129,10 @@ KOKKOS_INSTALL_SCRIPT="$PARENT_DIR/scripts/install-scripts/install_kokkos.sh"
 source "$KOKKOS_INSTALL_SCRIPT" --kokkos_build_type=$kokkos_build_type --num_jobs=$num_jobs
 
 # --------building hdf5
-HDF5_INSTALL_SCRIPT="$PARENT_DIR/scripts/install-scripts/install_hdf5.sh"
-source "$HDF5_INSTALL_SCRIPT" --num_jobs=$num_jobs
+if [ "$build_hdf5" -eq 1 ]; then
+  HDF5_INSTALL_SCRIPT="$PARENT_DIR/scripts/install-scripts/install_hdf5.sh"
+  source "$HDF5_INSTALL_SCRIPT" --num_jobs=$num_jobs
+fi
 
 # --------building matar
 MATAR_INSTALL_SCRIPT="$PARENT_DIR/scripts/install-scripts/install_matar.sh"
@@ -139,8 +146,9 @@ EVPFFT_BUILD_DIR="$PARENT_DIR/evpfft_${heffte_build_type}_${kokkos_build_type}"
 HEFFTE_INSTALL_DIR="$LIB_DIR/heffte/install_heffte_$heffte_build_type"
 KOKKOS_INSTALL_DIR="$LIB_DIR/kokkos/install_kokkos_$kokkos_build_type"
 MATAR_INSTALL_DIR="$LIB_DIR/MATAR/install_MATAR_$kokkos_build_type"
-HDF5_INSTALL_DIR="$LIB_DIR/hdf5/install_hdf5"
-
+if [ "$build_hdf5" -eq 1 ]; then
+  HDF5_INSTALL_DIR="$LIB_DIR/hdf5/install_hdf5"
+fi
 
 # Configure EVPFFT using CMake
 cmake_options=(

--- a/src/EVPFFT/scripts/install-scripts/install_fftw.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_fftw.sh
@@ -1,0 +1,116 @@
+#!/bin/bash -e
+
+show_help() {
+    echo "Usage: source $(basename "$BASH_SOURCE") [OPTION]"
+    echo "Valid options:"
+    echo "  --num_jobs=<number>: Number of jobs for 'make' (default: 1, on Mac use 1)"
+    echo "  --help: Display this help message"
+    return 1
+}
+
+# Initialize variables with default values
+num_jobs=1
+
+# Parse command line arguments
+for arg in "$@"; do
+    case "$arg" in
+        --num_jobs=*)
+            num_jobs="${arg#*=}"
+            if ! [[ "$num_jobs" =~ ^[0-9]+$ ]]; then
+                echo "Error: Invalid --num_jobs value. Must be a positive integer."
+                show_help
+                return 1
+            fi
+            ;;
+        --help)
+            show_help
+            return 1
+            ;;
+        *)
+            echo "Error: Invalid argument or value specified."
+            show_help
+            return 1
+            ;;
+    esac
+done
+
+# Determine the script's directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "Script location: $SCRIPT_DIR"
+
+# Determine the parent directory of the script's directory
+PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
+
+# make lib directory to store all dependencies
+LIB_DIR="$PARENT_DIR/lib"
+mkdir -p "$LIB_DIR"
+
+# Define FFTW directories
+FFTW_SOURCE_DIR="$LIB_DIR/fftw-3.3.10"
+FFTW_INSTALL_DIR="$LIB_DIR/fftw-3.3.10/install"
+FFTW_BUILD_DIR="$LIB_DIR/fftw-3.3.10/build"
+
+# Check if the 'fftw-3.3.10' directory exists in the lib directory; if not, clone it
+if [ ! -d "$FFTW_SOURCE_DIR" ]; then
+  echo "Directory 'fftw' does not exist in '$LIB_DIR', downloading 'fftw'...."
+  wget -P "$LIB_DIR" "http://www.fftw.org/fftw-3.3.10.tar.gz"
+  tar -C "$LIB_DIR" -zxvf "$LIB_DIR/fftw-3.3.10.tar.gz"
+else
+  echo "Directory 'fftw' exists in '$LIB_DIR', skipping 'fftw' download"
+fi
+
+# Check to avoid reinstalling FFTW which might take time
+if [ -d "$FFTW_INSTALL_DIR" ]; then
+    echo "FFTW already installed, to reinstall FFTW delete $FFTW_INSTALL_DIR and $FFTW_BUILD_DIR"
+    return 0
+fi
+
+# Configure fftw
+config_options=(
+    CFLAGS='-O3 -DNDEBUG -fPIC'
+    --prefix=${FFTW_INSTALL_DIR}
+    --enable-mpi
+    --enable-threads
+    --enable-openmp
+    #--enable-avx
+    #--enable-avx2
+    #--enable-avx512
+)
+
+current_dir=$(pwd)
+# have to mkdir and cd because configure does not provide option for build_dir
+mkdir -p "$FFTW_BUILD_DIR"
+cd "$FFTW_BUILD_DIR"
+# Run configure
+"$FFTW_SOURCE_DIR/configure" "${config_options[@]}"
+
+echo "Building double precision fftw..."
+make -C "$FFTW_BUILD_DIR" -j"$num_jobs"
+
+echo "Installing double precision fftw..."
+make -C "$FFTW_BUILD_DIR" install
+
+# cleanup before installing single precision
+make distclean
+
+# Configure for single precision
+config_options+=(
+    --enable-float
+)
+
+# Run configure for single precision
+"$FFTW_SOURCE_DIR/configure" "${config_options[@]}"
+
+echo "Building single precision fftw..."
+make -C "$FFTW_BUILD_DIR" -j"$num_jobs"
+
+echo "Installing single precision fftw..."
+make -C "$FFTW_BUILD_DIR" install
+
+#cleanup
+make distclean
+
+cd "$current_dir"
+
+echo "fftw installation complete."
+

--- a/src/EVPFFT/scripts/install-scripts/install_fftw.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_fftw.sh
@@ -47,8 +47,8 @@ mkdir -p "$LIB_DIR"
 
 # Define FFTW directories
 FFTW_SOURCE_DIR="$LIB_DIR/fftw-3.3.10"
-FFTW_INSTALL_DIR="$LIB_DIR/fftw-3.3.10/install"
-FFTW_BUILD_DIR="$LIB_DIR/fftw-3.3.10/build"
+FFTW_INSTALL_DIR="$LIB_DIR/fftw-3.3.10/install_fftw"
+FFTW_BUILD_DIR="$LIB_DIR/fftw-3.3.10/build_fftw"
 
 # Check if the 'fftw-3.3.10' directory exists in the lib directory; if not, clone it
 if [ ! -d "$FFTW_SOURCE_DIR" ]; then

--- a/src/EVPFFT/scripts/install-scripts/install_hdf5.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_hdf5.sh
@@ -47,8 +47,8 @@ mkdir -p "$LIB_DIR"
 
 # Define hdf5 directories
 HDF5_SOURCE_DIR="$LIB_DIR/hdf5"
-HDF5_INSTALL_DIR="$LIB_DIR/hdf5/install"
-HDF5_BUILD_DIR="$LIB_DIR/hdf5/build"
+HDF5_INSTALL_DIR="$LIB_DIR/hdf5/install_hdf5"
+HDF5_BUILD_DIR="$LIB_DIR/hdf5/build_hdf5"
 
 # Check if the 'hdf5' directory exists in the parent directory; if not, clone it
 if [ ! -d "$HDF5_SOURCE_DIR" ]; then

--- a/src/EVPFFT/scripts/install-scripts/install_hdf5.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_hdf5.sh
@@ -41,19 +41,23 @@ echo "Script location: $SCRIPT_DIR"
 # Determine the parent directory of the script's directory
 PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 
-# Check if the 'hdf5' directory exists in the parent directory; if not, clone it
-HDF5_DIR="$PARENT_DIR/hdf5"
-if [ ! -d "$HDF5_DIR" ]; then
-  echo "Directory 'hdf5' does not exist in '$PARENT_DIR', downloading 'hdf5'...."
-  git clone --depth 1 https://github.com/HDFGroup/hdf5.git "$HDF5_DIR"
-else
-  echo "Directory 'hdf5' exists in '$PARENT_DIR', skipping 'hdf5' download"
-fi
+# make lib directory to store all dependencies
+LIB_DIR="$PARENT_DIR/lib"
+mkdir -p "$LIB_DIR"
 
 # Define hdf5 directories
-HDF5_SOURCE_DIR="$PARENT_DIR/hdf5"
-HDF5_INSTALL_DIR="$PARENT_DIR/hdf5/install"
-HDF5_BUILD_DIR="$PARENT_DIR/hdf5/build"
+HDF5_SOURCE_DIR="$LIB_DIR/hdf5"
+HDF5_INSTALL_DIR="$LIB_DIR/hdf5/install"
+HDF5_BUILD_DIR="$LIB_DIR/hdf5/build"
+
+# Check if the 'hdf5' directory exists in the parent directory; if not, clone it
+if [ ! -d "$HDF5_SOURCE_DIR" ]; then
+  echo "Directory 'hdf5' does not exist in '$LIB_DIR', downloading 'hdf5'...."
+  git clone --depth 1 https://github.com/HDFGroup/hdf5.git "$HDF5_SOURCE_DIR"
+else
+  echo "Directory 'hdf5' exists in '$LIB_DIR', skipping 'hdf5' download"
+fi
+
 
 # Check to avoid reinstalling HDF5 which might take time
 if [ -d "$HDF5_INSTALL_DIR" ]; then

--- a/src/EVPFFT/scripts/install-scripts/install_heffte.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_heffte.sh
@@ -86,7 +86,7 @@ HEFFTE_BUILD_DIR="$LIB_DIR/heffte/build_heffte_$heffte_build_type"
 if [ "$heffte_build_type" = "fftw" ] && [ "$build_fftw" -eq 1 ]; then
   FFTW_INSTALL_SCRIPT="$PARENT_DIR/scripts/install-scripts/install_fftw.sh"
   source "$FFTW_INSTALL_SCRIPT" --num_jobs=$num_jobs
-  FFTW_INSTALL_DIR="$LIB_DIR/fftw-3.3.10/install"
+  FFTW_INSTALL_DIR="$LIB_DIR/fftw-3.3.10/install_fftw"
 fi
 
 # Check if the 'heffte' directory exists in the parent directory; if not, clone it

--- a/src/EVPFFT/scripts/install-scripts/install_heffte.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_heffte.sh
@@ -2,8 +2,11 @@
 
 show_help() {
     echo "Usage: source $(basename "$BASH_SOURCE") [OPTION]"
-    echo "Valid options:"
+    echo "Required arguments:"
     echo "  --heffte_build_type=<fftw|cufft|rocfft>"
+    echo " "
+    echo "Optional arguments:"
+    echo "  --build_fftw: builds fftw from scratch"
     echo "  --num_jobs=<number>: Number of jobs for 'make' (default: 1, on Mac use 1)"
     echo "  --help: Display this help message"
     return 1
@@ -12,6 +15,7 @@ show_help() {
 # Initialize variables with default values
 heffte_build_type=""
 num_jobs=1
+build_fftw=0  # Default value for build_fftw
 
 # Define arrays of valid options
 valid_heffte_build_types=("fftw" "cufft" "rocfft")
@@ -36,6 +40,9 @@ for arg in "$@"; do
                 show_help
                 return 1
             fi
+            ;;
+        --build_fftw)  # New option without a value
+            build_fftw=1
             ;;
         --help)
             show_help
@@ -66,20 +73,29 @@ echo "Script location: $SCRIPT_DIR"
 # Determine the parent directory of the script's directory
 PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 
-# Check if the 'heffte' directory exists in the parent directory; if not, clone it
-HEFFTE_DIR="$PARENT_DIR/heffte"
-if [ ! -d "$HEFFTE_DIR" ]; then
-  echo "Directory 'heffte' does not exist in '$PARENT_DIR', downloading 'heffte'...."
-  git clone --depth 1 https://github.com/icl-utk-edu/heffte.git "$HEFFTE_DIR"
-else
-  echo "Directory 'heffte' exists in '$PARENT_DIR', skipping 'heffte' download"
+# make lib directory to store all dependencies
+LIB_DIR="$PARENT_DIR/lib"
+mkdir -p "$LIB_DIR"
+
+# Define HeFFTe directories
+HEFFTE_SOURCE_DIR="$LIB_DIR/heffte"
+HEFFTE_INSTALL_DIR="$LIB_DIR/heffte/install_heffte_$heffte_build_type"
+HEFFTE_BUILD_DIR="$LIB_DIR/heffte/build_heffte_$heffte_build_type"
+
+# --------building fftw
+if [ "$heffte_build_type" = "fftw" ] && [ "$build_fftw" -eq 1 ]; then
+  FFTW_INSTALL_SCRIPT="$PARENT_DIR/scripts/install-scripts/install_fftw.sh"
+  source "$FFTW_INSTALL_SCRIPT" --num_jobs=$num_jobs
+  FFTW_INSTALL_DIR="$LIB_DIR/fftw-3.3.10/install"
 fi
 
-# Define HeFFTe and FFTW directories
-HEFFTE_SOURCE_DIR="$PARENT_DIR/heffte"
-HEFFTE_INSTALL_DIR="$PARENT_DIR/heffte/install_heffte_$heffte_build_type"
-HEFFTE_BUILD_DIR="$PARENT_DIR/heffte/build_heffte_$heffte_build_type"
-
+# Check if the 'heffte' directory exists in the parent directory; if not, clone it
+if [ ! -d "$HEFFTE_SOURCE_DIR" ]; then
+  echo "Directory 'heffte' does not exist in '$LIB_DIR', downloading 'heffte'...."
+  git clone --depth 1 https://github.com/icl-utk-edu/heffte.git "$HEFFTE_SOURCE_DIR"
+else
+  echo "Directory 'heffte' exists in '$LIB_DIR', skipping 'heffte' download"
+fi
 
 # Configure heffte using CMake
 cmake_options=(
@@ -95,6 +111,11 @@ if [ "$heffte_build_type" = "fftw" ]; then
         -D Heffte_ENABLE_FFTW=ON
         #-D FFTW_ROOT="$FFTW_DIR"
     )
+    if [ "$build_fftw" -eq 1 ]; then
+      cmake_options+=(
+        -D FFTW_ROOT="$FFTW_INSTALL_DIR"
+      )
+    fi
 elif [ "$heffte_build_type" = "cufft" ]; then
     cmake_options+=(
         -D Heffte_ENABLE_CUDA=ON

--- a/src/EVPFFT/scripts/install-scripts/install_kokkos.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_kokkos.sh
@@ -66,19 +66,22 @@ echo "Script location: $SCRIPT_DIR"
 # Determine the parent directory of the script's directory
 PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 
-# Check if the 'kokkos' directory exists in the parent directory; if not, clone it
-KOKKOS_DIR="$PARENT_DIR/kokkos"
-if [ ! -d "$KOKKOS_DIR" ]; then
-  echo "Directory 'kokkos' does not exist in '$PARENT_DIR', downloading 'kokkos'...."
-  git clone --depth 1 https://github.com/kokkos/kokkos.git "$KOKKOS_DIR"
-else
-  echo "Directory 'kokkos' exists in '$PARENT_DIR', skipping 'kokkos' download"
-fi
+# make lib directory to store all dependencies
+LIB_DIR="$PARENT_DIR/lib"
+mkdir -p "$LIB_DIR"
 
 # Define kokkos directories
-KOKKOS_SOURCE_DIR="$PARENT_DIR/kokkos"
-KOKKOS_INSTALL_DIR="$PARENT_DIR/kokkos/install_kokkos_$kokkos_build_type"
-KOKKOS_BUILD_DIR="$PARENT_DIR/kokkos/build_kokkos_$kokkos_build_type"
+KOKKOS_SOURCE_DIR="$LIB_DIR/kokkos"
+KOKKOS_INSTALL_DIR="$LIB_DIR/kokkos/install_kokkos_$kokkos_build_type"
+KOKKOS_BUILD_DIR="$LIB_DIR/kokkos/build_kokkos_$kokkos_build_type"
+
+# Check if the 'kokkos' directory exists in the parent directory; if not, clone it
+if [ ! -d "$KOKKOS_SOURCE_DIR" ]; then
+  echo "Directory 'kokkos' does not exist in '$LIB_DIR', downloading 'kokkos'...."
+  git clone --depth 1 https://github.com/kokkos/kokkos.git "$KOKKOS_SOURCE_DIR"
+else
+  echo "Directory 'kokkos' exists in '$LIB_DIR', skipping 'kokkos' download"
+fi
 
 # Configure kokkos using CMake
 cmake_options=(

--- a/src/EVPFFT/scripts/install-scripts/install_matar.sh
+++ b/src/EVPFFT/scripts/install-scripts/install_matar.sh
@@ -69,20 +69,23 @@ echo "Script location: $SCRIPT_DIR"
 # Determine the parent directory of the script's directory
 PARENT_DIR=$(dirname $(dirname "${SCRIPT_DIR}"))
 
-# Check if the 'MATAR' directory exists in the parent directory; if not, clone it
-MATAR_DIR="$PARENT_DIR/MATAR"
-if [ ! -d "$MATAR_DIR" ]; then
-  echo "Directory 'MATAR' does not exist in '$PARENT_DIR', downloading 'MATAR'...."
-  git clone --depth 1 https://github.com/lanl/MATAR.git "$MATAR_DIR"
-else
-  echo "Directory 'MATAR' exists in '$PARENT_DIR', skipping 'MATAR' download"
-fi
+# make lib directory to store all dependencies
+LIB_DIR="$PARENT_DIR/lib"
+mkdir -p "$LIB_DIR"
 
-# Define kokkos directories
-MATAR_SOURCE_DIR="$PARENT_DIR/MATAR"
-MATAR_INSTALL_DIR="$PARENT_DIR/MATAR/install_MATAR_$kokkos_build_type"
-MATAR_BUILD_DIR="$PARENT_DIR/MATAR/build_MATAR_$kokkos_build_type"
-KOKKOS_INSTALL_DIR="${PARENT_DIR}/kokkos/install_kokkos_$kokkos_build_type"
+# Define MATAR and kokkos directories
+MATAR_SOURCE_DIR="$LIB_DIR/MATAR"
+MATAR_INSTALL_DIR="$LIB_DIR/MATAR/install_MATAR_$kokkos_build_type"
+MATAR_BUILD_DIR="$LIB_DIR/MATAR/build_MATAR_$kokkos_build_type"
+KOKKOS_INSTALL_DIR="${LIB_DIR}/kokkos/install_kokkos_$kokkos_build_type"
+
+# Check if the 'MATAR' directory exists in the parent directory; if not, clone it
+if [ ! -d "$MATAR_SOURCE_DIR" ]; then
+  echo "Directory 'MATAR' does not exist in '$LIB_DIR', downloading 'MATAR'...."
+  git clone --depth 1 https://github.com/lanl/MATAR.git "$MATAR_SOURCE_DIR"
+else
+  echo "Directory 'MATAR' exists in '$LIB_DIR', skipping 'MATAR' download"
+fi
 
 cmake_options=(
     -D CMAKE_INSTALL_PREFIX="${MATAR_INSTALL_DIR}"

--- a/src/EVPFFT/scripts/machines/linux-env.sh
+++ b/src/EVPFFT/scripts/machines/linux-env.sh
@@ -1,0 +1,12 @@
+# Assign path's to the current software you want to use.
+# These path's will need to be changed based on your computer
+# The default for homebrew should place packages as shown below
+
+#export CC=/opt/homebrew/opt/llvm/bin/clang
+#export CXX=/opt/homebrew/opt/llvm/bin/clang++
+#export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+#export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+#export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+#export OMPI_CC=${CC}
+#export OMPI_CXX=${CXX}
+#export FFTW_ROOT=/path/to/where/FFTW/lib/and/include/folders/are/located

--- a/src/EVPFFT/scripts/machines/linux-env.sh
+++ b/src/EVPFFT/scripts/machines/linux-env.sh
@@ -9,4 +9,5 @@
 #export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 #export OMPI_CC=${CC}
 #export OMPI_CXX=${CXX}
+#export HDF5_ROOT=/path/to/where/HDF5/lib/and/include/folders/are/located
 #export FFTW_ROOT=/path/to/where/FFTW/lib/and/include/folders/are/located

--- a/src/EVPFFT/scripts/machines/mac-env.sh
+++ b/src/EVPFFT/scripts/machines/mac-env.sh
@@ -9,3 +9,4 @@ export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 export OMPI_CC=${CC}
 export OMPI_CXX=${CXX}
+#export FFTW_ROOT=/path/to/where/FFTW/lib/and/include/folders/are/located

--- a/src/EVPFFT/scripts/machines/mac-env.sh
+++ b/src/EVPFFT/scripts/machines/mac-env.sh
@@ -9,4 +9,5 @@ export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
 export OMPI_CC=${CC}
 export OMPI_CXX=${CXX}
+#export HDF5_ROOT=/path/to/where/HDF5/lib/and/include/folders/are/located
 #export FFTW_ROOT=/path/to/where/FFTW/lib/and/include/folders/are/located

--- a/src/EVPFFT/src/Fierro-EVPFFT-Link/UserEOSModel.cpp
+++ b/src/EVPFFT/src/Fierro-EVPFFT-Link/UserEOSModel.cpp
@@ -9,7 +9,7 @@ UserEOSModel::UserEOSModel(
   const size_t mat_id,
   const size_t elem_gid)
 {
- sound_speed = global_vars(mat_id,4); 
+ sound_speed = global_vars(mat_id,1); 
 }
 
 KOKKOS_FUNCTION

--- a/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.cpp
+++ b/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.cpp
@@ -76,7 +76,7 @@ int UserStrengthModel::calc_stress(
       }
     }
 
-    double udotAccTh = global_vars.host(mat_id,3); // Linear Aprox. Threshold
+    double udotAccTh = global_vars.host(mat_id,0); // Linear Aprox. Threshold
     evpfft_ptr->solve(Fvel_grad.pointer(), Fstress.pointer(), dt_rk, cycle, elem_gid, udotAccTh);
 
     // Transpose stress. Not needed, stress is symmetric. But why not.

--- a/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.cpp
+++ b/src/EVPFFT/src/Fierro-EVPFFT-Link/UserStrengthModel.cpp
@@ -24,11 +24,6 @@ UserStrengthModel::UserStrengthModel(
     // Input files for for multiple materials should be names as evpfft1.in, evpfft2.in, etc.
     std::string filename = "evpfft" + std::to_string(mat_id+1) + ".in";
 
-    // get dimensions
-    int N1 = global_vars.host(mat_id,0);
-    int N2 = global_vars.host(mat_id,1);
-    int N3 = global_vars.host(mat_id,2);
-
     real_t stress_scale = 1.0; // 1.0e-5; // used to convert MPa to MegaBar
     real_t time_scale = 1.0; // 1.0e+6; // used to convert second to microsecond
 


### PR DESCRIPTION
I added --build_fftw and --build_hdf5 options to the EVPFFT build script. This gives more control to the user as to whether to use their own installation of the packages or build it from scratch.

Additionally, I included instructions on how to use the Anaconda package manager to build EVPFFT.