### PR TITLE
Create Fierro-cpu Anaconda Builds + Github Actions

### DIFF
--- a/.conda/fierro/cpu/build.sh
+++ b/.conda/fierro/cpu/build.sh
@@ -2,6 +2,11 @@
 source "$RECIPE_DIR/../../cross-compile-setup.sh"
 mkdir build
 cd build
+
+# -D _LIBCPP_DISABLE_AVAILABILITY
+# is added to the CXXFLAGS for MacOS builds. 
+# see https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+
 cmake .. \
       -D CMAKE_BUILD_TYPE:STRING=RELEASE \
       -D CMAKE_INSTALL_PREFIX:PATH=$PREFIX \
@@ -11,7 +16,7 @@ cmake .. \
       -D BUILD_ELEMENTS=OFF \
       -D DISTRIBUTION=On \
       $CMAKE_ARGS \
-      -D CMAKE_CXX_FLAGS="$PATCHED_CXXFLAGS -fopenmp" \
+      -D CMAKE_CXX_FLAGS="$PATCHED_CXXFLAGS -fopenmp -D_LIBCPP_DISABLE_AVAILABILITY" \
       -D MPI_C_COMPILER="$BUILD_PREFIX/bin/mpicc" \
       -D MPI_CXX_COMPILER="$BUILD_PREFIX/bin/mpicxx" \
       -D VECTOR_ARCH_FLAGS="$VECTOR_ARCH_FLAGS" \

--- a/.conda/fierro/cpu/build.sh
+++ b/.conda/fierro/cpu/build.sh
@@ -1,25 +1,16 @@
-export SRC_DIR=$(pwd)
-mkdir -p build
-cd build
-
-export MPI_FLAGS="--allow-run-as-root"
-
-if [ $(uname) == Linux ]; then
-    export MPI_FLAGS="$MPI_FLAGS;-mca;plm;isolated"
-fi
-
 # These flag variables are set by anaconda.
 source "$RECIPE_DIR/../../cross-compile-setup.sh"
-
-cmake -D CMAKE_BUILD_TYPE:STRING=RELEASE \
+mkdir build
+cd build
+cmake .. \
+      -D CMAKE_BUILD_TYPE:STRING=RELEASE \
       -D CMAKE_INSTALL_PREFIX:PATH=$PREFIX \
       -D CMAKE_CXX_STANDARD:STRING=17 \
       -D BUILD_PARALLEL_EXPLICIT_SOLVER=ON \
       -D BUILD_IMPLICIT_SOLVER=ON \
       -D BUILD_ELEMENTS=OFF \
-      -D DISTRIBUTION=True \
+      -D DISTRIBUTION=On \
       $CMAKE_ARGS \
-      $SRC_DIR \
       -D CMAKE_CXX_FLAGS="$PATCHED_CXXFLAGS -fopenmp" \
       -D MPI_C_COMPILER="$BUILD_PREFIX/bin/mpicc" \
       -D MPI_CXX_COMPILER="$BUILD_PREFIX/bin/mpicxx" \

--- a/.conda/fierro/cpu/meta.yaml
+++ b/.conda/fierro/cpu/meta.yaml
@@ -1,5 +1,9 @@
 {% set version = "1.0.0" %}
-{% set compiler_version = "10.4.0" %}
+{% set linux_compiler_version = "10.4.0" %}
+{% set macos_compiler_version = "12" %}
+# We need the same MPI version in build + host. 
+# So we have to specify it, unfortunately
+{% set mpi_version = "4.1" %}
 
 package:
   name: fierro-cpu
@@ -10,26 +14,26 @@ source:
   git_depth: 1
 
 build:
-  number: 1
+  number: 2
   script_env:
     - PLATFORM={{ target_platform }}
 
 requirements:
   build:
     - cmake >=3.17.0
-    - {{ compiler('c') }} ={{ compiler_version }}
-    - {{ compiler('cxx') }} ={{ compiler_version }}
-    - openmpi
+    - {{ compiler('c') }}={{ linux_compiler_version }} # [linux]
+    - {{ compiler('c') }}={{ macos_compiler_version }} # [osx]
+    - {{ compiler('cxx') }}={{ linux_compiler_version }} # [linux]
+    - {{ compiler('cxx') }}={{ macos_compiler_version }} # [osx]
+    - openmpi={{ mpi_version }}
   host:
-    - _openmp_mutex
-    - openmpi
+    - openmp
+    - openmpi={{ mpi_version }}
     - fierro-trilinos-cpu
     - elements
   run:
     - fierro-trilinos-cpu
     - mpi
-
-#TODO: Add tests
 
 about:
   home: https://github.com/lanl/Fierro

--- a/.conda/fierro/cpu/meta.yaml
+++ b/.conda/fierro/cpu/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - {{ compiler('cxx') }}={{ macos_compiler_version }} # [osx]
     - openmpi={{ mpi_version }}
   host:
-    - openmp      # [linux]
-    - llvm-openmp # [osx]
+    - _openmp_mutex # [linux]
+    - llvm-openmp   # [osx]
     - openmpi={{ mpi_version }}
     - fierro-trilinos-cpu
     - elements

--- a/.conda/fierro/cpu/meta.yaml
+++ b/.conda/fierro/cpu/meta.yaml
@@ -27,7 +27,8 @@ requirements:
     - {{ compiler('cxx') }}={{ macos_compiler_version }} # [osx]
     - openmpi={{ mpi_version }}
   host:
-    - openmp
+    - openmp      # [linux]
+    - llvm-openmp # [osx]
     - openmpi={{ mpi_version }}
     - fierro-trilinos-cpu
     - elements

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -60,3 +60,15 @@ The recipe_dir is the folder containing the conda build `meta.yaml` file as well
 
 The second is the package specific action that triggers off of package specific source code changes and invokes `build-conda-package` with the correct package recipe location and additional build variants. In the case of our source-in-repo packages, these trigger of off relevant source code changes. For other dependencies, where the source is not contained in the repo, we configure the actions for manual dispatch.
 
+
+# Debugging
+Complex github actions can be very annoying to debug for two reasons:
+1. The feedback loop is long/slow. Pushing changes to github and waiting for a runner to initialize can easily add ~5 mins to your feedback loop.
+2. You don't have easy access to the runtime environment. Github automatically will unmount the docker image and be on its way if an action fails.
+
+We have some tools to deal with this, though. If you can run docker (not WSL1), you can use [act](https://github.com/nektos/act) to execute github actions locally. This is **much** faster for debugging things like action syntax. We also have a tool to deal with #2 that I have built into the `build-conda-package` action. We have a `debug` option that enables a special workflow step after the package building step. If the debug flag is set, we make use of the [tmate](https://github.com/mxschmitt/action-tmate) github action to create a temporary ssh host and wait for 30 minutes. On the github Actions page you can inspect the log and find something like:
+```
+SSH: ssh bJV7VnwDn5NUzBn6fGrkJYQg9@nyc1.tmate.io
+```
+
+If you are the user that triggered the action, you can ssh into the docker container that was runing your build action. From there you can continue debugging.

--- a/.github/workflows/publish-fierro-cpu.yaml
+++ b/.github/workflows/publish-fierro-cpu.yaml
@@ -1,0 +1,15 @@
+name: 'Publish Fierro-CPU'
+
+on: 
+  push:
+    paths:
+      - .conda/fierro/cpu/**
+      - .github/workflows/publish-fierro-cpu.yaml
+  workflow_dispatch:
+
+jobs:
+  publish:
+    uses: ./.github/workflows/build-conda-package.yaml
+    with:
+      recipe_dir: .conda/fierro/cpu
+    secrets: inherit

--- a/src/CLI/README.md
+++ b/src/CLI/README.md
@@ -1,0 +1,168 @@
+# Fiero Command Line Interface
+This CLI package is a Fierro command line interface that is intended to act as a consolidated front-end for our Fierro backend tools. It provides a consistent interface and framework for exposing tools to the user.
+
+## Front-End
+The front end here is built off of [argparse](https://github.com/p-ranav/argparse), which implements a language agnostic standard for simple command line interface design. It defines a syntax for programs from the command line with suitable helptext/defaults/post-processing.
+
+The Fierro-CLI implements two things: 
+1. Output directory -- A directory to run the program in. Outputs of the program will by default be put here if some other backend specific option is not specified.
+2. Subcommands -- a list of argparse "subcommands" that each represent an available backend tool.
+
+Example:
+```
+$ fierro -h
+
+Usage: fierro [--help] [--version] [--output VAR] {mesh-builder,parallel-explicit,parallel-implicit,voxelizer}
+
+Optional arguments:
+  -h, --help            shows help message and exits
+  -v, --version         prints version information and exits
+  -o, --output          output directory for the program [default: "."]
+
+Subcommands:
+  mesh-builder    Build rectangular or cylindrical mesh in 2 or 3 dimensions. Useful for setting up test problems.
+  parallel-explicit Use an explicit solution scheme to step the system.
+  parallel-implicit Use an implicit solution scheme to step the system.
+  voxelizer       Take a mesh defined by an STL and turn it into a dense voxel grid represented by a VTK structured mesh. The extent of the grid is selected by taking the minimum and maximum extent of the mesh along each dimenison. Note: Only supports binary STL mesh inputs
+```
+
+## Backends
+This Fierro-CLI package is designed to operate decoupled from backends. Each registered backend is an executable that may or may not be present in the system.
+
+### Registering Backends
+To add a new backend, you only need to do a couple of steps.
+#### 1. Implementing NewBackend.hpp
+You should start by copying one of the existing backend.hpp files and implementing your new backend. We will use `VoxelizerBackend.hpp` as an example.
+
+You should derive from `FierroBackend` and tell the base class which executable name to look for
+```c++
+#include "backend.hpp"
+struct VoxelizerBackend: public FierroBackend {
+    VoxelizerBackend() : FierroBackend("fierro-voxelizer") {
+        ...
+    }
+    ...
+};
+```
+
+Then, in the constructor, setup your argparse command
+
+```c++
+    
+struct VoxelizerBackend: public FierroBackend {
+    VoxelizerBackend() : FierroBackend("fierro-voxelizer") {
+
+        this->command = std::shared_ptr<argparse::ArgumentParser>(
+            new argparse::ArgumentParser("voxelizer") // <--- This is the name that shows up under "Subcommands:" in the CLI
+        );
+        
+        // Here you can add your arguments with their helptext.
+        this->command->add_argument("input-file")
+            .help("The binary STL file to voxelize.") 
+            .action(absolute_fp); // <--  You can also add a post-processing command. In this case we convert the input filepath to an absolute one.
+        this->command->add_argument("output-name")
+            .help("The name of the VTK structured mesh output file.");
+        this->command->add_argument("x")
+            .help("The number of voxels along the X direction (int).");
+        this->command->add_argument("y")
+            .help("The number of voxels along the Y direction (int).");
+        this->command->add_argument("z")
+            .help("The number of voxels along the Z direction (int).");
+        this->command->add_argument("use-index-space")
+            .help("Wether or not to output the VTK in index-space coordinates.");
+
+        // Add a description for your subcommand
+        this->command->add_description(
+            "Take a mesh defined by an STL and turn it into a dense voxel grid represented by a VTK structured mesh. "
+            "The extent of the grid is selected by taking the minimum and maximum extent of the mesh along each dimenison. "
+            "Note: Only supports binary STL mesh inputs."
+        );
+    }
+    ...
+};
+```
+
+Lastly you tell the CLI framework how to actually invoke the backend command. This is mostly just building a system command string and invoking it, but I suppose you could do whatever you want.
+```c++
+
+struct VoxelizerBackend: public FierroBackend {
+    ...
+    
+    /**
+     * Invoke the backend executable.
+     * Will throw an ArgumentException if the arguments aren't valid.
+     * 
+     * @return Return code of the executable.
+    */
+    int invoke() {
+        if (!exec_path.has_value())
+            throw std::runtime_error("Cannot invoke executable without absolute path.");
+        
+        auto err = this->validate_arguments();
+        if (err.has_value()) throw ArgumentException(err.value());
+        
+        std::string sys_command;
+        sys_command = this->exec_path.value().string()
+                        + " " + this->command->get("input-file")
+                        + " " + this->command->get("output-name")
+                        + " " + this->command->get("x")
+                        + " " + this->command->get("y")
+                        + " " + this->command->get("z")
+                        + " " + this->command->get("use-index-space");
+
+        return system(sys_command.c_str());
+    }
+};
+```
+
+You probably also want to add some validation to your input arguments. The voxelizer does this with a serparate function:
+
+```c++
+struct VoxelizerBackend: public FierroBackend {
+    ...
+    
+    /** 
+     * Check that the arguments of the CLI are valid and make sense.
+     * 
+     * Checks for explicit/implicit logical consistency.
+     * Checks that the mesh file is real and readable.
+     *      Does not check that it is correctly formatted.
+     * 
+     * @return An optional error. If the empty, the arguments are valid.
+     * 
+    */
+    std::optional<std::string> validate_arguments() {
+        std::string msg = "";
+        auto parser = this->command;
+
+        // Here we just check if the input file is an actual file.
+        if (!file_exists(parser->get<std::string>("input-file"))) {
+            msg = "Unable to find input file: " + parser->get<std::string>("input-file");
+        }
+        
+        if (msg.length() > 0) {
+            return std::optional(msg);
+        }
+        return {};
+    }
+    ...
+};
+```
+
+Now you have a well defined backend.
+
+
+#### 2. Plug it into the CLI framework
+Head over to main.cpp and add your backend to the list of backends:
+```c++
+std::vector<std::shared_ptr<FierroBackend>> BACKENDS {
+    std::shared_ptr<ParallelExplicit>(),
+    std::shared_ptr<ParallelImplicit>(),
+    std::shared_ptr<MeshBuilderBackend>(),
+    std::shared_ptr<VoxelizerBackend>(),
+    //std::shared_ptr<YourBackend>() <-- Add yours here
+};
+
+```
+
+Now you have everything set up, and it will automatically be picked up if its compiled and in the system.

--- a/src/CLI/src/main.cpp
+++ b/src/CLI/src/main.cpp
@@ -11,10 +11,10 @@
 #include <string>
 
 std::vector<std::shared_ptr<FierroBackend>> BACKENDS {
-    std::shared_ptr<FierroBackend>(new ParallelExplicit()),
-    std::shared_ptr<FierroBackend>(new ParallelImplicit()),
-    std::shared_ptr<FierroBackend>(new MeshBuilderBackend()),
-    std::shared_ptr<FierroBackend>(new VoxelizerBackend()),
+    std::shared_ptr<ParallelExplicit>(),
+    std::shared_ptr<ParallelImplicit>(),
+    std::shared_ptr<MeshBuilderBackend>(),
+    std::shared_ptr<VoxelizerBackend>(),
 };
 
 std::vector<std::shared_ptr<FierroBackend>> find_fierro_backends() {


### PR DESCRIPTION
## Previously
We didn't have a working anaconda package for the fierro cpu builds. It was outdated.
We also didn't have a github action for automatically building fierro-cpu

## Changes
Now we have a working conda package for fierro-cpu for both OSX and Linux (the usual CPU targets)
+ we have a github action.

I decided against tracking the source code to trigger auto-rebuilding of the packages, since I expect that we don't really want to keep fierro-cpu *that* up to date. For now I have just left you with a manual workflow dispatch trigger + triggering on build metadata change

```yaml
on: 
  push:
    paths:
      - .conda/fierro/cpu/**
      - .github/workflows/publish-fierro-cpu.yaml
  workflow_dispatch:
```


Bonus -- Added some debugging tips to the Anaconda and Github Actions READMEs

Bonus Bonus -- Added a README to the CLI. So you have clear instructions on how to use it.