### PR TITLE
Implement fixed length serialization for T[N] and array<T, N> things.

### DIFF
--- a/src/Yaml-Serializable/README.md
+++ b/src/Yaml-Serializable/README.md
@@ -264,22 +264,21 @@ IMPL_YAML_SERIALIZABLE_FOR(MyStruct, a, b, c, d)
 
 
 ### Derived Data
-YAML has much less expressive semantics than you might want for your C++ struct. It is often useful to have a post-read hook to put the data into a more useful view for consumers of the struct. For this reason, there is a `Yaml::DerivedFields` class to inherit from and a `void derive()` hook that you can implement. This function will get run after the data is loaded, but before the custom `void validate()` hook is run. The following example uses the `void derive()` hook to initialize difficult to unserializable members of a base class[^2].
+YAML has much less expressive semantics than you might want for your C++ struct. It is often useful to have a post-read hook to put the data into a more useful view for consumers of the struct. For this reason, there is a `Yaml::DerivedFields` class to inherit from and a `void derive()` hook that you can implement. This function will get run after the data is loaded, but before the custom `void validate()` hook is run. The following example uses the `void derive()` hook to initialize difficult to unserializable members of a base class.
 
 ```c++
 
 struct my_struct {
-    double array[5];
+    double* array;
 };
 
 struct MyStruct : my_struct, Yaml::DerivedFields {
     std::vector<double> array;
 
     void derive() {
-        if (array.size() != 5)
-            throw Yaml::ConfigurationException("Expected list of 5 elements", "array");
+        my_struct::array = new double[array.size()];
 
-        for (size_t i = 0; i < 5; i++)
+        for (size_t i = 0; i < array.size(); i++)
             my_struct::array[i] = array[i];
     }
 };
@@ -386,4 +385,3 @@ The difference between `apply` and `try_apply` is that `apply` will throw a runt
 
 
 [^1]: There is a slight addition to the YAML 1.0 spec to include simple lists with bracket syntax: "[1, 2, 3, ... ]".
-[^2]: Fixed size arrays (`std::array<T, N>` or `T[N]`) and raw pointers (`T*`) are not currently supported as serialization targets.

--- a/src/Yaml-Serializable/include/yaml-serializable-base.h
+++ b/src/Yaml-Serializable/include/yaml-serializable-base.h
@@ -41,10 +41,15 @@
 #define YAML_BASE_H
 
 #include "Yaml.hpp"
+#include <array>
 
 namespace Yaml {
     template<typename T> void serialize(const T& v, Yaml::Node& node);
     template<typename T> void deserialize(T& v, Yaml::Node& node, bool raw=false);
+    template<typename T, size_t N> void serialize(const T(&v)[N], Yaml::Node& node);
+    template<typename T, size_t N> void deserialize(T(&v)[N], Yaml::Node& node, bool raw=false);
+    template<typename T, size_t N> void serialize(const std::array<T, N>& v, Yaml::Node& node);
+    template<typename T, size_t N> void deserialize(std::array<T, N>& v, Yaml::Node& node, bool raw=false);
     
     template<>
     inline void deserialize<bool>(bool& v, Yaml::Node& node, bool raw) {

--- a/src/Yaml-Serializable/include/yaml-serializable.h
+++ b/src/Yaml-Serializable/include/yaml-serializable.h
@@ -101,6 +101,25 @@ namespace Yaml {
         Containers::Impl<T>::deserialize(v, node, raw);
     }
 
+    template<typename T, size_t N>
+    void serialize(const T(&v)[N], Yaml::Node& node) {
+        Containers::FixedLengthImpl<T, N>::serialize(v, node);
+    }
+
+    template<typename T, size_t N>
+    void deserialize(T(&v)[N], Yaml::Node& node, bool raw) {
+        Containers::FixedLengthImpl<T, N>::deserialize(v, node, raw);
+    }
+
+    template<typename T, size_t N>
+    void serialize(const std::array<T, N>& v, Yaml::Node& node) {
+        Containers::FixedLengthImpl<T, N>::serialize(v, node);
+    }
+
+    template<typename T, size_t N>
+    void deserialize(std::array<T, N>& v, Yaml::Node& node, bool raw) {
+        Containers::FixedLengthImpl<T, N>::deserialize(v, node, raw);
+    }
 
     /**
      * Implements direct string serialization for Yaml Serializable objects.

--- a/src/Yaml-Serializable/test/test.cpp
+++ b/src/Yaml-Serializable/test/test.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <memory>
 #include <optional>
+#include <array>
 
 template<typename T>
 bool compare_vec(std::vector<T> a, std::vector<T> b) {
@@ -632,4 +633,101 @@ TEST(YamlSerializable, TypeDiscriminatedTryApplyNoThrow) {
 
 TEST(YamlSerializable, StaticTypeName) {
     EXPECT_STREQ(std::string(Yaml::static_type_name<DerivedA>()).c_str(), "DerivedA");
+}
+
+TEST(YamlSerializable, ArrayReading) {
+    std::string input = R"(
+        - 1
+        - 2
+        - 3
+    )";
+
+    int v[3];
+    Yaml::from_string(input, v);
+
+    for (size_t i = 0; i < 3; i++)
+        EXPECT_EQ(i+1, v[i]);
+}
+
+TEST(YamlSerializable, ArrayReadWrite) {
+    int a[3];
+    std::string str = Yaml::to_string(a);
+
+    int b[3];
+    Yaml::from_string(str, b);
+
+    for (size_t i = 0; i < 3; i++)
+        EXPECT_EQ(a[i], b[i]);
+}
+
+TEST(YamlSerializable, StdArrayReading) {
+    std::string input = R"(
+        - 1
+        - 2
+        - 3
+    )";
+
+    std::array<int, 3> v;
+    Yaml::from_string(input, v);
+
+    for (size_t i = 0; i < 3; i++)
+        EXPECT_EQ(i+1, v[i]);
+}
+
+TEST(YamlSerializable, StdArrayReadWrite) {
+    std::array<int, 3> a;
+    std::string str = Yaml::to_string(a);
+
+    std::array<int, 3> b;
+    Yaml::from_string(str, b);
+
+    for (size_t i = 0; i < 3; i++)
+        EXPECT_EQ(a[i], b[i]);
+}
+
+
+TEST(YamlSerializable, ArrayReadingInvalidLength) {
+    std::string input = R"(
+        - 1
+        - 2
+    )";
+
+    int v[3];
+
+    EXPECT_THROW({
+        Yaml::from_string(input, v);
+    }, Yaml::ConfigurationException);
+}
+
+TEST(YamlSerializable, StdArrayReadingInvalidLength) {
+    std::string input = R"(
+        - 1
+        - 2
+    )";
+
+    std::array<int, 3> v;
+
+    EXPECT_THROW({
+        Yaml::from_string(input, v);
+    }, Yaml::ConfigurationException);
+}
+
+
+TEST(YamlSerializable, InvalidScalarList) {
+    std::string input = "1 2 3";
+
+    int v[3];
+    EXPECT_THROW({
+        Yaml::from_string(input, v);
+    }, Yaml::ConfigurationException);
+}
+
+TEST(YamlSerializable, ValidScalarList) {
+    std::string input = "[1, 2, 3]";
+
+    int v[3];
+    Yaml::from_string(input, v);
+
+    for (size_t i = 0; i < 3; i++)
+        EXPECT_EQ(i+1, v[i]);
 }


### PR DESCRIPTION
It was really bugging me that we didn't have usable, native support for fixed length arrays in our auto-serializer. 

# Changes
Now you can serialize things like `double v[5]` and `std::array<double, 5> v`.
+ The docs are changed to reflect that.

This is great, since it makes it far more likely that you can directly serialize to a GPU serializable type, removing the need to have a special serialization class layer.

Also, you no longer have to use a vector with bespoke length validation to emulate a fixed length array. if you really have a fixed length array, you can just use `T v[N]` and serialize to that + length validation for free.