### PR TITLE
Uncrustify Explicit-Lagrange-Kokkos Files

### DIFF
--- a/docs/formatting/README.md
+++ b/docs/formatting/README.md
@@ -1,0 +1,7 @@
+# Formatting
+
+Fierro uses [Uncrustify](https://github.com/uncrustify/uncrustify/tree/master) to standardize the syle and clean up code. Currently, code formatting is not
+strictly enforced, but that is the current direction. The Uncrustify [GitHub](https://github.com/uncrustify/uncrustify/tree/master) page has extensive
+documentation for building and running Uncrustify. The supplied uncrustify.cfg file should be used when formatting with Uncrustify.
+
+A future goal is to automate this process during a push.

--- a/docs/formatting/uncrustify.cfg
+++ b/docs/formatting/uncrustify.cfg
@@ -1,0 +1,447 @@
+# Control what to do with the UTF-8 BOM (recommend 'remove')
+utf8_bom                        = remove   # ignore/add/remove/force
+
+# The number of columns to indent per level.
+# Usually 2, 3, 4, or 8. Default=8
+indent_columns                  = 4        # number
+
+# The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
+# For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
+indent_continue                 = 0        # number
+
+# How to use tabs when indenting code
+# 0=spaces only
+# 1=indent with tabs to brace level, align with spaces (default)
+# 2=indent and align with tabs, using spaces when not on a tabstop
+indent_with_tabs                = 0        # number
+
+# Indent the code after an access specifier by one level.
+# If set, this option forces 'indent_access_spec=0'
+indent_access_spec_body         = true     # false/true
+
+# True:  indent continued function call parameters one indent level
+# False: align parameters under the open paren
+indent_func_call_param          = true     # false/true
+
+# Same as indent_func_call_param, but for function defs
+indent_func_def_param           = false    # false/true
+
+# Same as indent_func_call_param, but for function protos
+indent_func_proto_param         = false    # false/true
+
+# Same as indent_func_call_param, but for class declarations
+indent_func_class_param         = false    # false/true
+
+# Same as indent_func_call_param, but for class variable constructors
+indent_func_ctor_var_param      = false    # false/true
+
+# Same as indent_func_call_param, but for templates
+indent_template_param           = false    # false/true
+
+# Double the indent for indent_func_xxx_param options
+indent_func_param_double        = false    # false/true
+
+# True:  indent_func_call_param will be used (default)
+# False: indent_func_call_param will NOT be used
+use_indent_func_call_param      = false    # false/true
+
+# Add or remove newline at the end of the file
+nl_end_of_file                  = add      # ignore/add/remove/force
+
+# The maximum consecutive newlines (3 = 2 blank lines)
+nl_max                          = 2        # number
+
+# Whether to remove blank lines after '{'
+eat_blanks_after_open_brace     = true     # false/true
+
+# Whether to remove blank lines before '}'
+eat_blanks_before_close_brace   = true     # false/true
+
+# Add or remove braces on single-line 'for' statement
+mod_full_brace_for              = force      # ignore/add/remove/force
+
+# Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
+mod_full_brace_if               = force      # ignore/add/remove/force
+
+# Add or remove braces on single-line 'while' statement
+mod_full_brace_while            = force      # ignore/add/remove/force
+
+# Whether to remove superfluous semicolons
+mod_remove_extra_semicolon      = false    # false/true
+
+# Whether to sort consecutive single-line '#include' statements (C/C++) and
+# '#import' statements (Objective-C). Be aware that this has the potential to
+# break your code if your includes/imports have ordering dependencies.
+# mod_sort_include                = true    # true/false
+
+# Indeed, the mode above actually break the code
+# Need to work on the code
+
+
+# Add or remove newline between 'enum' and '{'
+nl_enum_brace                   = force      # ignore/add/remove/force
+
+# Newline between namespace and {.
+nl_namespace_brace              = force   # ignore/add/remove/force
+
+# Add or remove newline between 'class' and '{'.
+nl_class_brace                  = force   # ignore/add/remove/force
+
+# Add or remove newline between 'struct and '{'
+nl_struct_brace                 = force      # ignore/add/remove/force
+
+# Add or remove newline between 'union' and '{'
+nl_union_brace                  = force      # ignore/add/remove/force
+
+# Add or remove newline between 'if' and '{'
+nl_if_brace                     = force      # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'else'
+nl_brace_else                   = force      # ignore/add/remove/force
+
+# Add or remove newline between 'else' and '{'
+nl_else_brace                   = force      # ignore/add/remove/force
+
+# Add or remove newline between 'else' and 'if'
+nl_else_if                      = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'finally'
+nl_brace_finally                = force      # ignore/add/remove/force
+
+# Add or remove newline between 'finally' and '{'
+nl_finally_brace                = force      # ignore/add/remove/force
+
+# Add or remove newline between 'try' and '{'
+nl_try_brace                    = force      # ignore/add/remove/force
+
+# Add or remove newline between 'for' and '{'
+nl_for_brace                    = force      # ignore/add/remove/force
+
+# Add or remove newline between 'catch' and '{'
+nl_catch_brace                  = force      # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'catch'
+nl_brace_catch                  = force      # ignore/add/remove/force
+
+# Add or remove newline between 'do' and '{'
+nl_do_brace                     = force      # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'while' of 'do' statement
+nl_brace_while                  = force      # ignore/add/remove/force
+
+# Add or remove newline between 'switch' and '{'
+nl_switch_brace                 = force      # ignore/add/remove/force
+
+# Add or remove newline between function signature and '{'
+nl_fdef_brace                   = force      # ignore/add/remove/force
+
+# Don't split one-line braced statements inside a class xx { } body
+nl_class_leave_one_liners       = true     # false/true
+
+# Don't split one-line C++11 lambdas - '[]() { return 0; }'
+nl_cpp_lambda_leave_one_liners  = true     # false/true
+
+# The number of newlines after '}' of a multi-line function body.
+nl_after_func_body              = 2        # unsigned number
+
+# Add or remove newline between return type and function name in a function
+# definition.
+nl_func_type_name               = force   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a prototype.
+nl_func_proto_type_name         = remove   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name inside a class
+# definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name
+# is used instead.
+nl_func_type_name_class         = remove   # ignore/add/remove/force
+
+# Add or remove space around compare operator '<', '>', '==', etc
+sp_compare                      = force      # ignore/add/remove/force
+
+# Add or remove space around non-assignment symbolic operators ('+', '/', '%',
+# '<<', and so forth).
+sp_arith                        = force   # ignore/add/remove/force
+
+# Add or remove space around boolean operators '&&' and '||'.
+sp_bool                         = force   # ignore/add/remove/force
+
+# Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.
+sp_after_comma                  = force   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty '[' and ']'.
+sp_inside_square                = remove   # ignore/add/remove/force
+
+# Add or remove space before '(' of control statements ('if', 'for', 'switch',
+# 'while', etc.).
+sp_before_sparen                = force   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')' of control statements.
+sp_inside_sparen                = remove   # ignore/add/remove/force
+
+# Add or remove space after '(' of control statements.
+#
+# Overrides sp_inside_sparen.
+sp_inside_sparen_open           = remove   # ignore/add/remove/force
+
+# Add or remove space before ')' of control statements.
+#
+# Overrides sp_inside_sparen.
+sp_inside_sparen_close          = remove   # ignore/add/remove/force
+
+# Add or remove space after ')' of control statements.
+sp_after_sparen                 = remove   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of of control statements.
+sp_sparen_brace                 = force   # ignore/add/remove/force
+
+# Add or remove space before a trailing comment.
+sp_before_tr_cmt                = add   # ignore/add/remove/force/not_defined
+
+# If true, cpp lambda body will be indentedDefault=False.
+indent_cpp_lambda_body          = true    # false/true
+
+# Add or remove space around assignment operator '=', '+=', etc
+sp_assign                       = add      # ignore/add/remove/force
+
+# Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
+sp_angle_shift                  = remove   # ignore/add/remove/force
+
+# Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
+# sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift           = true     # false/true
+
+# Add or remove space inside '{' and '}'.
+sp_inside_braces                = force   # ignore/add/remove/force
+
+# Add or remove space inside enum '{' and '}'.
+sp_inside_braces_enum           = force   # ignore/add/remove/force
+
+# Add or remove space inside struct/union '{' and '}'.
+sp_inside_braces_struct         = force   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')'.
+sp_inside_paren                 = remove   # ignore/add/remove/force
+
+# Add or remove space inside empty function '()'.
+sp_inside_fparens               = remove   # ignore/add/remove/force
+
+# Add or remove space inside function '(' and ')'.
+sp_inside_fparen                = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function definition.
+sp_func_def_paren               = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function definition
+# without parameters.
+sp_func_def_paren_empty         = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function calls.
+sp_func_call_paren              = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function calls without
+# parameters. If set to 'ignore' (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty        = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function declaration.
+sp_func_proto_paren             = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function declaration
+# without parameters.
+sp_func_proto_paren_empty       = remove   # ignore/add/remove/force
+
+# Control the space after the opening of a C++ comment '// A' vs '//A'.
+sp_cmt_cpp_start                = add   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{'.
+sp_paren_brace                  = force   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of function.
+sp_fparen_brace                 = force   # ignore/add/remove/force
+
+# Add or remove space between ')' and a qualifier such as 'const'.
+# Note: this option is currently not avaialbe in uncrustify 0.64
+# sp_paren_qualifier              = force   # ignore/add/remove/force
+
+# Add or remove space between ')' and 'noexcept'.
+# Note: this option is currently not avaialbe in uncrustify 0.64
+#sp_paren_noexcept               = force   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*'.
+sp_before_ptr_star              = remove   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*' that isn't followed by a
+# variable name. If set to 'ignore', sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star      = remove   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a word.
+sp_after_ptr_star               = force   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by a function
+# prototype or function definition.
+sp_after_ptr_star_func          = force   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by an open
+# parenthesis, as in 'void* (*)().
+sp_ptr_star_paren               = force   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&'.
+sp_before_byref                 = remove   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&' that isn't followed by a
+# variable name. If set to 'ignore', sp_before_byref is used instead.
+sp_before_unnamed_byref         = remove   # ignore/add/remove/force
+
+# Add or remove space after reference sign '&', if followed by a word.
+sp_after_byref                  = force   # ignore/add/remove/force
+
+# Add or remove space after a reference sign '&', if followed by a function
+# prototype or function definition.
+sp_after_byref_func             = force   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&', if followed by a function
+# prototype or function definition.
+sp_before_byref_func            = remove   # ignore/add/remove/force
+
+# Add or remove space between 'template' and '<'.
+# If set to ignore, sp_before_angle is used.
+sp_template_angle               = remove   # ignore/add/remove/force
+
+# Add or remove space before '<'.
+sp_before_angle                 = remove   # ignore/add/remove/force
+
+# Add or remove space inside '<' and '>'.
+sp_inside_angle                 = remove   # ignore/add/remove/force
+
+# Add or remove space inside '<>'.
+# Note: this option is currently not avaialbe in uncrustify 0.64
+#sp_inside_angle_empty           = remove   # ignore/add/remove/force
+
+# Add or remove space between '>' and ':'.
+# Note: this option is currently not avaialbe in uncrustify 0.64
+#sp_angle_colon                  = remove   # ignore/add/remove/force
+
+# Add or remove space after '<>'.
+sp_after_angle                  = remove   # ignore/add/remove/force
+
+# Add or remove space between '>' and '(' as found in 'new List<byte>(foo);'.
+sp_angle_paren                  = remove   # ignore/add/remove/force
+
+# Add or remove space between '>' and '()' as found in 'new List<byte>();'.
+sp_angle_paren_empty            = remove   # ignore/add/remove/force
+
+# Add or remove space between '>' and a word as in 'List<byte> m;' or
+# 'template <typename T> static ...'.
+sp_angle_word                   = force   # ignore/add/remove/force
+
+# Add or remove space before '[' (except '[]').
+sp_before_square                = remove   # ignore/add/remove/force
+
+# Add or remove space before '[]'.
+sp_before_squares               = remove   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty '[' and ']'.
+sp_inside_square                = remove   # ignore/add/remove/force
+
+# The span for aligning variable definitions.
+#
+# 0 = Don't align (default).
+align_var_def_span              = 1        # unsigned number
+
+# How to align the '&' in variable definitions.
+#  0=Part of the type
+#  1=Part of the variable
+#  2=Dangling
+align_var_def_amp_style         = 0        # number
+
+# The span for aligning comments that end lines.
+#
+# 0 = Don't align (default).
+align_right_cmt_span            = 0        # unsigned number
+
+# The span for aligning class (0=don't align)
+align_var_class_span            = 1        # number
+
+# The threshold for aligning class member definitions.
+# Use a negative number for absolute thresholds.
+#
+# 0 = No limit (default).
+align_var_class_thresh          = 6        # number
+
+# Whether to align variable definitions in prototypes and functions.
+align_func_params               = true    # true/false
+
+# The span for aligning on '=' in assignments.
+#
+# 0 = Don't align (default).
+align_assign_span               = 1        # unsigned number
+
+# The threshold for aligning on '=' in assignments.
+# Use a negative number for absolute thresholds.
+#
+# 0 = No limit (default).
+align_assign_thresh             = 6        # number
+
+# Whether to align lines that start with '<<' with previous '<<'.
+#
+# Default: true
+align_left_shift                = true     # true/false
+
+# Try to limit code width to N number of columns
+code_width                      = 200      # number
+
+#
+# Positioning options
+#
+
+# The position of arithmetic operators in wrapped expressions.
+pos_arith                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of assignment in wrapped expressions. Do not affect '='
+# followed by '{'.
+pos_assign                      = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of Boolean operators in wrapped expressions.
+pos_bool                        = lead     # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of comparison operators in wrapped expressions.
+pos_compare                     = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of conditional operators, as in the '?' and ':' of
+# 'expr ? stmt : stmt', in wrapped expressions.
+pos_conditional                 = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in wrapped expressions.
+pos_comma                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in enum entries.
+pos_enum_comma                  = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in the base class list if there is more than one
+# line. Affects nl_class_init_args.
+pos_class_comma                 = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of the comma in the constructor initialization list.
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
+pos_constr_comma                = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of trailing/leading class colon, between class and base class
+# list. Affects nl_class_colon.
+pos_class_colon                 = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of colons between constructor and member initialization.
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
+pos_constr_colon                = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# If false, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
+# Default=True.
+# Cound interfere with license header
+cmt_indent_multi                = false    # false/true
+
+# The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+# cmt_insert_file_header          = "../HeaderForSources.txt"
+
+# If a namespace body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_namespace_closebrace_comment = 1        # number

--- a/docs/formatting/uncrustify.cfg
+++ b/docs/formatting/uncrustify.cfg
@@ -146,7 +146,7 @@ nl_after_func_body              = 2        # unsigned number
 
 # Add or remove newline between return type and function name in a function
 # definition.
-nl_func_type_name               = force   # ignore/add/remove/force
+nl_func_type_name               = remove   # ignore/add/remove/force
 
 # Add or remove newline between return type and function name in a prototype.
 nl_func_proto_type_name         = remove   # ignore/add/remove/force

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/boundary.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/boundary.cpp
@@ -1,82 +1,71 @@
 // -------------------------------------------------------
 // This function applys the boundary condition
 // to points on a list of patches created at setup
-//--------------------------------------------------------
+// --------------------------------------------------------
 
 #include "mesh.h"
 #include "state.h"
 
-
-void boundary_velocity(const mesh_t &mesh,
-                       const CArrayKokkos <boundary_t> &boundary,
-                       DViewCArrayKokkos <double> &node_vel,
-                       const double time_value){
-
-    
+void
+boundary_velocity(const mesh_t&                   mesh,
+                  const CArrayKokkos<boundary_t>& boundary,
+                  DViewCArrayKokkos<double>&      node_vel,
+                  const double                    time_value)
+{
     // Loop over boundary sets
-    for (size_t bdy_set=0; bdy_set<mesh.num_bdy_sets; bdy_set++){
-        
+    for (size_t bdy_set = 0; bdy_set < mesh.num_bdy_sets; bdy_set++)
+    {
         // Loop over boundary nodes in a boundary set
         FOR_ALL(bdy_node_lid, 0, mesh.num_bdy_nodes_in_set.host(bdy_set), {
-                
             // reflected (boundary array is on the device)
-            if (boundary(bdy_set).hydro_bc == bdy::reflected){
-            
+            if (boundary(bdy_set).hydro_bc == bdy::reflected)
+            {
                 // directions with hydro_bc:
                 // x_plane  = 0,
                 // y_plane  = 1,
                 // z_plane  = 2,
                 size_t direction = boundary(bdy_set).surface;
-                
+
                 size_t bdy_node_gid = mesh.bdy_nodes_in_set(bdy_set, bdy_node_lid);
-                    
+
                 // Set velocity to zero in that directdion
                 node_vel(1, bdy_node_gid, direction) = 0.0;
-                        
             }
-            else if (boundary(bdy_set).hydro_bc == bdy::fixed){
-                
-                
+            else if (boundary(bdy_set).hydro_bc == bdy::fixed)
+            {
                 size_t bdy_node_gid = mesh.bdy_nodes_in_set(bdy_set, bdy_node_lid);
-                
-                for(size_t dim=0; dim<mesh.num_dims; dim++){
+
+                for (size_t dim = 0; dim < mesh.num_dims; dim++)
+                {
                     // Set velocity to zero
                     node_vel(1, bdy_node_gid, dim) = 0.0;
                 }
-                
-            }// end if
-            else if (boundary(bdy_set).hydro_bc == bdy::velocity){
-                
-                
+            } // end if
+            else if (boundary(bdy_set).hydro_bc == bdy::velocity)
+            {
                 size_t bdy_node_gid = mesh.bdy_nodes_in_set(bdy_set, bdy_node_lid);
-                
-                
+
                 // directions with hydro_bc:
                 // x_plane  = 0,
                 // y_plane  = 1,
                 // z_plane  = 2,
                 size_t direction = boundary(bdy_set).surface;
-                
+
                 // Set velocity to that directdion to specified value
                 // if t_end > time > t_start
                 // v(t) = v0 exp(-v1*(time - time_start) )
-                if (time_value >= boundary(bdy_set).hydro_bc_vel_t_start &&
-                    time_value <= boundary(bdy_set).hydro_bc_vel_t_end){
-                    
+                if (time_value >= boundary(bdy_set).hydro_bc_vel_t_start
+                    && time_value <= boundary(bdy_set).hydro_bc_vel_t_end)
+                {
                     double time_delta = time_value - boundary(bdy_set).hydro_bc_vel_t_start;
-                    
+
                     node_vel(1, bdy_node_gid, direction) =
                         boundary(bdy_set).hydro_bc_vel_0 *
-                        exp(-boundary(bdy_set).hydro_bc_vel_1 * time_delta );
-                    
+                        exp(-boundary(bdy_set).hydro_bc_vel_1 * time_delta);
                 } // end if on time
-                
-            }// end if
-            
-                
+            } // end if
         }); // end for bdy_node_lid
-	    
     } // end for bdy_set
-    
+
     return;
 } // end boundary_velocity function

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/boundary.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/boundary.cpp
@@ -6,6 +6,17 @@
 #include "mesh.h"
 #include "state.h"
 
+/**
+ * \brief Apply velocity boundary conditions
+ *
+ * This function loops over all boundary nodes and applies boundary conditions
+ * depending on the definition of boundary set.
+ *
+ * \param mesh The mesh that boundary conditions are applied to
+ * \param boundary The type of boundary condition being applied
+ * \param node_vel A view into the nodal velocity
+ * \param time_value Current simulation time, uesd to apply transient boundary conditions
+ */
 void boundary_velocity(const mesh_t&                   mesh,
                        const CArrayKokkos<boundary_t>& boundary,
                        DViewCArrayKokkos<double>&      node_vel,

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/boundary.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/boundary.cpp
@@ -6,11 +6,10 @@
 #include "mesh.h"
 #include "state.h"
 
-void
-boundary_velocity(const mesh_t&                   mesh,
-                  const CArrayKokkos<boundary_t>& boundary,
-                  DViewCArrayKokkos<double>&      node_vel,
-                  const double                    time_value)
+void boundary_velocity(const mesh_t&                   mesh,
+                       const CArrayKokkos<boundary_t>& boundary,
+                       DViewCArrayKokkos<double>&      node_vel,
+                       const double                    time_value)
 {
     // Loop over boundary sets
     for (size_t bdy_set = 0; bdy_set < mesh.num_bdy_sets; bdy_set++)

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/driver.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/driver.cpp
@@ -1,25 +1,19 @@
 // -----------------------------------------------------------------------------
 // This is the main function
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include <stdio.h>
 #include <iostream>
 #include <cmath>
 #include <sys/stat.h>
 #include <ctime>
 
-
 #include "mesh.h"
 #include "state.h"
 #include "matar.h"
 
-
-
-
-//==============================================================================
+// ==============================================================================
 //   Variables, setting default inputs
-//==============================================================================
-
-
+// ==============================================================================
 
 // --- num vars ----
 size_t num_dims = 3;
@@ -30,48 +24,43 @@ size_t num_state_vars;
 size_t num_fills;
 size_t num_bcs;
 
-
 // --- Graphics output variables ---
-size_t graphics_id = 0;
+size_t graphics_id       = 0;
 size_t graphics_cyc_ival = 50;
 
-CArray <double> graphics_times(2000);
-double graphics_dt_ival = 1.0e8;
-double graphics_time = graphics_dt_ival;  // the times for writing graphics dump
-
+CArray<double> graphics_times(2000);
+double         graphics_dt_ival = 1.0e8;
+double         graphics_time    = graphics_dt_ival; // the times for writing graphics dump
 
 // --- Time and cycling variables ---
 double time_value = 0.0;
 double time_final = 1.e16;
-double dt = 1.e-8;
-double dt_max = 1.0e-2;
-double dt_min = 1.0e-8;
-double dt_cfl = 0.4;
+double dt       = 1.e-8;
+double dt_max   = 1.0e-2;
+double dt_min   = 1.0e-8;
+double dt_cfl   = 0.4;
 double dt_start = 1.0e-8;
 
 size_t rk_num_stages = 2;
-size_t rk_num_bins = 2;
+size_t rk_num_bins   = 2;
 
-size_t cycle = 0;
+size_t cycle      = 0;
 size_t cycle_stop = 1000000000;
 
-
 // --- Precision variables ---
-double fuzz = 1.0e-16;  // machine precision
-double tiny = 1.0e-12;  // very very small (between real_t and single)
-double small= 1.0e-8;   // single precision
+double fuzz  = 1.0e-16; // machine precision
+double tiny  = 1.0e-12; // very very small (between real_t and single)
+double small = 1.0e-8;   // single precision
 
-
-
-
-//==============================================================================
+// ==============================================================================
 //    main
-//==============================================================================
-int main(int argc, char *argv[]){
-    
-    
+// ==============================================================================
+int
+main(int argc, char* argv[])
+{
     // check to see of a mesh was supplied when running the code
-    if (argc == 1) {
+    if (argc == 1)
+    {
         std::cout << "\n\n**********************************\n\n";
         std::cout << " ERROR:\n";
         std::cout << " Please supply a mesh \n";
@@ -80,35 +69,30 @@ int main(int argc, char *argv[]){
         std::exit(EXIT_FAILURE);
     } // end if
 
-
     printf("Starting Lagrangian SGH code\n");
-
 
     // The kokkos scope
     Kokkos::initialize();
     {
-     
         // ---------------------------------------------------------------------
         //    state data type declarations
         // ---------------------------------------------------------------------
-        node_t  node;
-        elem_t  elem;
-        corner_t  corner;
-        CArrayKokkos <material_t> material;
-        CArrayKokkos <double> state_vars; // array to hold init model variables
-        
-        
+        node_t                   node;
+        elem_t                   elem;
+        corner_t                 corner;
+        CArrayKokkos<material_t> material;
+        CArrayKokkos<double>     state_vars; // array to hold init model variables
+
         // ---------------------------------------------------------------------
         //    mesh data type declarations
         // ---------------------------------------------------------------------
-        mesh_t mesh;
-        CArrayKokkos <mat_fill_t> mat_fill;
-        CArrayKokkos <boundary_t> boundary;
-        
+        mesh_t                   mesh;
+        CArrayKokkos<mat_fill_t> mat_fill;
+        CArrayKokkos<boundary_t> boundary;
 
         // ---------------------------------------------------------------------
         //    read the input file
-        // ---------------------------------------------------------------------  
+        // ---------------------------------------------------------------------
         input(material,
               mat_fill,
               boundary,
@@ -127,117 +111,106 @@ int main(int argc, char *argv[]){
               graphics_cyc_ival,
               cycle_stop,
               rk_num_stages
-              );
-        
-
-
+            );
 
         // ---------------------------------------------------------------------
         //    read in supplied mesh
-        // --------------------------------------------------------------------- 
+        // ---------------------------------------------------------------------
         read_mesh_ensight(argv[1], mesh, node, elem, corner, num_dims, rk_num_bins);
         mesh.build_corner_connectivity();
         mesh.build_elem_elem_connectivity();
         mesh.build_patch_connectivity();
         mesh.build_node_node_connectivity();
-        
-        
+
         // ---------------------------------------------------------------------
         //    allocate memory
         // ---------------------------------------------------------------------
 
         // shorthand names
-        const size_t num_nodes = mesh.num_nodes;
-        const size_t num_elems = mesh.num_elems;
+        const size_t num_nodes   = mesh.num_nodes;
+        const size_t num_elems   = mesh.num_elems;
         const size_t num_corners = mesh.num_corners;
 
-        
         // allocate elem_statev
-        elem.statev = CArray <double> (num_elems, num_state_vars);
+        elem.statev = CArray<double>(num_elems, num_state_vars);
 
         // --- make dual views of data on CPU and GPU ---
         //  Notes:
-        //     Instead of using a struct of dual types like the mesh type, 
-        //     individual dual views will be made for all the state 
-        //     variables.  The motivation is to reduce memory movement 
-        //     when passing state into a function.  Passing a struct by 
-        //     reference will copy the meta data and pointers for the 
-        //     variables held inside the struct.  Since all the mesh 
-        //     variables are typically used by most functions, a single 
-        //     mesh struct or passing the arrays will be roughly equivalent 
+        //     Instead of using a struct of dual types like the mesh type,
+        //     individual dual views will be made for all the state
+        //     variables.  The motivation is to reduce memory movement
+        //     when passing state into a function.  Passing a struct by
+        //     reference will copy the meta data and pointers for the
+        //     variables held inside the struct.  Since all the mesh
+        //     variables are typically used by most functions, a single
+        //     mesh struct or passing the arrays will be roughly equivalent
         //     for memory movement.
 
-        
         // create Dual Views of the individual node struct variables
-        DViewCArrayKokkos <double> node_coords(&node.coords(0,0,0),
-                                               rk_num_bins,
-                                               num_nodes,
+        DViewCArrayKokkos<double> node_coords(&node.coords(0, 0, 0),
+                                              rk_num_bins,
+                                              num_nodes,
+                                              num_dims);
+
+        DViewCArrayKokkos<double> node_vel(&node.vel(0, 0, 0),
+                                           rk_num_bins,
+                                           num_nodes,
+                                           num_dims);
+
+        DViewCArrayKokkos<double> node_mass(&node.mass(0),
+                                            num_nodes);
+
+        // create Dual Views of the individual elem struct variables
+        DViewCArrayKokkos<double> elem_den(&elem.den(0),
+                                           num_elems);
+
+        DViewCArrayKokkos<double> elem_pres(&elem.pres(0),
+                                            num_elems);
+
+        DViewCArrayKokkos<double> elem_stress(&elem.stress(0, 0, 0, 0),
+                                              rk_num_bins,
+                                              num_elems,
+                                              3,
+                                              3);  // always 3D even in 2D-RZ
+
+        DViewCArrayKokkos<double> elem_sspd(&elem.sspd(0),
+                                            num_elems);
+
+        DViewCArrayKokkos<double> elem_sie(&elem.sie(0, 0),
+                                           rk_num_bins,
+                                           num_elems);
+
+        DViewCArrayKokkos<double> elem_vol(&elem.vol(0),
+                                           num_elems);
+
+        DViewCArrayKokkos<double> elem_div(&elem.div(0),
+                                           num_elems);
+
+        DViewCArrayKokkos<double> elem_mass(&elem.mass(0),
+                                            num_elems);
+
+        DViewCArrayKokkos<size_t> elem_mat_id(&elem.mat_id(0),
+                                              num_elems);
+
+        DViewCArrayKokkos<double> elem_statev(&elem.statev(0, 0),
+                                              num_elems,
+                                              num_state_vars);
+
+        // create Dual Views of the corner struct variables
+        DViewCArrayKokkos<double> corner_force(&corner.force(0, 0),
+                                               num_corners,
                                                num_dims);
 
-        DViewCArrayKokkos <double> node_vel(&node.vel(0,0,0),
-                                            rk_num_bins,
-                                            num_nodes,
-                                            num_dims);
+        DViewCArrayKokkos<double> corner_mass(&corner.mass(0),
+                                              num_corners);
 
-        DViewCArrayKokkos <double> node_mass(&node.mass(0),
-                                             num_nodes);
-        
-        
-        // create Dual Views of the individual elem struct variables
-        DViewCArrayKokkos <double> elem_den(&elem.den(0),
-                                            num_elems);
-
-        DViewCArrayKokkos <double> elem_pres(&elem.pres(0),
-                                             num_elems);
-
-        DViewCArrayKokkos <double> elem_stress(&elem.stress(0,0,0,0),
-                                               rk_num_bins,
-                                               num_elems,
-                                               3,
-                                               3); // always 3D even in 2D-RZ
-
-        DViewCArrayKokkos <double> elem_sspd(&elem.sspd(0),
-                                             num_elems);
-
-        DViewCArrayKokkos <double> elem_sie(&elem.sie(0,0),
-                                            rk_num_bins,
-                                            num_elems);
-
-        DViewCArrayKokkos <double> elem_vol(&elem.vol(0),
-                                            num_elems);
-        
-        DViewCArrayKokkos <double> elem_div(&elem.div(0),
-                                            num_elems);
-        
-
-        DViewCArrayKokkos <double> elem_mass(&elem.mass(0),
-                                             num_elems);
-
-        DViewCArrayKokkos <size_t> elem_mat_id(&elem.mat_id(0),
-                                               num_elems);
-
-        DViewCArrayKokkos <double> elem_statev(&elem.statev(0,0),
-                                               num_elems,
-                                               num_state_vars );
-        
-        // create Dual Views of the corner struct variables
-        DViewCArrayKokkos <double> corner_force(&corner.force(0,0),
-                                                num_corners, 
-                                                num_dims);
-
-        DViewCArrayKokkos <double> corner_mass(&corner.mass(0),
-                                               num_corners);
-        
-        
         // ---------------------------------------------------------------------
         //   calculate geometry
         // ---------------------------------------------------------------------
         node_coords.update_device();
         Kokkos::fence();
-        
-        
-        get_vol(elem_vol, node_coords, mesh);
 
+        get_vol(elem_vol, node_coords, mesh);
 
         // ---------------------------------------------------------------------
         //   setup the IC's and BC's
@@ -265,14 +238,13 @@ int main(int argc, char *argv[]){
               num_bcs,
               num_materials,
               num_state_vars);
-        
+
         // intialize time, time_step, and cycles
         time_value = 0.0;
         dt = dt_start;
-        graphics_id = 0;
+        graphics_id       = 0;
         graphics_times(0) = 0.0;
-        graphics_time = graphics_dt_ival;  // the times for writing graphics dump
-        
+        graphics_time     = graphics_dt_ival; // the times for writing graphics dump
 
         // ---------------------------------------------------------------------
         //   Calculate the SGH solution
@@ -312,32 +284,25 @@ int main(int argc, char *argv[]){
                   graphics_times,
                   graphics_id);
 
-
         // calculate total energy at time=t_end
-        
-        
     } // end of kokkos scope
     Kokkos::finalize();
-    
-
 
     printf("Finished\n");
 
-
     return 0;
-}// end of main function
-
+} // end of main function
 
 // for easy copy and paste to functions
-//DViewCArrayKokkos <double> node_coords,
-//DViewCArrayKokkos <double> node_vel,
-//DViewCArrayKokkos <double> node_mass,
-//DViewCArrayKokkos <double> elem_den,
-//DViewCArrayKokkos <double> elem_pres,
-//DViewCArrayKokkos <double> elem_stress,
-//DViewCArrayKokkos <double> elem_sspd, 
-//DViewCArrayKokkos <double> elem_sie,
-//DViewCArrayKokkos <double> elem_vol,
-//DViewCArrayKokkos <double> elem_mass,
-//DViewCArrayKokkos <size_t> elem_mat_id,
-//DViewCArrayKokkos <double> elem_statev
+// DViewCArrayKokkos <double> node_coords,
+// DViewCArrayKokkos <double> node_vel,
+// DViewCArrayKokkos <double> node_mass,
+// DViewCArrayKokkos <double> elem_den,
+// DViewCArrayKokkos <double> elem_pres,
+// DViewCArrayKokkos <double> elem_stress,
+// DViewCArrayKokkos <double> elem_sspd,
+// DViewCArrayKokkos <double> elem_sie,
+// DViewCArrayKokkos <double> elem_vol,
+// DViewCArrayKokkos <double> elem_mass,
+// DViewCArrayKokkos <size_t> elem_mat_id,
+// DViewCArrayKokkos <double> elem_statev

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/driver.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/driver.cpp
@@ -55,8 +55,7 @@ double small = 1.0e-8;   // single precision
 // ==============================================================================
 //    main
 // ==============================================================================
-int
-main(int argc, char* argv[])
+int main(int argc, char* argv[])
 {
     // check to see of a mesh was supplied when running the code
     if (argc == 1)

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/energy_sgh.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/energy_sgh.cpp
@@ -2,15 +2,14 @@
 #include "mesh.h"
 #include "state.h"
 
-void
-update_energy_sgh(double                           rk_alpha,
-                  double                           dt,
-                  const mesh_t&                    mesh,
-                  const DViewCArrayKokkos<double>& node_vel,
-                  const DViewCArrayKokkos<double>& node_coords,
-                  DViewCArrayKokkos<double>&       elem_sie,
-                  const DViewCArrayKokkos<double>& elem_mass,
-                  const DViewCArrayKokkos<double>& corner_force)
+void update_energy_sgh(double                           rk_alpha,
+                       double                           dt,
+                       const mesh_t&                    mesh,
+                       const DViewCArrayKokkos<double>& node_vel,
+                       const DViewCArrayKokkos<double>& node_coords,
+                       DViewCArrayKokkos<double>&       elem_sie,
+                       const DViewCArrayKokkos<double>& elem_mass,
+                       const DViewCArrayKokkos<double>& corner_force)
 {
     // loop over all the elements in the mesh
     FOR_ALL(elem_gid, 0, mesh.num_elems, {

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/energy_sgh.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/energy_sgh.cpp
@@ -1,7 +1,21 @@
-
 #include "mesh.h"
 #include "state.h"
 
+/**
+ * \brief Update specific internal energy for the SGH solver
+ *
+ * This function updates the specific internal energy of each element by 
+ * integrating the power (Force dotted into velocity) over the element.
+ *
+ * \param rk_alpha Time integration partition
+ * \param dt time increment
+ * \param mesh simulation mesh
+ * \param node_vel view into the nodal velocity memory
+ * \param node_coords view into the nodal position memory
+ * \param elem_sie view into the specific internal energy of each element
+ * \param elem_mass view into the element mass
+ * \param corner_force view into the corner forces
+ */
 void update_energy_sgh(double                           rk_alpha,
                        double                           dt,
                        const mesh_t&                    mesh,

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/energy_sgh.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/energy_sgh.cpp
@@ -2,54 +2,51 @@
 #include "mesh.h"
 #include "state.h"
 
-
-void update_energy_sgh(double rk_alpha,
-                       double dt,
-                       const mesh_t &mesh,
-                       const DViewCArrayKokkos <double> &node_vel,
-                       const DViewCArrayKokkos <double> &node_coords,
-                       DViewCArrayKokkos <double> &elem_sie,
-                       const DViewCArrayKokkos <double> &elem_mass,
-                       const DViewCArrayKokkos <double> &corner_force){
-
+void
+update_energy_sgh(double                           rk_alpha,
+                  double                           dt,
+                  const mesh_t&                    mesh,
+                  const DViewCArrayKokkos<double>& node_vel,
+                  const DViewCArrayKokkos<double>& node_coords,
+                  DViewCArrayKokkos<double>&       elem_sie,
+                  const DViewCArrayKokkos<double>& elem_mass,
+                  const DViewCArrayKokkos<double>& corner_force)
+{
     // loop over all the elements in the mesh
-    FOR_ALL (elem_gid, 0, mesh.num_elems, {
-
+    FOR_ALL(elem_gid, 0, mesh.num_elems, {
         double elem_power = 0.0;
 
         // --- tally the contribution from each corner to the element ---
 
         // Loop over the nodes in the element
-        for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++){
-            
+        for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++)
+        {
             size_t corner_lid = node_lid;
-            
+
             // Get node global id for the local node id
             size_t node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
-            
+
             // Get the corner global id for the local corner id
             size_t corner_gid = mesh.corners_in_elem(elem_gid, corner_lid);
-            
+
             double node_radius = 1;
-            if(mesh.num_dims==2){
-                node_radius = node_coords(1,node_gid,1);
+            if (mesh.num_dims == 2)
+            {
+                node_radius = node_coords(1, node_gid, 1);
             }
 
             // calculate the Power=F dot V for this corner
-            for (size_t dim=0; dim<mesh.num_dims; dim++){
-                
-                double half_vel = (node_vel(1, node_gid, dim) + node_vel(0, node_gid, dim))*0.5;
-                elem_power += corner_force(corner_gid, dim)*node_radius*half_vel;
-                
+            for (size_t dim = 0; dim < mesh.num_dims; dim++)
+            {
+                double half_vel = (node_vel(1, node_gid, dim) + node_vel(0, node_gid, dim)) * 0.5;
+                elem_power     += corner_force(corner_gid, dim) * node_radius * half_vel;
             } // end for dim
-            
         } // end for node_lid
 
         // update the specific energy
         elem_sie(1, elem_gid) = elem_sie(0, elem_gid) -
-                                rk_alpha*dt/elem_mass(elem_gid) * elem_power;
-
+                                rk_alpha * dt / elem_mass(elem_gid) * elem_power;
     }); // end parallel loop over the elements
-    
+
     return;
 } // end subroutine

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/eos.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/eos.cpp
@@ -1,47 +1,43 @@
 // -----------------------------------------------------------------------------
 // This code contains the equation of state information (constitutive relations)
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include "state.h"
-
-
-
 
 // -----------------------------------------------------------------------------
 // This is the gamma-law gas eos
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void ideal_gas(const DViewCArrayKokkos <double> &elem_pres,
-               const DViewCArrayKokkos <double> &elem_stress,
-               const size_t elem_gid,
-               const size_t mat_id,
-               const DViewCArrayKokkos <double> &elem_state_vars,
-               const DViewCArrayKokkos <double> &elem_sspd,
-               const double den,
-               const double sie){
-    
-
+void
+ideal_gas(const DViewCArrayKokkos<double>& elem_pres,
+          const DViewCArrayKokkos<double>& elem_stress,
+          const size_t                     elem_gid,
+          const size_t                     mat_id,
+          const DViewCArrayKokkos<double>& elem_state_vars,
+          const DViewCArrayKokkos<double>& elem_sspd,
+          const double                     den,
+          const double                     sie)
+{
     // statev(0) = gamma
     // statev(1) = minimum sound speed
     // statev(2) = specific heat c_v
     // statev(3) = ref temperature
     // statev(4) = ref density
     // statev(5) = ref specific internal energy
-    
-    double gamma = elem_state_vars(elem_gid,0);
-    double csmin = elem_state_vars(elem_gid,1);
-    
-    
+
+    double gamma = elem_state_vars(elem_gid, 0);
+    double csmin = elem_state_vars(elem_gid, 1);
+
     // pressure
-    elem_pres(elem_gid) = (gamma - 1.0)*sie*den;
-    
+    elem_pres(elem_gid) = (gamma - 1.0) * sie * den;
+
     // sound speed
-    elem_sspd(elem_gid) = sqrt(gamma*(gamma - 1.0)*sie);
-    
+    elem_sspd(elem_gid) = sqrt(gamma * (gamma - 1.0) * sie);
+
     // ensure soundspeed is great than min specified
-    if (elem_sspd(elem_gid) < csmin){
+    if (elem_sspd(elem_gid) < csmin)
+    {
         elem_sspd(elem_gid) = csmin;
     } // end if
 
     return;
 } // end of ideal_gas
-

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/eos.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/eos.cpp
@@ -7,15 +7,14 @@
 // This is the gamma-law gas eos
 // ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void
-ideal_gas(const DViewCArrayKokkos<double>& elem_pres,
-          const DViewCArrayKokkos<double>& elem_stress,
-          const size_t                     elem_gid,
-          const size_t                     mat_id,
-          const DViewCArrayKokkos<double>& elem_state_vars,
-          const DViewCArrayKokkos<double>& elem_sspd,
-          const double                     den,
-          const double                     sie)
+void ideal_gas(const DViewCArrayKokkos<double>& elem_pres,
+               const DViewCArrayKokkos<double>& elem_stress,
+               const size_t                     elem_gid,
+               const size_t                     mat_id,
+               const DViewCArrayKokkos<double>& elem_state_vars,
+               const DViewCArrayKokkos<double>& elem_sspd,
+               const double                     den,
+               const double                     sie)
 {
     // statev(0) = gamma
     // statev(1) = minimum sound speed

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/force_sgh.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/force_sgh.cpp
@@ -2,94 +2,83 @@
 #include "mesh.h"
 #include "state.h"
 
-
-
-
-
 // -----------------------------------------------------------------------------
 // This function calculates the corner forces and the evolves stress (hypo)
-//------------------------------------------------------------------------------
-void get_force_sgh(const CArrayKokkos <material_t> &material,
-                   const mesh_t &mesh,
-                   const DViewCArrayKokkos <double> &node_coords,
-                   const DViewCArrayKokkos <double> &node_vel,
-                   const DViewCArrayKokkos <double> &elem_den,
-                   const DViewCArrayKokkos <double> &elem_sie,
-                   const DViewCArrayKokkos <double> &elem_pres,
-                   const DViewCArrayKokkos <double> &elem_stress,
-                   const DViewCArrayKokkos <double> &elem_sspd,
-                   const DViewCArrayKokkos <double> &elem_vol,
-                   const DViewCArrayKokkos <double> &elem_div,
-                   const DViewCArrayKokkos <size_t> &elem_mat_id,
-                   DViewCArrayKokkos <double> &corner_force,
-                   const double fuzz,
-                   const double small,
-                   const DViewCArrayKokkos <double> &elem_statev,
-                   const double dt,
-                   const double rk_alpha
-                   ){
-    
-
-    
+// ------------------------------------------------------------------------------
+void
+get_force_sgh(const CArrayKokkos<material_t>&  material,
+              const mesh_t&                    mesh,
+              const DViewCArrayKokkos<double>& node_coords,
+              const DViewCArrayKokkos<double>& node_vel,
+              const DViewCArrayKokkos<double>& elem_den,
+              const DViewCArrayKokkos<double>& elem_sie,
+              const DViewCArrayKokkos<double>& elem_pres,
+              const DViewCArrayKokkos<double>& elem_stress,
+              const DViewCArrayKokkos<double>& elem_sspd,
+              const DViewCArrayKokkos<double>& elem_vol,
+              const DViewCArrayKokkos<double>& elem_div,
+              const DViewCArrayKokkos<size_t>& elem_mat_id,
+              DViewCArrayKokkos<double>&       corner_force,
+              const double                     fuzz,
+              const double                     small,
+              const DViewCArrayKokkos<double>& elem_statev,
+              const double                     dt,
+              const double                     rk_alpha
+              )
+{
     // --- calculate the forces acting on the nodes from the element ---
-    FOR_ALL (elem_gid, 0, mesh.num_elems, {
-        
+    FOR_ALL(elem_gid, 0, mesh.num_elems, {
         const size_t num_dims = 3;
         const size_t num_nodes_in_elem = 8;
-        
+
         // total Cauchy stress
         double tau_array[9];
-        
+
         // corner area normals
         double area_normal_array[24];
-        
+
         // estimate of shock direction
         double shock_dir_array[3];
-        
+
         // the sums in the Riemann solver
         double sum_array[4];
-        
+
         // corner shock impeadance x |corner area normal dot shock_dir|
         double muc_array[8];
-        
+
         // Riemann velocity
         double vel_star_array[3];
-        
+
         // velocity gradient
         double vel_grad_array[9];
-        
-        // --- Create views of arrays to aid the force calculation ---
-    
-        ViewCArrayKokkos <double> tau(tau_array, num_dims, num_dims);
-        ViewCArrayKokkos <double> area_normal(area_normal_array, num_nodes_in_elem, num_dims);
-        ViewCArrayKokkos <double> shock_dir(shock_dir_array, num_dims);
-        ViewCArrayKokkos <double> sum(sum_array, 4);
-        ViewCArrayKokkos <double> muc(muc_array, num_nodes_in_elem);
-        ViewCArrayKokkos <double> vel_star(vel_star_array, num_dims);
-        ViewCArrayKokkos <double> vel_grad(vel_grad_array, num_dims, num_dims);
 
-        
+        // --- Create views of arrays to aid the force calculation ---
+
+        ViewCArrayKokkos<double> tau(tau_array, num_dims, num_dims);
+        ViewCArrayKokkos<double> area_normal(area_normal_array, num_nodes_in_elem, num_dims);
+        ViewCArrayKokkos<double> shock_dir(shock_dir_array, num_dims);
+        ViewCArrayKokkos<double> sum(sum_array, 4);
+        ViewCArrayKokkos<double> muc(muc_array, num_nodes_in_elem);
+        ViewCArrayKokkos<double> vel_star(vel_star_array, num_dims);
+        ViewCArrayKokkos<double> vel_grad(vel_grad_array, num_dims, num_dims);
+
         // --- abviatations of variables ---
-        
+
         // element volume
         double vol = elem_vol(elem_gid);
-        
+
         // create a view of the stress_matrix
-        ViewCArrayKokkos <double> stress(&elem_stress(1, elem_gid, 0,0), 3, 3);
-        
-        
+        ViewCArrayKokkos<double> stress(&elem_stress(1, elem_gid, 0, 0), 3, 3);
+
         // cut out the node_gids for this element
-        ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
-        
-        
-        
+        ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
+
         // get the B matrix which are the OUTWARD corner area normals
         get_bmatrix(area_normal,
                     elem_gid,
                     node_coords,
                     elem_node_gids);
-    
-        
+
         // --- Calculate the velocity gradient ---
         get_velgrad(vel_grad,
                     elem_node_gids,
@@ -97,76 +86,74 @@ void get_force_sgh(const CArrayKokkos <material_t> &material,
                     area_normal,
                     vol,
                     elem_gid);
-        
-        
+
         // the -1 is for the inward surface area normal,
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-            for (size_t dim = 0; dim < num_dims; dim++){
-                area_normal(node_lid, dim) = (-1.0)*area_normal(node_lid,dim);
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
+            for (size_t dim = 0; dim < num_dims; dim++)
+            {
+                area_normal(node_lid, dim) = (-1.0) * area_normal(node_lid, dim);
             } // end for
         } // end for
-        
-    
-        
+
         double div = elem_div(elem_gid);
-        
-    
+
         // vel = [u,v,w]
         //            [du/dx,  du/dy,  du/dz]
         // vel_grad = [dv/dx,  dv/dy,  dv/dz]
         //            [dw/dx,  dw/dy,  dw/dz]
         double curl[3];
-        curl[0] = vel_grad(2,1) - vel_grad(1,2);  // dw/dy - dv/dz
-        curl[1] = vel_grad(0,2) - vel_grad(2,0);  // du/dz - dw/dx
-        curl[2] = vel_grad(1,0) - vel_grad(0,1);  // dv/dx - du/dy
-        
-        double mag_curl = sqrt(curl[0]*curl[0] + curl[1]*curl[1] + curl[2]*curl[2]);
-        
-        
+        curl[0] = vel_grad(2, 1) - vel_grad(1, 2);  // dw/dy - dv/dz
+        curl[1] = vel_grad(0, 2) - vel_grad(2, 0);  // du/dz - dw/dx
+        curl[2] = vel_grad(1, 0) - vel_grad(0, 1);  // dv/dx - du/dy
+
+        double mag_curl = sqrt(curl[0] * curl[0] + curl[1] * curl[1] + curl[2] * curl[2]);
+
         // --- Calculate the Cauchy stress ---
-        for (size_t i = 0; i < 3; i++){
-            for (size_t j = 0; j < 3; j++){
-                tau(i, j) = stress(i,j);
+        for (size_t i = 0; i < 3; i++)
+        {
+            for (size_t j = 0; j < 3; j++)
+            {
+                tau(i, j) = stress(i, j);
                 // artificial viscosity can be added here to tau
             } // end for
-        } //end for
+        } // end for
 
         // add the pressure
-        for (int i = 0; i < num_dims; i++){
+        for (int i = 0; i < num_dims; i++)
+        {
             tau(i, i) -= elem_pres(elem_gid);
         } // end for
-        
-        
-
 
         // ---- Multidirectional Approximate Riemann solver (MARS) ----
         // find the average velocity of the elem, it is an
         // estimate of the Riemann velocity
-            
+
         // initialize to Riemann velocity to zero
-        for (size_t dim = 0; dim < num_dims; dim++){
+        for (size_t dim = 0; dim < num_dims; dim++)
+        {
             vel_star(dim) = 0.0;
         }
 
         // loop over nodes and calculate an average velocity, which is
         // an estimate of Riemann velocity
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             // Get node gloabl index and create view of nodal velocity
             int node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
-            
-            ViewCArrayKokkos <double> vel(&node_vel(1, node_gid, 0), num_dims);
-            
-            vel_star(0) += 0.125*vel(0);
-            vel_star(1) += 0.125*vel(1);
-            vel_star(2) += 0.125*vel(2);
-                
+
+            ViewCArrayKokkos<double> vel(&node_vel(1, node_gid, 0), num_dims);
+
+            vel_star(0) += 0.125 * vel(0);
+            vel_star(1) += 0.125 * vel(1);
+            vel_star(2) += 0.125 * vel(2);
         } // end for loop over nodes
 
         // find shock direction and shock impedance associated with each node
-        
+
         // initialize sum term in MARS to zero
-        for (int i = 0; i < 4; i++){
+        for (int i = 0; i < 4; i++)
+        {
             sum(i) = 0.0;
         }
 
@@ -174,103 +161,102 @@ void get_force_sgh(const CArrayKokkos <material_t> &material,
         double mag_vel;   // magnitude of velocity
 
         // loop over the nodes of the elem
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++) {
-
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             // Get global node id
             size_t node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
 
             // Create view of nodal velocity
-            ViewCArrayKokkos <double> vel(&node_vel(1, node_gid, 0), num_dims);
+            ViewCArrayKokkos<double> vel(&node_vel(1, node_gid, 0), num_dims);
 
             // Get an estimate of the shock direction.
-            mag_vel = sqrt( (vel(0) - vel_star(0) )*(vel(0) - vel_star(0) )
-                          + (vel(1) - vel_star(1) )*(vel(1) - vel_star(1) )
-                          + (vel(2) - vel_star(2) )*(vel(2) - vel_star(2) ) );
+            mag_vel = sqrt( (vel(0) - vel_star(0) ) * (vel(0) - vel_star(0) )
+                + (vel(1) - vel_star(1) ) * (vel(1) - vel_star(1) )
+                + (vel(2) - vel_star(2) ) * (vel(2) - vel_star(2) ) );
 
-     
-            if (mag_vel > small) {
-        
+            if (mag_vel > small)
+            {
                 // estimate of the shock direction, a unit normal
-                for (int dim = 0; dim < num_dims; dim++){
+                for (int dim = 0; dim < num_dims; dim++)
+                {
                     shock_dir(dim) = (vel(dim) - vel_star(dim)) / mag_vel;
                 }
             }
-
-            else {
-                
+            else
+            {
                 // if there is no velocity change, then use the surface area
                 // normal as the shock direction
-                mag = sqrt( area_normal(node_lid, 0)*area_normal(node_lid, 0)
-                          + area_normal(node_lid, 1)*area_normal(node_lid, 1)
-                          + area_normal(node_lid, 2)*area_normal(node_lid, 2) );
-                
+                mag = sqrt(area_normal(node_lid, 0) * area_normal(node_lid, 0)
+                    + area_normal(node_lid, 1) * area_normal(node_lid, 1)
+                    + area_normal(node_lid, 2) * area_normal(node_lid, 2) );
+
                 // estimate of the shock direction
-                for (int dim = 0; dim < num_dims; dim++){
-                    shock_dir(dim) = area_normal(node_lid, dim)/mag;
+                for (int dim = 0; dim < num_dims; dim++)
+                {
+                    shock_dir(dim) = area_normal(node_lid, dim) / mag;
                 }
-                
             } // end if mag_vel
-            
 
             // cell divergence indicates compression or expansions
             size_t mat_id = elem_mat_id(elem_gid);
-            if (div < 0){ // element in compression
+            if (div < 0)  // element in compression
+            {
                 muc(node_lid) = elem_den(elem_gid) *
-                               (material(mat_id).q1*elem_sspd(elem_gid) + material(mat_id).q2*mag_vel);
+                                (material(mat_id).q1 * elem_sspd(elem_gid) + material(mat_id).q2 * mag_vel);
             }
-            else { // element in expansion
+            else   // element in expansion
+            {
                 muc(node_lid) = elem_den(elem_gid) *
-                               (material(mat_id).q1ex*elem_sspd(elem_gid) + material(mat_id).q2ex*mag_vel);
+                                (material(mat_id).q1ex * elem_sspd(elem_gid) + material(mat_id).q2ex * mag_vel);
             } // end if on divergence sign
-           
 
             size_t use_shock_dir = 0;
             double mu_term;
-            
+
             // Coding to use shock direction
-            if (use_shock_dir == 1){
+            if (use_shock_dir == 1)
+            {
                 // this is denominator of the Riamann solver and the multiplier
                 // on velocity in the numerator.  It filters on the shock
                 // direction
-                mu_term = muc(node_lid)*
-                           fabs( shock_dir(0)*area_normal(node_lid,0)
-                               + shock_dir(1)*area_normal(node_lid,1)
-                               + shock_dir(2)*area_normal(node_lid,2) );
+                mu_term = muc(node_lid) *
+                          fabs(shock_dir(0) * area_normal(node_lid, 0)
+                    + shock_dir(1) * area_normal(node_lid, 1)
+                    + shock_dir(2) * area_normal(node_lid, 2) );
             }
-            else {
-               // Using a full tensoral Riemann jump relation
-               mu_term = muc(node_lid)
-                         * sqrt( area_normal(node_lid, 0)*area_normal(node_lid, 0)
-                               + area_normal(node_lid, 1)*area_normal(node_lid, 1)
-                               + area_normal(node_lid, 2)*area_normal(node_lid, 2) );
+            else
+            {
+                // Using a full tensoral Riemann jump relation
+                mu_term = muc(node_lid)
+                          * sqrt(area_normal(node_lid, 0) * area_normal(node_lid, 0)
+                    + area_normal(node_lid, 1) * area_normal(node_lid, 1)
+                    + area_normal(node_lid, 2) * area_normal(node_lid, 2) );
             }
-            
-            sum(0) += mu_term*vel(0);
-            sum(1) += mu_term*vel(1);
-            sum(2) += mu_term*vel(2);
+
+            sum(0) += mu_term * vel(0);
+            sum(1) += mu_term * vel(1);
+            sum(2) += mu_term * vel(2);
             sum(3) += mu_term;
 
             muc(node_lid) = mu_term; // the impeadance time surface area is stored here
-
         } // end for node_lid loop over nodes of the elem
 
-
-
-
         // The Riemann velocity, called vel_star
-        if (sum(3) > fuzz) {
-            for (size_t i = 0; i < num_dims; i++) {
-                vel_star(i) = sum(i)/sum(3);
+        if (sum(3) > fuzz)
+        {
+            for (size_t i = 0; i < num_dims; i++)
+            {
+                vel_star(i) = sum(i) / sum(3);
             }
         }
-        else {
-            for (int i = 0; i < num_dims; i++){
+        else
+        {
+            for (int i = 0; i < num_dims; i++)
+            {
                 vel_star(i) = 0.0;
             }
         } // end if
 
-            
-            
         // ---- Calculate the shock detector for the Riemann-solver ----
         //
         // The dissipation from the Riemann problem is limited by phi
@@ -283,7 +269,7 @@ void get_force_sgh(const CArrayKokkos <material_t> &material,
         //      phi = 0 highest-order solution
         //      phi = 1 first order solution
         //
-            
+
         double phi    = 0.0;  // the shock detector
         double r_face = 1.0;  // the ratio on the face
         double r_min  = 1.0;  // the min ratio for the cell
@@ -292,85 +278,77 @@ void get_force_sgh(const CArrayKokkos <material_t> &material,
         double n_coef = 1.0;  // the power on the limiting coefficient
                               //   (1=nominal, and n_coeff > 1 oscillatory)
 
-            
         // loop over the nieghboring cells
-        for (size_t elem_lid = 0; elem_lid < mesh.num_elems_in_elem(elem_gid); elem_lid++){
-            
+        for (size_t elem_lid = 0; elem_lid < mesh.num_elems_in_elem(elem_gid); elem_lid++)
+        {
             // Get global index for neighboring cell
             size_t neighbor_gid = mesh.elems_in_elem(elem_gid, elem_lid);
-            
+
             // calculate the velocity divergence in neighbor
             double div_neighbor = elem_div(neighbor_gid);
 
-            r_face = r_coef*(div_neighbor + small)/(div + small);
+            r_face = r_coef * (div_neighbor + small) / (div + small);
 
             // store the smallest face ratio
             r_min = fmin(r_face, r_min);
-            
         } // end for elem_lid
-        
 
         // calculate standard shock detector
         phi = 1.0 - fmax(0.0, r_min);
         phi = pow(phi, n_coef);
 
         //  Mach number shock detector
-        double omega = 20.0;//20.0;    // weighting factor on Mach number
-        double third = 1.0/3.0;
+        double omega    = 20.0; // 20.0;    // weighting factor on Mach number
+        double third    = 1.0 / 3.0;
         double c_length = pow(vol, third); // characteristic length
-        double alpha = fmin(1.0, omega * (c_length * fabs(div))/(elem_sspd(elem_gid) + fuzz) );
-        
+        double alpha    = fmin(1.0, omega * (c_length * fabs(div)) / (elem_sspd(elem_gid) + fuzz) );
+
         // use Mach based detector with standard shock detector
 
         // turn off dissipation in expansion
-        //alpha = fmax(-fabs(div0)/div0 * alpha, 0.0);  // this should be if(div0<0) alpha=alpha else alpha=0
-        
-        phi = alpha*phi;
-        
-        // curl limiter on Q
-        double phi_curl = fmin(1.0, 1.0*fabs(div)/(mag_curl + fuzz));  // disable Q when vorticity is high
-        //phi = phi_curl*phi;
+        // alpha = fmax(-fabs(div0)/div0 * alpha, 0.0);  // this should be if(div0<0) alpha=alpha else alpha=0
 
+        phi = alpha * phi;
+
+        // curl limiter on Q
+        double phi_curl = fmin(1.0, 1.0 * fabs(div) / (mag_curl + fuzz));  // disable Q when vorticity is high
+        // phi = phi_curl*phi;
 
         // ---- Calculate the Riemann force on each node ----
 
         // loop over the each node in the elem
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++) {
-            
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             size_t corner_lid = node_lid;
 
             // Get corner gid
             size_t corner_gid = mesh.corners_in_elem(elem_gid, corner_lid);
-            
+
             // Get node gid
             size_t node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
-   
+
             // loop over dimension
-            for (int dim = 0; dim < num_dims; dim++){
-
+            for (int dim = 0; dim < num_dims; dim++)
+            {
                 corner_force(corner_gid, dim) =
-                          area_normal(node_lid, 0)*tau(0, dim)
-                        + area_normal(node_lid, 1)*tau(1, dim)
-                        + area_normal(node_lid, 2)*tau(2, dim)
-                        + phi*muc(node_lid)*(vel_star(dim) - node_vel(1, node_gid, dim));
-
+                    area_normal(node_lid, 0) * tau(0, dim)
+                    + area_normal(node_lid, 1) * tau(1, dim)
+                    + area_normal(node_lid, 2) * tau(2, dim)
+                    + phi * muc(node_lid) * (vel_star(dim) - node_vel(1, node_gid, dim));
             } // end loop over dimension
-
         } // end for loop over nodes in elem
-        
-        
-        
+
         // --- Update Stress ---
         // calculate the new stress at the next rk level, if it is a hypo model
-        
-        size_t mat_id = elem_mat_id(elem_gid);
-        
-        // hypo elastic plastic model
-        if(material(mat_id).strength_type == model::hypo){
 
+        size_t mat_id = elem_mat_id(elem_gid);
+
+        // hypo elastic plastic model
+        if (material(mat_id).strength_type == model::hypo)
+        {
             // cut out the node_gids for this element
-            ViewCArrayKokkos <size_t>   elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
-            
+            ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
+
             // --- call strength model ---
             material(mat_id).strength_model(elem_pres,
                                             elem_stress,
@@ -387,110 +365,97 @@ void get_force_sgh(const CArrayKokkos <material_t> &material,
                                             elem_vol(elem_gid),
                                             dt,
                                             rk_alpha);
-            
         } // end logical on hypo strength model
-        
-
     }); // end parallel for loop over elements
 
-    
     return;
-    
 } // end of routine
-
-
-
 
 // -----------------------------------------------------------------------------
 // This function calculates the corner forces and the evolves stress (hypo)
-//------------------------------------------------------------------------------
-void get_force_sgh2D(const CArrayKokkos <material_t> &material,
-                     const mesh_t &mesh,
-                     const DViewCArrayKokkos <double> &node_coords,
-                     const DViewCArrayKokkos <double> &node_vel,
-                     const DViewCArrayKokkos <double> &elem_den,
-                     const DViewCArrayKokkos <double> &elem_sie,
-                     const DViewCArrayKokkos <double> &elem_pres,
-                     const DViewCArrayKokkos <double> &elem_stress,
-                     const DViewCArrayKokkos <double> &elem_sspd,
-                     const DViewCArrayKokkos <double> &elem_vol,
-                     const DViewCArrayKokkos <double> &elem_div,
-                     const DViewCArrayKokkos <size_t> &elem_mat_id,
-                     DViewCArrayKokkos <double> &corner_force,
-                     const double fuzz,
-                     const double small,
-                     const DViewCArrayKokkos <double> &elem_statev,
-                     const double dt,
-                     const double rk_alpha
-                     ){
-    
-
-    
+// ------------------------------------------------------------------------------
+void
+get_force_sgh2D(const CArrayKokkos<material_t>&  material,
+                const mesh_t&                    mesh,
+                const DViewCArrayKokkos<double>& node_coords,
+                const DViewCArrayKokkos<double>& node_vel,
+                const DViewCArrayKokkos<double>& elem_den,
+                const DViewCArrayKokkos<double>& elem_sie,
+                const DViewCArrayKokkos<double>& elem_pres,
+                const DViewCArrayKokkos<double>& elem_stress,
+                const DViewCArrayKokkos<double>& elem_sspd,
+                const DViewCArrayKokkos<double>& elem_vol,
+                const DViewCArrayKokkos<double>& elem_div,
+                const DViewCArrayKokkos<size_t>& elem_mat_id,
+                DViewCArrayKokkos<double>&       corner_force,
+                const double                     fuzz,
+                const double                     small,
+                const DViewCArrayKokkos<double>& elem_statev,
+                const double                     dt,
+                const double                     rk_alpha
+                )
+{
     // --- calculate the forces acting on the nodes from the element ---
-    FOR_ALL (elem_gid, 0, mesh.num_elems, {
-        
+    FOR_ALL(elem_gid, 0, mesh.num_elems, {
         const size_t num_dims = 2;
         const size_t num_nodes_in_elem = 4;
-        
+
         // total Cauchy stress
         double tau_array[9];
-        
+
         // corner area normals
         double area_normal_array[8]; // 4 corners and 2 directions
-        
+
         // estimate of shock direction
         double shock_dir_array[2];
-        
+
         // the sums in the Riemann solver
         double sum_array[4];
-        
+
         // corner shock impeadance x |corner area normal dot shock_dir|
         double muc_array[4];
-        
+
         // Riemann velocity
         double vel_star_array[2];
-        
+
         // velocity gradient
         double vel_grad_array[9];
-        
-        // --- Create views of arrays to aid the force calculation ---
-    
-        ViewCArrayKokkos <double> tau(tau_array, 3, 3);
-        ViewCArrayKokkos <double> area_normal(area_normal_array, num_nodes_in_elem, num_dims);
-        ViewCArrayKokkos <double> shock_dir(shock_dir_array, num_dims);
-        ViewCArrayKokkos <double> sum(sum_array, 4);
-        ViewCArrayKokkos <double> muc(muc_array, num_nodes_in_elem);
-        ViewCArrayKokkos <double> vel_star(vel_star_array, num_dims);
-        ViewCArrayKokkos <double> vel_grad(vel_grad_array, 3, 3);
 
-    
+        // --- Create views of arrays to aid the force calculation ---
+
+        ViewCArrayKokkos<double> tau(tau_array, 3, 3);
+        ViewCArrayKokkos<double> area_normal(area_normal_array, num_nodes_in_elem, num_dims);
+        ViewCArrayKokkos<double> shock_dir(shock_dir_array, num_dims);
+        ViewCArrayKokkos<double> sum(sum_array, 4);
+        ViewCArrayKokkos<double> muc(muc_array, num_nodes_in_elem);
+        ViewCArrayKokkos<double> vel_star(vel_star_array, num_dims);
+        ViewCArrayKokkos<double> vel_grad(vel_grad_array, 3, 3);
+
         // create a view of the stress_matrix
-        ViewCArrayKokkos <double> stress(&elem_stress(1, elem_gid, 0,0), 3, 3);
-        
-        
+        ViewCArrayKokkos<double> stress(&elem_stress(1, elem_gid, 0, 0), 3, 3);
+
         // cut out the node_gids for this element
-        ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
-        
+        ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
+
         // get the B matrix which are the OUTWARD corner area normals
         get_bmatrix2D(area_normal,
                       elem_gid,
                       node_coords,
                       elem_node_gids);
         // NOTE: I added a minus in bmatrix2D, it should be outward pointing now?
-        
+
         // facial area of the element
         double elem_area = get_area_quad(elem_gid, node_coords, elem_node_gids);
-        
+
         // facial area of the corners
         double corner_areas_array[4];
-        ViewCArrayKokkos <double> corner_areas(&corner_areas_array[0],4);
-        
+        ViewCArrayKokkos<double> corner_areas(&corner_areas_array[0], 4);
+
         get_area_weights2D(corner_areas,
                            elem_gid,
                            node_coords,
                            elem_node_gids);
-        
-        
+
         // --- Calculate the velocity gradient ---
         get_velgrad2D(vel_grad,
                       elem_node_gids,
@@ -499,71 +464,70 @@ void get_force_sgh2D(const CArrayKokkos <material_t> &material,
                       elem_vol(elem_gid),
                       elem_area,
                       elem_gid);
-        
-        
+
         // the -1 is for the inward surface area normal,
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-            for (size_t dim = 0; dim < num_dims; dim++){
-                area_normal(node_lid, dim) = (-1.0)*area_normal(node_lid,dim);
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
+            for (size_t dim = 0; dim < num_dims; dim++)
+            {
+                area_normal(node_lid, dim) = (-1.0) * area_normal(node_lid, dim);
             } // end for
         } // end for
-        
-    
-        
+
         double div = elem_div(elem_gid);
-        
-    
+
         // vel = [u,v]
         //            [du/dx,  du/dy]
         // vel_grad = [dv/dx,  dv/dy]
         double curl;
-        curl = vel_grad(1,0) - vel_grad(0,1);  // dv/dx - du/dy
-        
+        curl = vel_grad(1, 0) - vel_grad(0, 1);  // dv/dx - du/dy
+
         double mag_curl = curl;
-        
-        
+
         // --- Calculate the Cauchy stress ---
-        for (size_t i = 0; i < 3; i++){
-            for (size_t j = 0; j < 3; j++){
-                tau(i, j) = stress(i,j);
+        for (size_t i = 0; i < 3; i++)
+        {
+            for (size_t j = 0; j < 3; j++)
+            {
+                tau(i, j) = stress(i, j);
                 // artificial viscosity can be added here to tau
             } // end for
-        } //end for
+        } // end for
 
         // add the pressure
-        for (int i = 0; i < 3; i++){
+        for (int i = 0; i < 3; i++)
+        {
             tau(i, i) -= elem_pres(elem_gid);
         } // end for
-        
-
 
         // ---- Multidirectional Approximate Riemann solver (MARS) ----
         // find the average velocity of the elem, it is an
         // estimate of the Riemann velocity
-            
+
         // initialize to Riemann velocity to zero
-        for (size_t dim = 0; dim < num_dims; dim++){
+        for (size_t dim = 0; dim < num_dims; dim++)
+        {
             vel_star(dim) = 0.0;
         }
 
         // loop over nodes and calculate an average velocity, which is
         // an estimate of Riemann velocity
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             // Get node gloabl index and create view of nodal velocity
             int node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
-            
-            ViewCArrayKokkos <double> vel(&node_vel(1, node_gid, 0), num_dims);
-            
-            vel_star(0) += 0.25*vel(0);
-            vel_star(1) += 0.25*vel(1);
-                
+
+            ViewCArrayKokkos<double> vel(&node_vel(1, node_gid, 0), num_dims);
+
+            vel_star(0) += 0.25 * vel(0);
+            vel_star(1) += 0.25 * vel(1);
         } // end for loop over nodes
 
         // find shock direction and shock impedance associated with each node
-        
+
         // initialize sum term in MARS to zero
-        for (int i = 0; i < 4; i++){
+        for (int i = 0; i < 4; i++)
+        {
             sum(i) = 0.0;
         }
 
@@ -571,98 +535,97 @@ void get_force_sgh2D(const CArrayKokkos <material_t> &material,
         double mag_vel;   // magnitude of velocity
 
         // loop over the nodes of the elem
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++) {
-
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             // Get global node id
             size_t node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
 
             // Create view of nodal velocity
-            ViewCArrayKokkos <double> vel(&node_vel(1, node_gid, 0), num_dims);
+            ViewCArrayKokkos<double> vel(&node_vel(1, node_gid, 0), num_dims);
 
             // Get an estimate of the shock direction.
-            mag_vel = sqrt( (vel(0) - vel_star(0) )*(vel(0) - vel_star(0) )
-                          + (vel(1) - vel_star(1) )*(vel(1) - vel_star(1) ) );
+            mag_vel = sqrt( (vel(0) - vel_star(0) ) * (vel(0) - vel_star(0) )
+                + (vel(1) - vel_star(1) ) * (vel(1) - vel_star(1) ) );
 
-     
-            if (mag_vel > small) {
-        
+            if (mag_vel > small)
+            {
                 // estimate of the shock direction, a unit normal
-                for (int dim = 0; dim < num_dims; dim++){
+                for (int dim = 0; dim < num_dims; dim++)
+                {
                     shock_dir(dim) = (vel(dim) - vel_star(dim)) / mag_vel;
                 }
             }
-
-            else {
-                
+            else
+            {
                 // if there is no velocity change, then use the surface area
                 // normal as the shock direction
-                mag = sqrt( area_normal(node_lid, 0)*area_normal(node_lid, 0)
-                          + area_normal(node_lid, 1)*area_normal(node_lid, 1) );
-                
+                mag = sqrt(area_normal(node_lid, 0) * area_normal(node_lid, 0)
+                    + area_normal(node_lid, 1) * area_normal(node_lid, 1) );
+
                 // estimate of the shock direction
-                for (int dim = 0; dim < num_dims; dim++){
-                    shock_dir(dim) = area_normal(node_lid, dim)/mag;
+                for (int dim = 0; dim < num_dims; dim++)
+                {
+                    shock_dir(dim) = area_normal(node_lid, dim) / mag;
                 }
-                
             } // end if mag_vel
-            
 
             // cell divergence indicates compression or expansions
             size_t mat_id = elem_mat_id(elem_gid);
-            if (div < 0){ // element in compression
+            if (div < 0)  // element in compression
+            {
                 muc(node_lid) = elem_den(elem_gid) *
-                               (material(mat_id).q1*elem_sspd(elem_gid) + material(mat_id).q2*mag_vel);
+                                (material(mat_id).q1 * elem_sspd(elem_gid) + material(mat_id).q2 * mag_vel);
             }
-            else { // element in expansion
+            else   // element in expansion
+            {
                 muc(node_lid) = elem_den(elem_gid) *
-                               (material(mat_id).q1ex*elem_sspd(elem_gid) + material(mat_id).q2ex*mag_vel);
+                                (material(mat_id).q1ex * elem_sspd(elem_gid) + material(mat_id).q2ex * mag_vel);
             } // end if on divergence sign
-           
 
             size_t use_shock_dir = 0;
             double mu_term;
-            
+
             // Coding to use shock direction
-            if (use_shock_dir == 1){
+            if (use_shock_dir == 1)
+            {
                 // this is denominator of the Riamann solver and the multiplier
                 // on velocity in the numerator.  It filters on the shock
                 // direction
-                mu_term = muc(node_lid)*
-                           fabs( shock_dir(0)*area_normal(0)
-                               + shock_dir(1)*area_normal(1) );
+                mu_term = muc(node_lid) *
+                          fabs(shock_dir(0) * area_normal(0)
+                    + shock_dir(1) * area_normal(1) );
             }
-            else {
-               // Using a full tensoral Riemann jump relation
-               mu_term = muc(node_lid)
-                         * sqrt( area_normal(node_lid, 0)*area_normal(node_lid, 0)
-                               + area_normal(node_lid, 1)*area_normal(node_lid, 1) );
+            else
+            {
+                // Using a full tensoral Riemann jump relation
+                mu_term = muc(node_lid)
+                          * sqrt(area_normal(node_lid, 0) * area_normal(node_lid, 0)
+                    + area_normal(node_lid, 1) * area_normal(node_lid, 1) );
             }
-            
-            sum(0) += mu_term*vel(0);
-            sum(1) += mu_term*vel(1);
+
+            sum(0) += mu_term * vel(0);
+            sum(1) += mu_term * vel(1);
             sum(3) += mu_term;
 
             muc(node_lid) = mu_term; // the impeadance time surface area is stored here
-
         } // end for node_lid loop over nodes of the elem
 
-
-
-
         // The Riemann velocity, called vel_star
-        if (sum(3) > fuzz) {
-            for (size_t i = 0; i < num_dims; i++) {
-                vel_star(i) = sum(i)/sum(3);
+        if (sum(3) > fuzz)
+        {
+            for (size_t i = 0; i < num_dims; i++)
+            {
+                vel_star(i) = sum(i) / sum(3);
             }
         }
-        else {
-            for (int i = 0; i < num_dims; i++){
+        else
+        {
+            for (int i = 0; i < num_dims; i++)
+            {
                 vel_star(i) = 0.0;
             }
         } // end if
-            
-            
-            
+
         // ---- Calculate the shock detector for the Riemann-solver ----
         //
         // The dissipation from the Riemann problem is limited by phi
@@ -675,7 +638,7 @@ void get_force_sgh2D(const CArrayKokkos <material_t> &material,
         //      phi = 0 highest-order solution
         //      phi = 1 first order solution
         //
-            
+
         double phi    = 0.0;  // the shock detector
         double r_face = 1.0;  // the ratio on the face
         double r_min  = 1.0;  // the min ratio for the cell
@@ -684,102 +647,92 @@ void get_force_sgh2D(const CArrayKokkos <material_t> &material,
         double n_coef = 1.0;  // the power on the limiting coefficient
                               //   (1=nominal, and n_coeff > 1 oscillatory)
 
-            
         // loop over the nieghboring cells
-        for (size_t elem_lid = 0; elem_lid < mesh.num_elems_in_elem(elem_gid); elem_lid++){
-            
+        for (size_t elem_lid = 0; elem_lid < mesh.num_elems_in_elem(elem_gid); elem_lid++)
+        {
             // Get global index for neighboring cell
             size_t neighbor_gid = mesh.elems_in_elem(elem_gid, elem_lid);
-            
+
             // calculate the velocity divergence in neighbor
             double div_neighbor = elem_div(neighbor_gid);
 
-            r_face = r_coef*(div_neighbor + small)/(div + small);
+            r_face = r_coef * (div_neighbor + small) / (div + small);
 
             // store the smallest face ratio
             r_min = fmin(r_face, r_min);
-            
         } // end for elem_lid
-        
 
         // calculate standard shock detector
         phi = 1.0 - fmax(0.0, r_min);
         phi = pow(phi, n_coef);
 
         //  Mach number shock detector
-        double omega = 20.0;//20.0;    // weighting factor on Mach number
+        double omega    = 20.0; // 20.0;    // weighting factor on Mach number
         double c_length = sqrt(elem_area); // characteristic length
-        double alpha = fmin(1.0, omega * (c_length * fabs(div))/(elem_sspd(elem_gid) + fuzz) );
-        
+        double alpha    = fmin(1.0, omega * (c_length * fabs(div)) / (elem_sspd(elem_gid) + fuzz) );
+
         // use Mach based detector with standard shock detector
 
         // turn off dissipation in expansion
-        //alpha = fmax(-fabs(div0)/div0 * alpha, 0.0);  // this should be if(div0<0) alpha=alpha else alpha=0
-        
-        phi = alpha*phi;
-        
-        //phi = 1.0;  // WARNING WARNING WARNING
-        
+        // alpha = fmax(-fabs(div0)/div0 * alpha, 0.0);  // this should be if(div0<0) alpha=alpha else alpha=0
+
+        phi = alpha * phi;
+
+        // phi = 1.0;  // WARNING WARNING WARNING
+
         // curl limiter on Q
-        double phi_curl = fmin(1.0, 4.0*fabs(div)/(mag_curl + fuzz));  // disable Q when vorticity is high
-        //phi = phi_curl*phi;
-        
-
-
+        double phi_curl = fmin(1.0, 4.0 * fabs(div) / (mag_curl + fuzz));  // disable Q when vorticity is high
+        // phi = phi_curl*phi;
 
         // ---- Calculate the Riemann force on each node ----
 
         // loop over the each node in the elem
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++) {
-            
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             size_t corner_lid = node_lid;
 
             // Get corner gid
             size_t corner_gid = mesh.corners_in_elem(elem_gid, corner_lid);
-            
+
             // Get node gid
             size_t node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
-   
+
             // loop over dimension
-            for (int dim = 0; dim < num_dims; dim++){
-
+            for (int dim = 0; dim < num_dims; dim++)
+            {
                 corner_force(corner_gid, dim) =
-                          area_normal(node_lid, 0)*tau(0, dim)
-                        + area_normal(node_lid, 1)*tau(1, dim)
-                        + phi*muc(node_lid)*(vel_star(dim) - node_vel(1, node_gid, dim));
-
+                    area_normal(node_lid, 0) * tau(0, dim)
+                    + area_normal(node_lid, 1) * tau(1, dim)
+                    + phi * muc(node_lid) * (vel_star(dim) - node_vel(1, node_gid, dim));
             } // end loop over dimension
-            
-            
+
             // ---- add hoop stress terms ----
-            
-            double node_radius = node_coords(1,node_gid,1);
-            
+
+            double node_radius = node_coords(1, node_gid, 1);
+
             // Wilkins used elem_area*0.25 for the corner area, we will use the corner
             // areas calculated using Barlow's symmetry and energy preserving area partitioning
-            if(node_radius>1e-14){
+            if (node_radius > 1e-14)
+            {
                 // sigma_RZ / R_p
-                corner_force(corner_gid, 0) += tau(1,0)*corner_areas(corner_lid)/node_radius;
-                
+                corner_force(corner_gid, 0) += tau(1, 0) * corner_areas(corner_lid) / node_radius;
+
                 // (sigma_RR - sigma_theta) / R_p
-                corner_force(corner_gid, 1) += (tau(1,1) - tau(2,2))*corner_areas(corner_lid)/node_radius;
+                corner_force(corner_gid, 1) += (tau(1, 1) - tau(2, 2)) * corner_areas(corner_lid) / node_radius;
             } // end if radius >0
-            
         } // end for loop over nodes in elem
-        
-        
-        
+
         // --- Update Stress ---
         // calculate the new stress at the next rk level, if it is a hypo model
-        
-        size_t mat_id = elem_mat_id(elem_gid);
-        
-        // hypo elastic plastic model
-        if(material(mat_id).strength_type == model::hypo){
 
+        size_t mat_id = elem_mat_id(elem_gid);
+
+        // hypo elastic plastic model
+        if (material(mat_id).strength_type == model::hypo)
+        {
             // cut out the node_gids for this element
-            ViewCArrayKokkos <size_t>   elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
-            
+            ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
+
             // --- call strength model ---
             material(mat_id).strength_model(elem_pres,
                                             elem_stress,
@@ -796,13 +749,8 @@ void get_force_sgh2D(const CArrayKokkos <material_t> &material,
                                             elem_vol(elem_gid),
                                             dt,
                                             rk_alpha);
-            
         } // end logical on hypo strength model
-        
-
     }); // end parallel for loop over elements
 
-    
     return;
-    
 } // end of routine for 2D force and stress update

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/force_sgh.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/force_sgh.cpp
@@ -5,26 +5,25 @@
 // -----------------------------------------------------------------------------
 // This function calculates the corner forces and the evolves stress (hypo)
 // ------------------------------------------------------------------------------
-void
-get_force_sgh(const CArrayKokkos<material_t>&  material,
-              const mesh_t&                    mesh,
-              const DViewCArrayKokkos<double>& node_coords,
-              const DViewCArrayKokkos<double>& node_vel,
-              const DViewCArrayKokkos<double>& elem_den,
-              const DViewCArrayKokkos<double>& elem_sie,
-              const DViewCArrayKokkos<double>& elem_pres,
-              const DViewCArrayKokkos<double>& elem_stress,
-              const DViewCArrayKokkos<double>& elem_sspd,
-              const DViewCArrayKokkos<double>& elem_vol,
-              const DViewCArrayKokkos<double>& elem_div,
-              const DViewCArrayKokkos<size_t>& elem_mat_id,
-              DViewCArrayKokkos<double>&       corner_force,
-              const double                     fuzz,
-              const double                     small,
-              const DViewCArrayKokkos<double>& elem_statev,
-              const double                     dt,
-              const double                     rk_alpha
-              )
+void get_force_sgh(const CArrayKokkos<material_t>&  material,
+                   const mesh_t&                    mesh,
+                   const DViewCArrayKokkos<double>& node_coords,
+                   const DViewCArrayKokkos<double>& node_vel,
+                   const DViewCArrayKokkos<double>& elem_den,
+                   const DViewCArrayKokkos<double>& elem_sie,
+                   const DViewCArrayKokkos<double>& elem_pres,
+                   const DViewCArrayKokkos<double>& elem_stress,
+                   const DViewCArrayKokkos<double>& elem_sspd,
+                   const DViewCArrayKokkos<double>& elem_vol,
+                   const DViewCArrayKokkos<double>& elem_div,
+                   const DViewCArrayKokkos<size_t>& elem_mat_id,
+                   DViewCArrayKokkos<double>&       corner_force,
+                   const double                     fuzz,
+                   const double                     small,
+                   const DViewCArrayKokkos<double>& elem_statev,
+                   const double                     dt,
+                   const double                     rk_alpha
+                   )
 {
     // --- calculate the forces acting on the nodes from the element ---
     FOR_ALL(elem_gid, 0, mesh.num_elems, {
@@ -374,26 +373,25 @@ get_force_sgh(const CArrayKokkos<material_t>&  material,
 // -----------------------------------------------------------------------------
 // This function calculates the corner forces and the evolves stress (hypo)
 // ------------------------------------------------------------------------------
-void
-get_force_sgh2D(const CArrayKokkos<material_t>&  material,
-                const mesh_t&                    mesh,
-                const DViewCArrayKokkos<double>& node_coords,
-                const DViewCArrayKokkos<double>& node_vel,
-                const DViewCArrayKokkos<double>& elem_den,
-                const DViewCArrayKokkos<double>& elem_sie,
-                const DViewCArrayKokkos<double>& elem_pres,
-                const DViewCArrayKokkos<double>& elem_stress,
-                const DViewCArrayKokkos<double>& elem_sspd,
-                const DViewCArrayKokkos<double>& elem_vol,
-                const DViewCArrayKokkos<double>& elem_div,
-                const DViewCArrayKokkos<size_t>& elem_mat_id,
-                DViewCArrayKokkos<double>&       corner_force,
-                const double                     fuzz,
-                const double                     small,
-                const DViewCArrayKokkos<double>& elem_statev,
-                const double                     dt,
-                const double                     rk_alpha
-                )
+void get_force_sgh2D(const CArrayKokkos<material_t>&  material,
+                     const mesh_t&                    mesh,
+                     const DViewCArrayKokkos<double>& node_coords,
+                     const DViewCArrayKokkos<double>& node_vel,
+                     const DViewCArrayKokkos<double>& elem_den,
+                     const DViewCArrayKokkos<double>& elem_sie,
+                     const DViewCArrayKokkos<double>& elem_pres,
+                     const DViewCArrayKokkos<double>& elem_stress,
+                     const DViewCArrayKokkos<double>& elem_sspd,
+                     const DViewCArrayKokkos<double>& elem_vol,
+                     const DViewCArrayKokkos<double>& elem_div,
+                     const DViewCArrayKokkos<size_t>& elem_mat_id,
+                     DViewCArrayKokkos<double>&       corner_force,
+                     const double                     fuzz,
+                     const double                     small,
+                     const DViewCArrayKokkos<double>& elem_statev,
+                     const double                     dt,
+                     const double                     rk_alpha
+                     )
 {
     // --- calculate the forces acting on the nodes from the element ---
     FOR_ALL(elem_gid, 0, mesh.num_elems, {

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/geometry.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/geometry.cpp
@@ -5,13 +5,12 @@
 #include "mesh.h"
 #include "state.h"
 
-void
-update_position_sgh(double                           rk_alpha,
-                    double                           dt,
-                    const size_t                     num_dims,
-                    const size_t                     num_nodes,
-                    DViewCArrayKokkos<double>&       node_coords,
-                    const DViewCArrayKokkos<double>& node_vel)
+void update_position_sgh(double                           rk_alpha,
+                         double                           dt,
+                         const size_t                     num_dims,
+                         const size_t                     num_nodes,
+                         DViewCArrayKokkos<double>&       node_coords,
+                         const DViewCArrayKokkos<double>& node_vel)
 {
     // loop over all the nodes in the mesh
     FOR_ALL(node_gid, 0, num_nodes, {
@@ -35,11 +34,10 @@ update_position_sgh(double                           rk_alpha,
 //   B_p is the OUTWARD corner area normal at node p
 // ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void
-get_bmatrix(const ViewCArrayKokkos<double>&  B_matrix,
-            const size_t                     elem_gid,
-            const DViewCArrayKokkos<double>& node_coords,
-            const ViewCArrayKokkos<size_t>&  elem_node_gids)
+void get_bmatrix(const ViewCArrayKokkos<double>&  B_matrix,
+                 const size_t                     elem_gid,
+                 const DViewCArrayKokkos<double>& node_coords,
+                 const ViewCArrayKokkos<size_t>&  elem_node_gids)
 {
     const size_t num_nodes = 8;
 
@@ -231,10 +229,9 @@ get_bmatrix(const ViewCArrayKokkos<double>&  B_matrix,
                       + x(6) * (+y(2) + y(3) - y(4) - y(5) ) ) * twelth;
 } // end subroutine
 
-void
-get_vol(const DViewCArrayKokkos<double>& elem_vol,
-        const DViewCArrayKokkos<double>& node_coords,
-        const mesh_t&                    mesh)
+void get_vol(const DViewCArrayKokkos<double>& elem_vol,
+             const DViewCArrayKokkos<double>& node_coords,
+             const mesh_t&                    mesh)
 {
     const size_t num_dims = mesh.num_dims;
 
@@ -262,11 +259,10 @@ get_vol(const DViewCArrayKokkos<double>& elem_vol,
 
 // Exact volume for a hex element
 KOKKOS_FUNCTION
-void
-get_vol_hex(const DViewCArrayKokkos<double>& elem_vol,
-            const size_t                     elem_gid,
-            const DViewCArrayKokkos<double>& node_coords,
-            const ViewCArrayKokkos<size_t>&  elem_node_gids)
+void get_vol_hex(const DViewCArrayKokkos<double>& elem_vol,
+                 const size_t                     elem_gid,
+                 const DViewCArrayKokkos<double>& node_coords,
+                 const ViewCArrayKokkos<size_t>&  elem_node_gids)
 {
     const size_t num_nodes = 8;
 
@@ -306,11 +302,10 @@ get_vol_hex(const DViewCArrayKokkos<double>& elem_vol,
 } // end subroutine
 
 KOKKOS_FUNCTION
-void
-get_bmatrix2D(const ViewCArrayKokkos<double>&  B_matrix,
-              const size_t                     elem_gid,
-              const DViewCArrayKokkos<double>& node_coords,
-              const ViewCArrayKokkos<size_t>&  elem_node_gids)
+void get_bmatrix2D(const ViewCArrayKokkos<double>&  B_matrix,
+                   const size_t                     elem_gid,
+                   const DViewCArrayKokkos<double>& node_coords,
+                   const ViewCArrayKokkos<size_t>&  elem_node_gids)
 {
     const size_t num_nodes = 4;
 
@@ -371,11 +366,10 @@ get_bmatrix2D(const ViewCArrayKokkos<double>&  B_matrix,
 
 // true volume of a quad in RZ coords
 KOKKOS_FUNCTION
-void
-get_vol_quad(const DViewCArrayKokkos<double>& elem_vol,
-             const size_t                     elem_gid,
-             const DViewCArrayKokkos<double>& node_coords,
-             const ViewCArrayKokkos<size_t>&  elem_node_gids)
+void get_vol_quad(const DViewCArrayKokkos<double>& elem_vol,
+                  const size_t                     elem_gid,
+                  const DViewCArrayKokkos<double>& node_coords,
+                  const ViewCArrayKokkos<size_t>&  elem_node_gids)
 {
     // --- testing here ---
     /*
@@ -429,10 +423,9 @@ get_vol_quad(const DViewCArrayKokkos<double>& elem_vol,
 
 // element facial area
 KOKKOS_FUNCTION
-double
-get_area_quad(const size_t                     elem_gid,
-              const DViewCArrayKokkos<double>& node_coords,
-              const ViewCArrayKokkos<size_t>&  elem_node_gids)
+double get_area_quad(const size_t                     elem_gid,
+                     const DViewCArrayKokkos<double>& node_coords,
+                     const ViewCArrayKokkos<size_t>&  elem_node_gids)
 {
     double elem_area = 0.0;
 
@@ -463,13 +456,12 @@ get_area_quad(const size_t                     elem_gid,
 } // end subroutine
 
 KOKKOS_FUNCTION
-double
-heron(const double x1,
-      const double y1,
-      const double x2,
-      const double y2,
-      const double x3,
-      const double y3)
+double heron(const double x1,
+             const double y1,
+             const double x2,
+             const double y2,
+             const double x3,
+             const double y3)
 {
     double S, a, b, c, area;
 
@@ -488,11 +480,10 @@ heron(const double x1,
 }
 
 KOKKOS_FUNCTION
-void
-get_area_weights2D(const ViewCArrayKokkos<double>&  corner_areas,
-                   const size_t                     elem_gid,
-                   const DViewCArrayKokkos<double>& node_coords,
-                   const ViewCArrayKokkos<size_t>&  elem_node_gids)
+void get_area_weights2D(const ViewCArrayKokkos<double>&  corner_areas,
+                        const size_t                     elem_gid,
+                        const DViewCArrayKokkos<double>& node_coords,
+                        const ViewCArrayKokkos<size_t>&  elem_node_gids)
 {
     const size_t num_nodes = 4;
 

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/geometry.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/geometry.cpp
@@ -1,30 +1,27 @@
 // -----------------------------------------------------------------------------
 // This code handles the geometric information for the mesh for the SHG solver
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include "matar.h"
 #include "mesh.h"
 #include "state.h"
 
-
-void update_position_sgh(double rk_alpha,
-                         double dt,
-                         const size_t num_dims,
-                         const size_t num_nodes,
-                         DViewCArrayKokkos <double> &node_coords,
-                         const DViewCArrayKokkos <double> &node_vel){
-    
+void
+update_position_sgh(double                           rk_alpha,
+                    double                           dt,
+                    const size_t                     num_dims,
+                    const size_t                     num_nodes,
+                    DViewCArrayKokkos<double>&       node_coords,
+                    const DViewCArrayKokkos<double>& node_vel)
+{
     // loop over all the nodes in the mesh
     FOR_ALL(node_gid, 0, num_nodes, {
-
-        for (int dim = 0; dim < num_dims; dim++){
-            double half_vel = (node_vel(1, node_gid, dim) + node_vel(0, node_gid, dim))*0.5;
-            node_coords(1, node_gid, dim) = node_coords(0, node_gid, dim) + rk_alpha*dt*half_vel;
+        for (int dim = 0; dim < num_dims; dim++)
+        {
+            double half_vel = (node_vel(1, node_gid, dim) + node_vel(0, node_gid, dim)) * 0.5;
+            node_coords(1, node_gid, dim) = node_coords(0, node_gid, dim) + rk_alpha * dt * half_vel;
         }
-        
     }); // end parallel for over nodes
-    
 } // end subroutine
-
 
 // -----------------------------------------------------------------------------
 //  This function claculates
@@ -36,298 +33,297 @@ void update_position_sgh(double rk_alpha,
 //    \nabla_{xi} is the gradient opperator in the reference coordinates
 //
 //   B_p is the OUTWARD corner area normal at node p
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void get_bmatrix(const ViewCArrayKokkos <double> &B_matrix,
-                 const size_t elem_gid,
-                 const DViewCArrayKokkos <double> &node_coords,
-                 const ViewCArrayKokkos <size_t>  &elem_node_gids){
-
+void
+get_bmatrix(const ViewCArrayKokkos<double>&  B_matrix,
+            const size_t                     elem_gid,
+            const DViewCArrayKokkos<double>& node_coords,
+            const ViewCArrayKokkos<size_t>&  elem_node_gids)
+{
     const size_t num_nodes = 8;
 
     double x_array[8];
     double y_array[8];
     double z_array[8];
-    
+
     // x, y, z coordinates of elem vertices
-    auto x  = ViewCArrayKokkos <double> (x_array, num_nodes);
-    auto y  = ViewCArrayKokkos <double> (y_array, num_nodes);
-    auto z  = ViewCArrayKokkos <double> (z_array, num_nodes);
+    auto x = ViewCArrayKokkos<double>(x_array, num_nodes);
+    auto y = ViewCArrayKokkos<double>(y_array, num_nodes);
+    auto z = ViewCArrayKokkos<double>(z_array, num_nodes);
 
     // get the coordinates of the nodes(rk,elem,node) in this element
-    for (int node_lid = 0; node_lid < num_nodes; node_lid++){
+    for (int node_lid = 0; node_lid < num_nodes; node_lid++)
+    {
         x(node_lid) = node_coords(1, elem_node_gids(node_lid), 0);
         y(node_lid) = node_coords(1, elem_node_gids(node_lid), 1);
         z(node_lid) = node_coords(1, elem_node_gids(node_lid), 2);
     } // end for
 
-    double twelth = 1./12.;
-        
-    B_matrix(0,0) = ( +y(1)*( -z(2) -z(3) +z(4) +z(5) )
-                      +y(2)*( +z(1) -z(3) )
-                      +y(3)*( +z(1) +z(2) -z(4) -z(7) )
-                      +y(4)*( -z(1) +z(3) -z(5) +z(7) )
-                      +y(5)*( -z(1) +z(4) )
-                      +y(7)*( +z(3) -z(4) ) )*twelth;
+    double twelth = 1. / 12.;
 
-    B_matrix(1,0) = ( +y(0)*( +z(2) +z(3) -z(4) -z(5) )
-                      +y(2)*( -z(0) -z(3) +z(5) +z(6) )
-                      +y(3)*( -z(0) +z(2) )
-                      +y(4)*( +z(0) -z(5) )
-                      +y(5)*( +z(0) -z(2) +z(4) -z(6) )
-                      +y(6)*( -z(2) +z(5) ) )*twelth;
+    B_matrix(0, 0) = (+y(1) * (-z(2) - z(3) + z(4) + z(5) )
+                      + y(2) * (+z(1) - z(3) )
+                      + y(3) * (+z(1) + z(2) - z(4) - z(7) )
+                      + y(4) * (-z(1) + z(3) - z(5) + z(7) )
+                      + y(5) * (-z(1) + z(4) )
+                      + y(7) * (+z(3) - z(4) ) ) * twelth;
 
-    B_matrix(2,0) = ( +y(0)*( -z(1) +z(3) )
-                      +y(1)*( +z(0) +z(3) -z(5) -z(6) )
-                      +y(3)*( -z(0) -z(1) +z(6) +z(7) )
-                      +y(5)*( +z(1) -z(6) )
-                      +y(6)*( +z(1) -z(3) +z(5) -z(7) )
-                      +y(7)*( -z(3) +z(6) ) )*twelth;
+    B_matrix(1, 0) = (+y(0) * (+z(2) + z(3) - z(4) - z(5) )
+                      + y(2) * (-z(0) - z(3) + z(5) + z(6) )
+                      + y(3) * (-z(0) + z(2) )
+                      + y(4) * (+z(0) - z(5) )
+                      + y(5) * (+z(0) - z(2) + z(4) - z(6) )
+                      + y(6) * (-z(2) + z(5) ) ) * twelth;
 
-    B_matrix(3,0) = ( +y(0)*( -z(1) -z(2) +z(4) +z(7) )
-                      +y(1)*( +z(0) -z(2) )
-                      +y(2)*( +z(0) +z(1) -z(6) -z(7) )
-                      +y(4)*( -z(0) +z(7) )
-                      +y(6)*( +z(2) -z(7) )
-                      +y(7)*( -z(0) +z(2) -z(4) +z(6) ) )*twelth;
+    B_matrix(2, 0) = (+y(0) * (-z(1) + z(3) )
+                      + y(1) * (+z(0) + z(3) - z(5) - z(6) )
+                      + y(3) * (-z(0) - z(1) + z(6) + z(7) )
+                      + y(5) * (+z(1) - z(6) )
+                      + y(6) * (+z(1) - z(3) + z(5) - z(7) )
+                      + y(7) * (-z(3) + z(6) ) ) * twelth;
 
-    B_matrix(4,0) = ( +y(0)*( +z(1) -z(3) +z(5) -z(7) )
-                      +y(1)*( -z(0) +z(5) )
-                      +y(3)*( +z(0) -z(7) )
-                      +y(5)*( -z(0) -z(1) +z(6) +z(7) )
-                      +y(6)*( -z(5) +z(7) )
-                      +y(7)*( +z(0) +z(3) -z(5) -z(6) ) )*twelth;
+    B_matrix(3, 0) = (+y(0) * (-z(1) - z(2) + z(4) + z(7) )
+                      + y(1) * (+z(0) - z(2) )
+                      + y(2) * (+z(0) + z(1) - z(6) - z(7) )
+                      + y(4) * (-z(0) + z(7) )
+                      + y(6) * (+z(2) - z(7) )
+                      + y(7) * (-z(0) + z(2) - z(4) + z(6) ) ) * twelth;
 
-    B_matrix(5,0) = ( +y(0)*( +z(1) -z(4) )
-                      +y(1)*( -z(0) +z(2) -z(4) +z(6) )
-                      +y(2)*( -z(1) +z(6) )
-                      +y(4)*( +z(0) +z(1) -z(6) -z(7) )
-                      +y(6)*( -z(1) -z(2) +z(4) +z(7) )
-                      +y(7)*( +z(4) -z(6) ) )*twelth;
+    B_matrix(4, 0) = (+y(0) * (+z(1) - z(3) + z(5) - z(7) )
+                      + y(1) * (-z(0) + z(5) )
+                      + y(3) * (+z(0) - z(7) )
+                      + y(5) * (-z(0) - z(1) + z(6) + z(7) )
+                      + y(6) * (-z(5) + z(7) )
+                      + y(7) * (+z(0) + z(3) - z(5) - z(6) ) ) * twelth;
 
-    B_matrix(6,0) = ( +y(1)*( +z(2) -z(5) )
-                      +y(2)*( -z(1) +z(3) -z(5) +z(7) )
-                      +y(3)*( -z(2) +z(7) )
-                      +y(4)*( +z(5) -z(7) )
-                      +y(5)*( +z(1) +z(2) -z(4) -z(7) )
-                      +y(7)*( -z(2) -z(3) +z(4) +z(5) ) )*twelth;
+    B_matrix(5, 0) = (+y(0) * (+z(1) - z(4) )
+                      + y(1) * (-z(0) + z(2) - z(4) + z(6) )
+                      + y(2) * (-z(1) + z(6) )
+                      + y(4) * (+z(0) + z(1) - z(6) - z(7) )
+                      + y(6) * (-z(1) - z(2) + z(4) + z(7) )
+                      + y(7) * (+z(4) - z(6) ) ) * twelth;
 
-    B_matrix(7,0) = ( +y(0)*( -z(3) +z(4) )
-                      +y(2)*( +z(3) -z(6) )
-                      +y(3)*( +z(0) -z(2) +z(4) -z(6) )
-                      +y(4)*( -z(0) -z(3) +z(5) +z(6) )
-                      +y(5)*( -z(4) +z(6) )
-                      +y(6)*( +z(2) +z(3) -z(4) -z(5) ) )*twelth;
+    B_matrix(6, 0) = (+y(1) * (+z(2) - z(5) )
+                      + y(2) * (-z(1) + z(3) - z(5) + z(7) )
+                      + y(3) * (-z(2) + z(7) )
+                      + y(4) * (+z(5) - z(7) )
+                      + y(5) * (+z(1) + z(2) - z(4) - z(7) )
+                      + y(7) * (-z(2) - z(3) + z(4) + z(5) ) ) * twelth;
 
-    B_matrix(0,1) = ( +z(1)*( -x(2) -x(3) +x(4) +x(5) )
-                      +z(2)*( +x(1) -x(3) )
-                      +z(3)*( +x(1) +x(2) -x(4) -x(7) )
-                      +z(4)*( -x(1) +x(3) -x(5) +x(7) )
-                      +z(5)*( -x(1) +x(4) )
-                      +z(7)*( +x(3) -x(4) ) )*twelth;
+    B_matrix(7, 0) = (+y(0) * (-z(3) + z(4) )
+                      + y(2) * (+z(3) - z(6) )
+                      + y(3) * (+z(0) - z(2) + z(4) - z(6) )
+                      + y(4) * (-z(0) - z(3) + z(5) + z(6) )
+                      + y(5) * (-z(4) + z(6) )
+                      + y(6) * (+z(2) + z(3) - z(4) - z(5) ) ) * twelth;
 
-    B_matrix(1,1) = ( +z(0)*( +x(2) +x(3) -x(4) -x(5) )
-                      +z(2)*( -x(0) -x(3) +x(5) +x(6) )
-                      +z(3)*( -x(0) +x(2) )
-                      +z(4)*( +x(0) -x(5) )
-                      +z(5)*( +x(0) -x(2) +x(4) -x(6) )
-                      +z(6)*( -x(2) +x(5) ) )*twelth;
+    B_matrix(0, 1) = (+z(1) * (-x(2) - x(3) + x(4) + x(5) )
+                      + z(2) * (+x(1) - x(3) )
+                      + z(3) * (+x(1) + x(2) - x(4) - x(7) )
+                      + z(4) * (-x(1) + x(3) - x(5) + x(7) )
+                      + z(5) * (-x(1) + x(4) )
+                      + z(7) * (+x(3) - x(4) ) ) * twelth;
 
-    B_matrix(2,1) = ( +z(0)*( -x(1) +x(3) )
-                      +z(1)*( +x(0) +x(3) -x(5) -x(6) )
-                      +z(3)*( -x(0) -x(1) +x(6) +x(7) )
-                      +z(5)*( +x(1) -x(6) )
-                      +z(6)*( +x(1) -x(3) +x(5) -x(7) )
-                      +z(7)*( -x(3) +x(6) ) )*twelth;
+    B_matrix(1, 1) = (+z(0) * (+x(2) + x(3) - x(4) - x(5) )
+                      + z(2) * (-x(0) - x(3) + x(5) + x(6) )
+                      + z(3) * (-x(0) + x(2) )
+                      + z(4) * (+x(0) - x(5) )
+                      + z(5) * (+x(0) - x(2) + x(4) - x(6) )
+                      + z(6) * (-x(2) + x(5) ) ) * twelth;
 
-    B_matrix(3,1) = ( +z(0)*( -x(1) -x(2) +x(4) +x(7) )
-                      +z(1)*( +x(0) -x(2) )
-                      +z(2)*( +x(0) +x(1) -x(6) -x(7) )
-                      +z(4)*( -x(0) +x(7) )
-                      +z(6)*( +x(2) -x(7) )
-                      +z(7)*( -x(0) +x(2) -x(4) +x(6) ) )*twelth;
+    B_matrix(2, 1) = (+z(0) * (-x(1) + x(3) )
+                      + z(1) * (+x(0) + x(3) - x(5) - x(6) )
+                      + z(3) * (-x(0) - x(1) + x(6) + x(7) )
+                      + z(5) * (+x(1) - x(6) )
+                      + z(6) * (+x(1) - x(3) + x(5) - x(7) )
+                      + z(7) * (-x(3) + x(6) ) ) * twelth;
 
-    B_matrix(4,1) = ( +z(0)*( +x(1) -x(3) +x(5) -x(7) )
-                      +z(1)*( -x(0) +x(5) )
-                      +z(3)*( +x(0) -x(7) )
-                      +z(5)*( -x(0) -x(1) +x(6) +x(7) )
-                      +z(6)*( -x(5) +x(7) )
-                      +z(7)*( +x(0) +x(3) -x(5) -x(6) ) )*twelth;
+    B_matrix(3, 1) = (+z(0) * (-x(1) - x(2) + x(4) + x(7) )
+                      + z(1) * (+x(0) - x(2) )
+                      + z(2) * (+x(0) + x(1) - x(6) - x(7) )
+                      + z(4) * (-x(0) + x(7) )
+                      + z(6) * (+x(2) - x(7) )
+                      + z(7) * (-x(0) + x(2) - x(4) + x(6) ) ) * twelth;
 
-    B_matrix(5,1) = ( +z(0)*( +x(1) -x(4) )
-                      +z(1)*( -x(0) +x(2) -x(4) +x(6) )
-                      +z(2)*( -x(1) +x(6) )
-                      +z(4)*( +x(0) +x(1) -x(6) -x(7) )
-                      +z(6)*( -x(1) -x(2) +x(4) +x(7) )
-                      +z(7)*( +x(4) -x(6) ) )*twelth;
+    B_matrix(4, 1) = (+z(0) * (+x(1) - x(3) + x(5) - x(7) )
+                      + z(1) * (-x(0) + x(5) )
+                      + z(3) * (+x(0) - x(7) )
+                      + z(5) * (-x(0) - x(1) + x(6) + x(7) )
+                      + z(6) * (-x(5) + x(7) )
+                      + z(7) * (+x(0) + x(3) - x(5) - x(6) ) ) * twelth;
 
-    B_matrix(6,1) = ( +z(1)*( +x(2) -x(5) )
-                      +z(2)*( -x(1) +x(3) -x(5) +x(7) )
-                      +z(3)*( -x(2) +x(7) )
-                      +z(4)*( +x(5) -x(7) )
-                      +z(5)*( +x(1) +x(2) -x(4) -x(7) )
-                      +z(7)*( -x(2) -x(3) +x(4) +x(5) ) )*twelth;
+    B_matrix(5, 1) = (+z(0) * (+x(1) - x(4) )
+                      + z(1) * (-x(0) + x(2) - x(4) + x(6) )
+                      + z(2) * (-x(1) + x(6) )
+                      + z(4) * (+x(0) + x(1) - x(6) - x(7) )
+                      + z(6) * (-x(1) - x(2) + x(4) + x(7) )
+                      + z(7) * (+x(4) - x(6) ) ) * twelth;
 
-    B_matrix(7,1) = ( +z(0)*( -x(3) +x(4) )
-                      +z(2)*( +x(3) -x(6) )
-                      +z(3)*( +x(0) -x(2) +x(4) -x(6) )
-                      +z(4)*( -x(0) -x(3) +x(5) +x(6) )
-                      +z(5)*( -x(4) +x(6) )
-                      +z(6)*( +x(2) +x(3) -x(4) -x(5) ) )*twelth;
+    B_matrix(6, 1) = (+z(1) * (+x(2) - x(5) )
+                      + z(2) * (-x(1) + x(3) - x(5) + x(7) )
+                      + z(3) * (-x(2) + x(7) )
+                      + z(4) * (+x(5) - x(7) )
+                      + z(5) * (+x(1) + x(2) - x(4) - x(7) )
+                      + z(7) * (-x(2) - x(3) + x(4) + x(5) ) ) * twelth;
 
-    B_matrix(0,2) = ( +x(1)*( -y(2) -y(3) +y(4) +y(5) )
-                      +x(2)*( +y(1) -y(3) )
-                      +x(3)*( +y(1) +y(2) -y(4) -y(7) )
-                      +x(4)*( -y(1) +y(3) -y(5) +y(7) )
-                      +x(5)*( -y(1) +y(4) )
-                      +x(7)*( +y(3) -y(4) ) )*twelth;
+    B_matrix(7, 1) = (+z(0) * (-x(3) + x(4) )
+                      + z(2) * (+x(3) - x(6) )
+                      + z(3) * (+x(0) - x(2) + x(4) - x(6) )
+                      + z(4) * (-x(0) - x(3) + x(5) + x(6) )
+                      + z(5) * (-x(4) + x(6) )
+                      + z(6) * (+x(2) + x(3) - x(4) - x(5) ) ) * twelth;
 
-    B_matrix(1,2) = ( +x(0)*( +y(2) +y(3) -y(4) -y(5) )
-                      +x(2)*( -y(0) -y(3) +y(5) +y(6) )
-                      +x(3)*( -y(0) +y(2) )
-                      +x(4)*( +y(0) -y(5) )
-                      +x(5)*( +y(0) -y(2) +y(4) -y(6) )
-                      +x(6)*( -y(2) +y(5) ) )*twelth;
+    B_matrix(0, 2) = (+x(1) * (-y(2) - y(3) + y(4) + y(5) )
+                      + x(2) * (+y(1) - y(3) )
+                      + x(3) * (+y(1) + y(2) - y(4) - y(7) )
+                      + x(4) * (-y(1) + y(3) - y(5) + y(7) )
+                      + x(5) * (-y(1) + y(4) )
+                      + x(7) * (+y(3) - y(4) ) ) * twelth;
 
-    B_matrix(2,2) = ( +x(0)*( -y(1) +y(3) )
-                      +x(1)*( +y(0) +y(3) -y(5) -y(6) )
-                      +x(3)*( -y(0) -y(1) +y(6) +y(7) )
-                      +x(5)*( +y(1) -y(6) )
-                      +x(6)*( +y(1) -y(3) +y(5) -y(7) )
-                      +x(7)*( -y(3) +y(6) ) )*twelth;
+    B_matrix(1, 2) = (+x(0) * (+y(2) + y(3) - y(4) - y(5) )
+                      + x(2) * (-y(0) - y(3) + y(5) + y(6) )
+                      + x(3) * (-y(0) + y(2) )
+                      + x(4) * (+y(0) - y(5) )
+                      + x(5) * (+y(0) - y(2) + y(4) - y(6) )
+                      + x(6) * (-y(2) + y(5) ) ) * twelth;
 
-    B_matrix(3,2) = ( +x(0)*( -y(1) -y(2) +y(4) +y(7) )
-                      +x(1)*( +y(0) -y(2) )
-                      +x(2)*( +y(0) +y(1) -y(6) -y(7) )
-                      +x(4)*( -y(0) +y(7) )
-                      +x(6)*( +y(2) -y(7) )
-                      +x(7)*( -y(0) +y(2) -y(4) +y(6) ) )*twelth;
+    B_matrix(2, 2) = (+x(0) * (-y(1) + y(3) )
+                      + x(1) * (+y(0) + y(3) - y(5) - y(6) )
+                      + x(3) * (-y(0) - y(1) + y(6) + y(7) )
+                      + x(5) * (+y(1) - y(6) )
+                      + x(6) * (+y(1) - y(3) + y(5) - y(7) )
+                      + x(7) * (-y(3) + y(6) ) ) * twelth;
 
-    B_matrix(4,2) = ( +x(0)*( +y(1) -y(3) +y(5) -y(7) )
-                      +x(1)*( -y(0) +y(5) )
-                      +x(3)*( +y(0) -y(7) )
-                      +x(5)*( -y(0) -y(1) +y(6) +y(7) )
-                      +x(6)*( -y(5) +y(7) )
-                      +x(7)*( +y(0) +y(3) -y(5) -y(6) ) )*twelth;
+    B_matrix(3, 2) = (+x(0) * (-y(1) - y(2) + y(4) + y(7) )
+                      + x(1) * (+y(0) - y(2) )
+                      + x(2) * (+y(0) + y(1) - y(6) - y(7) )
+                      + x(4) * (-y(0) + y(7) )
+                      + x(6) * (+y(2) - y(7) )
+                      + x(7) * (-y(0) + y(2) - y(4) + y(6) ) ) * twelth;
 
-    B_matrix(5,2) = ( +x(0)*( +y(1) -y(4) )
-                      +x(1)*( -y(0) +y(2) -y(4) +y(6) )
-                      +x(2)*( -y(1) +y(6) )
-                      +x(4)*( +y(0) +y(1) -y(6) -y(7) )
-                      +x(6)*( -y(1) -y(2) +y(4) +y(7) )
-                      +x(7)*( +y(4) -y(6) ) )*twelth;
+    B_matrix(4, 2) = (+x(0) * (+y(1) - y(3) + y(5) - y(7) )
+                      + x(1) * (-y(0) + y(5) )
+                      + x(3) * (+y(0) - y(7) )
+                      + x(5) * (-y(0) - y(1) + y(6) + y(7) )
+                      + x(6) * (-y(5) + y(7) )
+                      + x(7) * (+y(0) + y(3) - y(5) - y(6) ) ) * twelth;
 
-    B_matrix(6,2) = ( +x(1)*( +y(2) -y(5) )
-                      +x(2)*( -y(1) +y(3) -y(5) +y(7) )
-                      +x(3)*( -y(2) +y(7) )
-                      +x(4)*( +y(5) -y(7) )
-                      +x(5)*( +y(1) +y(2) -y(4) -y(7) )
-                      +x(7)*( -y(2) -y(3) +y(4) +y(5) ) )*twelth;
+    B_matrix(5, 2) = (+x(0) * (+y(1) - y(4) )
+                      + x(1) * (-y(0) + y(2) - y(4) + y(6) )
+                      + x(2) * (-y(1) + y(6) )
+                      + x(4) * (+y(0) + y(1) - y(6) - y(7) )
+                      + x(6) * (-y(1) - y(2) + y(4) + y(7) )
+                      + x(7) * (+y(4) - y(6) ) ) * twelth;
 
-    B_matrix(7,2) = ( +x(0)*( -y(3) +y(4) )
-                      +x(2)*( +y(3) -y(6) )
-                      +x(3)*( +y(0) -y(2) +y(4) -y(6) )
-                      +x(4)*( -y(0) -y(3) +y(5) +y(6) )
-                      +x(5)*( -y(4) +y(6) )
-                      +x(6)*( +y(2) +y(3) -y(4) -y(5) ) )*twelth;
+    B_matrix(6, 2) = (+x(1) * (+y(2) - y(5) )
+                      + x(2) * (-y(1) + y(3) - y(5) + y(7) )
+                      + x(3) * (-y(2) + y(7) )
+                      + x(4) * (+y(5) - y(7) )
+                      + x(5) * (+y(1) + y(2) - y(4) - y(7) )
+                      + x(7) * (-y(2) - y(3) + y(4) + y(5) ) ) * twelth;
 
+    B_matrix(7, 2) = (+x(0) * (-y(3) + y(4) )
+                      + x(2) * (+y(3) - y(6) )
+                      + x(3) * (+y(0) - y(2) + y(4) - y(6) )
+                      + x(4) * (-y(0) - y(3) + y(5) + y(6) )
+                      + x(5) * (-y(4) + y(6) )
+                      + x(6) * (+y(2) + y(3) - y(4) - y(5) ) ) * twelth;
 } // end subroutine
 
-
-
-void get_vol(const DViewCArrayKokkos <double> &elem_vol,
-             const DViewCArrayKokkos <double> &node_coords,
-             const mesh_t &mesh){
-    
+void
+get_vol(const DViewCArrayKokkos<double>& elem_vol,
+        const DViewCArrayKokkos<double>& node_coords,
+        const mesh_t&                    mesh)
+{
     const size_t num_dims = mesh.num_dims;
-    
-    if (num_dims == 2){
+
+    if (num_dims == 2)
+    {
         FOR_ALL(elem_gid, 0, mesh.num_elems, {
-            
             // cut out the node_gids for this element
-            ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
+            ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
             get_vol_quad(elem_vol, elem_gid, node_coords, elem_node_gids);
-            
         });
         Kokkos::fence();
     }
-    else {
+    else
+    {
         FOR_ALL(elem_gid, 0, mesh.num_elems, {
-            
             // cut out the node_gids for this element
-            ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
+            ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
             get_vol_hex(elem_vol, elem_gid, node_coords, elem_node_gids);
-            
         });
         Kokkos::fence();
     } // end if
-    
-    return;
-    
-} // end subroutine
 
+    return;
+} // end subroutine
 
 // Exact volume for a hex element
 KOKKOS_FUNCTION
-void get_vol_hex(const DViewCArrayKokkos <double> &elem_vol,
-                 const size_t elem_gid,
-                 const DViewCArrayKokkos <double> &node_coords,
-                 const ViewCArrayKokkos <size_t>  &elem_node_gids){
-
+void
+get_vol_hex(const DViewCArrayKokkos<double>& elem_vol,
+            const size_t                     elem_gid,
+            const DViewCArrayKokkos<double>& node_coords,
+            const ViewCArrayKokkos<size_t>&  elem_node_gids)
+{
     const size_t num_nodes = 8;
 
     double x_array[8];
     double y_array[8];
     double z_array[8];
-    
+
     // x, y, z coordinates of elem vertices
-    auto x  = ViewCArrayKokkos <double> (x_array, num_nodes);
-    auto y  = ViewCArrayKokkos <double> (y_array, num_nodes);
-    auto z  = ViewCArrayKokkos <double> (z_array, num_nodes);
-    
+    auto x = ViewCArrayKokkos<double>(x_array, num_nodes);
+    auto y = ViewCArrayKokkos<double>(y_array, num_nodes);
+    auto z = ViewCArrayKokkos<double>(z_array, num_nodes);
+
     // get the coordinates of the nodes(rk,elem,node) in this element
-    for (int node_lid = 0; node_lid < num_nodes; node_lid++){
+    for (int node_lid = 0; node_lid < num_nodes; node_lid++)
+    {
         x(node_lid) = node_coords(1, elem_node_gids(node_lid), 0);
         y(node_lid) = node_coords(1, elem_node_gids(node_lid), 1);
         z(node_lid) = node_coords(1, elem_node_gids(node_lid), 2);
     } // end for
 
-    double twelth = 1./12.;
-        
+    double twelth = 1. / 12.;
+
     // element volume
     elem_vol(elem_gid) =
-        (x(1)*(y(3)*(-z(0) + z(2)) + y(4)*( z(0) - z(5)) + y(0)*(z(2) + z(3) - z(4) - z(5)) + y(6)*(-z(2) + z(5)) + y(5)*(z(0) - z(2) + z(4) - z(6)) + y(2)*(-z(0) - z(3) + z(5) + z(6))) +
-         x(7)*(y(0)*(-z(3) + z(4)) + y(6)*( z(2) + z(3)  - z(4) - z(5)) + y(2)*(z(3) - z(6)) + y(3)*(z(0) - z(2) + z(4) - z(6)) + y(5)*(-z(4) + z(6)) + y(4)*(-z(0) - z(3) + z(5) + z(6))) +
-         x(3)*(y(1)*( z(0) - z(2)) + y(7)*(-z(0) + z(2)  - z(4) + z(6)) + y(6)*(z(2) - z(7)) + y(2)*(z(0) + z(1) - z(6) - z(7)) + y(4)*(-z(0) + z(7)) + y(0)*(-z(1) - z(2) + z(4) + z(7))) +
-         x(5)*(y(0)*( z(1) - z(4)) + y(7)*( z(4) - z(6)) + y(2)*(-z(1) + z(6)) + y(1)*(-z(0) + z(2) - z(4) + z(6)) + y(4)*(z(0) + z(1) - z(6) - z(7)) + y(6)*(-z(1) - z(2) + z(4) + z(7))) +
-         x(6)*(y(1)*( z(2) - z(5)) + y(7)*(-z(2) - z(3)  + z(4) + z(5)) + y(5)*(z(1) + z(2) - z(4) - z(7)) + y(4)*(z(5) - z(7)) + y(3)*(-z(2) + z(7)) + y(2)*(-z(1) + z(3) - z(5) + z(7))) +
-         x(0)*(y(2)*( z(1) - z(3)) + y(7)*( z(3) - z(4)) + y(5)*(-z(1) + z(4)) + y(1)*(-z(2) - z(3) + z(4) + z(5)) + y(3)*(z(1) + z(2) - z(4) - z(7)) + y(4)*(-z(1) + z(3) - z(5) + z(7))) +
-         x(2)*(y(0)*(-z(1) + z(3)) + y(5)*( z(1) - z(6)) + y(1)*(z(0) + z(3) - z(5) - z(6)) + y(7)*(-z(3) + z(6)) + y(6)*(z(1) - z(3) + z(5) - z(7)) + y(3)*(-z(0) - z(1) + z(6) + z(7))) +
-         x(4)*(y(1)*(-z(0) + z(5)) + y(7)*( z(0) + z(3)  - z(5) - z(6)) + y(3)*(z(0) - z(7)) + y(0)*(z(1) - z(3) + z(5) - z(7)) + y(6)*(-z(5) + z(7)) + y(5)*(-z(0) - z(1) + z(6) + z(7))))*twelth;
+        (x(1) * (y(3) * (-z(0) + z(2)) + y(4) * (z(0) - z(5)) + y(0) * (z(2) + z(3) - z(4) - z(5)) + y(6) * (-z(2) + z(5)) + y(5) * (z(0) - z(2) + z(4) - z(6)) + y(2) * (-z(0) - z(3) + z(5) + z(6))) +
+         x(7) * (y(0) * (-z(3) + z(4)) + y(6) * (z(2) + z(3) - z(4) - z(5)) + y(2) * (z(3) - z(6)) + y(3) * (z(0) - z(2) + z(4) - z(6)) + y(5) * (-z(4) + z(6)) + y(4) * (-z(0) - z(3) + z(5) + z(6))) +
+         x(3) * (y(1) * (z(0) - z(2)) + y(7) * (-z(0) + z(2) - z(4) + z(6)) + y(6) * (z(2) - z(7)) + y(2) * (z(0) + z(1) - z(6) - z(7)) + y(4) * (-z(0) + z(7)) + y(0) * (-z(1) - z(2) + z(4) + z(7))) +
+         x(5) * (y(0) * (z(1) - z(4)) + y(7) * (z(4) - z(6)) + y(2) * (-z(1) + z(6)) + y(1) * (-z(0) + z(2) - z(4) + z(6)) + y(4) * (z(0) + z(1) - z(6) - z(7)) + y(6) * (-z(1) - z(2) + z(4) + z(7))) +
+         x(6) * (y(1) * (z(2) - z(5)) + y(7) * (-z(2) - z(3) + z(4) + z(5)) + y(5) * (z(1) + z(2) - z(4) - z(7)) + y(4) * (z(5) - z(7)) + y(3) * (-z(2) + z(7)) + y(2) * (-z(1) + z(3) - z(5) + z(7))) +
+         x(0) * (y(2) * (z(1) - z(3)) + y(7) * (z(3) - z(4)) + y(5) * (-z(1) + z(4)) + y(1) * (-z(2) - z(3) + z(4) + z(5)) + y(3) * (z(1) + z(2) - z(4) - z(7)) + y(4) * (-z(1) + z(3) - z(5) + z(7))) +
+         x(2) * (y(0) * (-z(1) + z(3)) + y(5) * (z(1) - z(6)) + y(1) * (z(0) + z(3) - z(5) - z(6)) + y(7) * (-z(3) + z(6)) + y(6) * (z(1) - z(3) + z(5) - z(7)) + y(3) * (-z(0) - z(1) + z(6) + z(7))) +
+         x(4) *
+         (y(1) * (-z(0) + z(5)) + y(7) * (z(0) + z(3) - z(5) - z(6)) + y(3) * (z(0) - z(7)) + y(0) * (z(1) - z(3) + z(5) - z(7)) + y(6) * (-z(5) + z(7)) + y(5) * (-z(0) - z(1) + z(6) + z(7)))) *
+        twelth;
 
     return;
-    
 } // end subroutine
 
-
-
 KOKKOS_FUNCTION
-void get_bmatrix2D(const ViewCArrayKokkos <double> &B_matrix,
-                   const size_t elem_gid,
-                   const DViewCArrayKokkos <double> &node_coords,
-                   const ViewCArrayKokkos <size_t>  &elem_node_gids){
-
+void
+get_bmatrix2D(const ViewCArrayKokkos<double>&  B_matrix,
+              const size_t                     elem_gid,
+              const DViewCArrayKokkos<double>& node_coords,
+              const ViewCArrayKokkos<size_t>&  elem_node_gids)
+{
     const size_t num_nodes = 4;
 
     double x_array[4];
     double y_array[4];
-    
+
     // x, y coordinates of elem vertices
-    auto x  = ViewCArrayKokkos <double> (x_array, num_nodes);
-    auto y  = ViewCArrayKokkos <double> (y_array, num_nodes);
+    auto x = ViewCArrayKokkos<double>(x_array, num_nodes);
+    auto y = ViewCArrayKokkos<double>(y_array, num_nodes);
 
     // get the coordinates of the nodes(rk,elem,node) in this element
-    for (int node_lid = 0; node_lid < num_nodes; node_lid++){
+    for (int node_lid = 0; node_lid < num_nodes; node_lid++)
+    {
         x(node_lid) = node_coords(1, elem_node_gids(node_lid), 0);
         y(node_lid) = node_coords(1, elem_node_gids(node_lid), 1);
     } // end for
@@ -335,26 +331,23 @@ void get_bmatrix2D(const ViewCArrayKokkos <double> &B_matrix,
     /* ensight node order   0 1 2 3
        Flanaghan node order 3 4 1 2
     */
-    
-    
-    B_matrix(0,0) = -0.5*(y(3)-y(1));
-                  
-    B_matrix(1,0) = -0.5*(y(0)-y(2));
-                  
-    B_matrix(2,0) = -0.5*(y(1)-y(3));
-                  
-    B_matrix(3,0) = -0.5*(y(2)-y(0));
-                 
 
-    B_matrix(0,1) = -0.5*(x(1)-x(3));
-                 
-    B_matrix(1,1) = -0.5*(x(2)-x(0));
-                  
-    B_matrix(2,1) = -0.5*(x(3)-x(1));
-                  
-    B_matrix(3,1) = -0.5*(x(0)-x(2));
+    B_matrix(0, 0) = -0.5 * (y(3) - y(1));
 
-    
+    B_matrix(1, 0) = -0.5 * (y(0) - y(2));
+
+    B_matrix(2, 0) = -0.5 * (y(1) - y(3));
+
+    B_matrix(3, 0) = -0.5 * (y(2) - y(0));
+
+    B_matrix(0, 1) = -0.5 * (x(1) - x(3));
+
+    B_matrix(1, 1) = -0.5 * (x(2) - x(0));
+
+    B_matrix(2, 1) = -0.5 * (x(3) - x(1));
+
+    B_matrix(3, 1) = -0.5 * (x(0) - x(2));
+
     //
     /*
      The Flanagan and Belytschko paper has:
@@ -363,65 +356,63 @@ void get_bmatrix2D(const ViewCArrayKokkos <double> &B_matrix,
        node 2: 0.5*(y3 - y1)  ,  0.5*(x1 - x3)
        node 3: 0.5*(y4 - y2)  ,  0.5*(x2 - x4)
        node 4: 0.5*(y1 - y3)  ,  0.5*(x3 - x1)
-     
+
      Ensight order would be
-     
+
        node 2: 0.5*(y3 - y1)  ,  0.5*(x1 - x3)
        node 3: 0.5*(y0 - y2)  ,  0.5*(x2 - x0)
        node 0: 0.5*(y1 - y3)  ,  0.5*(x3 - x1)
        node 1: 0.5*(y2 - y0)  ,  0.5*(x0 - x2)
-     
+
      */
 
     return;
-    
 } // end subroutine
-
 
 // true volume of a quad in RZ coords
 KOKKOS_FUNCTION
-void get_vol_quad(const DViewCArrayKokkos <double> &elem_vol,
-                  const size_t elem_gid,
-                  const DViewCArrayKokkos <double> &node_coords,
-                  const ViewCArrayKokkos <size_t>  &elem_node_gids){
-
-    
+void
+get_vol_quad(const DViewCArrayKokkos<double>& elem_vol,
+             const size_t                     elem_gid,
+             const DViewCArrayKokkos<double>& node_coords,
+             const ViewCArrayKokkos<size_t>&  elem_node_gids)
+{
     // --- testing here ---
     /*
     double test_vol = 0.0;
     // getting the corner facial area
     double corner_areas_array[4];
     ViewCArrayKokkos <double> corner_areas(&corner_areas_array[0],4);
-    
+
     get_area_weights2D(corner_areas,
                        elem_gid,
                        node_coords,
                        elem_node_gids);
 
-    
+
     for(size_t node_lid=0; node_lid<4; node_lid++){
         double y = node_coords(1, elem_node_gids(node_lid), 1);  // node radius
         test_vol += corner_areas(node_lid)*y;
     } // end for
-     
+
      test_vol matches the Barlow volume formula
     */
     // -------------------
-    
-    
+
     elem_vol(elem_gid) = 0.0;
-    
+
     const size_t num_nodes = 4;
 
     double x_array[4];
     double y_array[4];
-    
+
     // x, y coordinates of elem vertices
-    auto x  = ViewCArrayKokkos <double> (x_array, num_nodes);
-    auto y  = ViewCArrayKokkos <double> (y_array, num_nodes);
-     
+    auto x = ViewCArrayKokkos<double>(x_array, num_nodes);
+    auto y = ViewCArrayKokkos<double>(y_array, num_nodes);
+
     // get the coordinates of the nodes(rk,elem,node) in this element
-    for (int node_lid = 0; node_lid < num_nodes; node_lid++){
+    for (int node_lid = 0; node_lid < num_nodes; node_lid++)
+    {
         x(node_lid) = node_coords(1, elem_node_gids(node_lid), 0);
         y(node_lid) = node_coords(1, elem_node_gids(node_lid), 1);
     } // end for
@@ -430,33 +421,33 @@ void get_vol_quad(const DViewCArrayKokkos <double> &elem_vol,
        Flanaghan node order 3 4 1 2
     */
     elem_vol(elem_gid) =
-           ( (y(2)+y(3)+y(0))*((y(2)-y(3))*(x(0)-x(3))-(y(0)-y(3))*(x(2)-x(3)) )
-          +  (y(0)+y(1)+y(2))*((y(0)-y(1))*(x(2)-x(1))-(y(2)-y(1))*(x(0)-x(1))) )/6.0;
+        ( (y(2) + y(3) + y(0)) * ((y(2) - y(3)) * (x(0) - x(3)) - (y(0) - y(3)) * (x(2) - x(3)) )
+          + (y(0) + y(1) + y(2)) * ((y(0) - y(1)) * (x(2) - x(1)) - (y(2) - y(1)) * (x(0) - x(1))) ) / 6.0;
 
     return;
-    
 } // end subroutine
-
 
 // element facial area
 KOKKOS_FUNCTION
-double get_area_quad(const size_t elem_gid,
-                     const DViewCArrayKokkos <double> &node_coords,
-                     const ViewCArrayKokkos <size_t>  &elem_node_gids){
+double
+get_area_quad(const size_t                     elem_gid,
+              const DViewCArrayKokkos<double>& node_coords,
+              const ViewCArrayKokkos<size_t>&  elem_node_gids)
+{
+    double elem_area = 0.0;
 
-    double elem_area=0.0;
-    
     const size_t num_nodes = 4;
 
     double x_array[4];
     double y_array[4];
-    
+
     // x, y coordinates of elem vertices
-    auto x  = ViewCArrayKokkos <double> (x_array, num_nodes);
-    auto y  = ViewCArrayKokkos <double> (y_array, num_nodes);
-     
+    auto x = ViewCArrayKokkos<double>(x_array, num_nodes);
+    auto y = ViewCArrayKokkos<double>(y_array, num_nodes);
+
     // get the coordinates of the nodes(rk,elem,node) in this element
-    for (int node_lid = 0; node_lid < num_nodes; node_lid++){
+    for (int node_lid = 0; node_lid < num_nodes; node_lid++)
+    {
         x(node_lid) = node_coords(1, elem_node_gids(node_lid), 0);
         y(node_lid) = node_coords(1, elem_node_gids(node_lid), 1);
     } // end for
@@ -464,85 +455,80 @@ double get_area_quad(const size_t elem_gid,
     /* ensight node order   0 1 2 3
        Flanaghan node order 3 4 1 2
     */
-    
+
     // element facial area
-    elem_area = 0.5*((x(0)-x(2))*(y(1)-y(3))+(x(3)-x(1))*(y(0)-y(2)));
+    elem_area = 0.5 * ((x(0) - x(2)) * (y(1) - y(3)) + (x(3) - x(1)) * (y(0) - y(2)));
 
     return elem_area;
-    
 } // end subroutine
 
-
 KOKKOS_FUNCTION
-double heron(const double x1,
-             const double y1,
-             const double x2,
-             const double y2,
-             const double x3,
-             const double y3)
+double
+heron(const double x1,
+      const double y1,
+      const double x2,
+      const double y2,
+      const double x3,
+      const double y3)
 {
-  double S,a,b,c,area;
+    double S, a, b, c, area;
 
-  S=0.0;
-  a=sqrt((x2-x1)*(x2-x1)+(y2-y1)*(y2-y1));
-  S+=a;
-  b=sqrt((x3-x2)*(x3-x2)+(y3-y2)*(y3-y2));
-  S+=b;
-  c=sqrt((x3-x1)*(x3-x1)+(y3-y1)*(y3-y1));
-  S+=c;
+    S  = 0.0;
+    a  = sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+    S += a;
+    b  = sqrt((x3 - x2) * (x3 - x2) + (y3 - y2) * (y3 - y2));
+    S += b;
+    c  = sqrt((x3 - x1) * (x3 - x1) + (y3 - y1) * (y3 - y1));
+    S += c;
 
-  S*=0.5;
-  area=sqrt(S*(S-a)*(S-b)*(S-c));
+    S   *= 0.5;
+    area = sqrt(S * (S - a) * (S - b) * (S - c));
 
-  return area;
+    return area;
 }
-  
-  
 
 KOKKOS_FUNCTION
-void get_area_weights2D(const ViewCArrayKokkos <double> &corner_areas,
-                        const size_t elem_gid,
-                        const DViewCArrayKokkos <double> &node_coords,
-                        const ViewCArrayKokkos <size_t>  &elem_node_gids){
-
+void
+get_area_weights2D(const ViewCArrayKokkos<double>&  corner_areas,
+                   const size_t                     elem_gid,
+                   const DViewCArrayKokkos<double>& node_coords,
+                   const ViewCArrayKokkos<size_t>&  elem_node_gids)
+{
     const size_t num_nodes = 4;
 
     double x_array[4];
     double y_array[4];
 
-    double rc,zc;
-    double A12,A23,A34,A41;
-    
+    double rc, zc;
+    double A12, A23, A34, A41;
+
     // x, y coordinates of elem vertices
-    ViewCArrayKokkos <double> x(x_array, num_nodes);
-    ViewCArrayKokkos <double> y(y_array, num_nodes);
+    ViewCArrayKokkos<double> x(x_array, num_nodes);
+    ViewCArrayKokkos<double> y(y_array, num_nodes);
 
     // get the coordinates of the nodes(rk,elem,node) in this element
-    rc=zc=0.0;
-    for (int node_lid = 0; node_lid < num_nodes; node_lid++){
+    rc = zc = 0.0;
+    for (int node_lid = 0; node_lid < num_nodes; node_lid++)
+    {
         x(node_lid) = node_coords(1, elem_node_gids(node_lid), 0);
         y(node_lid) = node_coords(1, elem_node_gids(node_lid), 1);
-    rc+=0.25*y(node_lid);
-    zc+=0.25*x(node_lid);
+        rc += 0.25 * y(node_lid);
+        zc += 0.25 * x(node_lid);
     } // end for
 
     /* ensight node order   0 1 2 3
        Barlow node order    1 2 3 4
     */
-    
-    A12 = heron(x(0),y(0),zc,rc,x(1),y(1));
-    A23 = heron(x(1),y(1),zc,rc,x(2),y(2));
-    A34 = heron(x(2),y(2),zc,rc,x(3),y(3));
-    A41 = heron(x(3),y(3),zc,rc,x(0),y(0));
 
-    corner_areas(0)=(5.*A41+5.*A12+A23+A34)/12.;
-    corner_areas(1)=(A41+5.*A12+5.*A23+A34)/12.;
-    corner_areas(2)=(A41+A12+5.*A23+5.*A34)/12.;
-    corner_areas(3)=(5.*A41+A12+A23+5.*A34)/12.;
+    A12 = heron(x(0), y(0), zc, rc, x(1), y(1));
+    A23 = heron(x(1), y(1), zc, rc, x(2), y(2));
+    A34 = heron(x(2), y(2), zc, rc, x(3), y(3));
+    A41 = heron(x(3), y(3), zc, rc, x(0), y(0));
 
-
+    corner_areas(0) = (5. * A41 + 5. * A12 + A23 + A34) / 12.;
+    corner_areas(1) = (A41 + 5. * A12 + 5. * A23 + A34) / 12.;
+    corner_areas(2) = (A41 + A12 + 5. * A23 + 5. * A34) / 12.;
+    corner_areas(3) = (5. * A41 + A12 + A23 + 5. * A34) / 12.;
 
     return;
-    
 } // end subroutine
-

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/input.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/input.cpp
@@ -46,25 +46,24 @@ test::setup test_problem;
 // -----------------------------------------------------------------------------
 // The user must input their parameters inside this function
 // ------------------------------------------------------------------------------
-void
-input(CArrayKokkos<material_t>& material,
-      CArrayKokkos<mat_fill_t>& mat_fill,
-      CArrayKokkos<boundary_t>& boundary,
-      CArrayKokkos<double>&     state_vars,
-      size_t&                   num_materials,
-      size_t&                   num_fills,
-      size_t&                   num_bcs,
-      size_t&                   num_dims,
-      size_t&                   max_num_state_vars,
-      double&                   dt_start,
-      double&                   time_final,
-      double&                   dt_max,
-      double&                   dt_min,
-      double&                   dt_cfl,
-      double&                   graphics_dt_ival,
-      size_t&                   graphics_cyc_ival,
-      size_t&                   cycle_stop,
-      size_t&                   rk_num_stages)
+void input(CArrayKokkos<material_t>& material,
+           CArrayKokkos<mat_fill_t>& mat_fill,
+           CArrayKokkos<boundary_t>& boundary,
+           CArrayKokkos<double>&     state_vars,
+           size_t&                   num_materials,
+           size_t&                   num_fills,
+           size_t&                   num_bcs,
+           size_t&                   num_dims,
+           size_t&                   max_num_state_vars,
+           double&                   dt_start,
+           double&                   time_final,
+           double&                   dt_max,
+           double&                   dt_min,
+           double&                   dt_cfl,
+           double&                   graphics_dt_ival,
+           size_t&                   graphics_cyc_ival,
+           size_t&                   cycle_stop,
+           size_t&                   rk_num_stages)
 {
     // Dimensions
     num_dims = 3;

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/input.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/input.cpp
@@ -1,11 +1,10 @@
-                                                           
+
 // -----------------------------------------------------------------------------
 // This code is the input file
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include "matar.h"
 #include "state.h"
 #include "mesh.h"
-
 
 // Problem choice:
 //     sedov 3D and RZ
@@ -20,100 +19,93 @@
 //     Taylor Anvil
 namespace test
 {
-    
-    // applying initial conditions
-    enum setup
-    {
-        none = 0,
-        Sedov3D = 1,
-        SedovRZ = 2,
-        
-        Noh3D = 3,
-        NohRZ = 4,
-        
-        SodZ = 5,
-        Sod3DX = 6,
-        Sod3DY = 7,
-        Sod3DZ = 8,
-        
-        TriplePoint = 9,
-        TaylorAnvil = 10,
-        
-        box = 11,
-    };
-    
+// applying initial conditions
+enum setup
+{
+    none = 0,
+    Sedov3D = 1,
+    SedovRZ = 2,
+
+    Noh3D = 3,
+    NohRZ = 4,
+
+    SodZ = 5,
+    Sod3DX = 6,
+    Sod3DY = 7,
+    Sod3DZ = 8,
+
+    TriplePoint = 9,
+    TaylorAnvil = 10,
+
+    box = 11,
+};
 } // end of initial conditions namespace
 
 test::setup test_problem;
 
 // -----------------------------------------------------------------------------
 // The user must input their parameters inside this function
-//------------------------------------------------------------------------------
-void input(CArrayKokkos <material_t> &material,
-           CArrayKokkos <mat_fill_t> &mat_fill,
-           CArrayKokkos <boundary_t> &boundary,
-           CArrayKokkos <double> &state_vars,
-           size_t &num_materials,
-           size_t &num_fills,
-           size_t &num_bcs,
-           size_t &num_dims,
-           size_t &max_num_state_vars,
-           double &dt_start,
-           double &time_final,
-           double &dt_max,
-           double &dt_min,
-           double &dt_cfl,
-           double &graphics_dt_ival,
-           size_t &graphics_cyc_ival,
-           size_t &cycle_stop,
-           size_t &rk_num_stages){
-    
+// ------------------------------------------------------------------------------
+void
+input(CArrayKokkos<material_t>& material,
+      CArrayKokkos<mat_fill_t>& mat_fill,
+      CArrayKokkos<boundary_t>& boundary,
+      CArrayKokkos<double>&     state_vars,
+      size_t&                   num_materials,
+      size_t&                   num_fills,
+      size_t&                   num_bcs,
+      size_t&                   num_dims,
+      size_t&                   max_num_state_vars,
+      double&                   dt_start,
+      double&                   time_final,
+      double&                   dt_max,
+      double&                   dt_min,
+      double&                   dt_cfl,
+      double&                   graphics_dt_ival,
+      size_t&                   graphics_cyc_ival,
+      size_t&                   cycle_stop,
+      size_t&                   rk_num_stages)
+{
     // Dimensions
     num_dims = 3;
-    
+
     // ---- time varaibles and cycle info ----
     time_final = 1.0;  // 1.0 for Sedov
-    dt_min = 1.e-8;
-    dt_max = 1.e-2;
-    dt_start = 1.e-5;
+    dt_min     = 1.e-8;
+    dt_max     = 1.e-2;
+    dt_start   = 1.e-5;
     cycle_stop = 100000;
-
 
     // ---- graphics information ----
     graphics_cyc_ival = 1000000;
     graphics_dt_ival  = 0.25;
 
-    
     // --- number of material regions ---
     num_materials = 1;
-    material = CArrayKokkos <material_t> (num_materials); // create material
-    
-    
+    material      = CArrayKokkos<material_t>(num_materials); // create material
+
     // --- declare model state variable array size ---
     max_num_state_vars = 6;  // it is a memory block
-    state_vars = CArrayKokkos <double> (num_materials, max_num_state_vars); // init values
-    
-    
+    state_vars = CArrayKokkos<double>(num_materials, max_num_state_vars); // init values
+
     // --- number of fill regions ---
     num_fills = 2;  // =2 for Sedov
-    mat_fill = CArrayKokkos <mat_fill_t> (num_fills); // create fills
-    
-    
+    mat_fill  = CArrayKokkos<mat_fill_t>(num_fills);  // create fills
+
     // --- number of boundary conditions ---
-    num_bcs=6;  // =6 for Sedov
-    boundary = CArrayKokkos <boundary_t> (num_bcs);  // create boundaries
-    
+    num_bcs  = 6; // =6 for Sedov
+    boundary = CArrayKokkos<boundary_t>(num_bcs);  // create boundaries
+
     // --- test problems ---
     test_problem = test::Sedov3D;
-    
-    
+
     // ---- fill instructions and intial conditions ---- //
 
-    
     // Sedov blast wave test case
-    if (test_problem == test::Sedov3D){
+    if (test_problem == test::Sedov3D)
+    {
         time_final = 1.0;  // 1.0 for Sedov
-        
+
         RUN({
             // gamma law model
             // statev(0) = gamma
@@ -122,89 +114,85 @@ void input(CArrayKokkos <material_t> &material,
             // statev(3) = ref temperature
             // statev(4) = ref density
             // statev(5) = ref specific internal energy
-            
+
             material(0).eos_model = ideal_gas; // EOS model is required
-            
-            material(0).strength_type = model::none;
+
+            material(0).strength_type  = model::none;
             material(0).strength_setup = model_init::input; // not need, the input is the default
             material(0).strength_model = NULL;  // not needed, but illistrates the syntax
-            
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
+
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
             material(0).num_state_vars = 3;  // actual num_state_vars
-            state_vars(0,0) = 5.0/3.0; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat
-            
+            state_vars(0, 0) = 5.0 / 3.0; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat
+
             // global initial conditions
             mat_fill(0).volume = region::global; // fill everywhere
             mat_fill(0).mat_id = 0;              // material id
-            mat_fill(0).den = 1.0;               // intial density
-            mat_fill(0).sie = 1.e-10;            // intial specific internal energy
-            
+            mat_fill(0).den    = 1.0;            // intial density
+            mat_fill(0).sie    = 1.e-10;         // intial specific internal energy
+
             mat_fill(0).velocity = init_conds::cartesian;
             mat_fill(0).u = 0.0;   // initial x-dir velocity
             mat_fill(0).v = 0.0;   // initial y-dir velocity
             mat_fill(0).w = 0.0;   // initial z-dir velocity
-            
+
             // energy source initial conditions
-            mat_fill(1).volume = region::sphere; // fill a sphere
-            mat_fill(1).mat_id = 0;              // material id
+            mat_fill(1).volume  = region::sphere; // fill a sphere
+            mat_fill(1).mat_id  = 0;             // material id
             mat_fill(1).radius1 = 0.0;           // inner radius of fill region
-            mat_fill(1).radius2 = 1.2/8.0;       // outer radius of fill region
-            mat_fill(1).den = 1.0;               // initial density
-            mat_fill(1).sie = (963.652344*
-                               pow((1.2/30.0),3))/pow((mat_fill(1).radius2),3);
-            
+            mat_fill(1).radius2 = 1.2 / 16.0;       // outer radius of fill region
+            mat_fill(1).den     = 1.0;           // initial density
+            mat_fill(1).sie     = (963.652344 *
+                                   pow((1.2 / 30.0), 3)) / pow((mat_fill(1).radius2), 3);
+
             mat_fill(1).velocity = init_conds::cartesian;
             mat_fill(1).u = 0.0;   // initial x-dir velocity
             mat_fill(1).v = 0.0;   // initial y-dir velocity
             mat_fill(1).w = 0.0;   // initial z-dir velocity
 
-
-
             // ---- boundary conditions ---- //
-            
-            // Tag X plane
-            boundary(0).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(0).value = 0.0;
-            boundary(0).hydro_bc = bdy::reflected;
-            
-            // Tag Y plane
-            boundary(1).surface = bdy::y_plane;
-            boundary(1).value = 0.0;
-            boundary(1).hydro_bc = bdy::reflected;
-            
-            // Tag Z plane
-            boundary(2).surface = bdy::z_plane;
-            boundary(2).value = 0.0;
-            boundary(2).hydro_bc = bdy::reflected;
-            
-            
-            // Tag X plane
-            boundary(3).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(3).value = 1.2;
-            boundary(3).hydro_bc = bdy::reflected;
-            
-            // Tag Y plane
-            boundary(4).surface = bdy::y_plane;
-            boundary(4).value = 1.2;
-            boundary(4).hydro_bc = bdy::reflected;
-            
-            // Tag Z plane
-            boundary(5).surface = bdy::z_plane;
-            boundary(5).value = 1.2;
-            boundary(5).hydro_bc = bdy::reflected;
-            
-        });  // end RUN
 
+            // Tag X plane
+            boundary(0).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(0).value    = 0.0;
+            boundary(0).hydro_bc = bdy::reflected;
+
+            // Tag Y plane
+            boundary(1).surface  = bdy::y_plane;
+            boundary(1).value    = 0.0;
+            boundary(1).hydro_bc = bdy::reflected;
+
+            // Tag Z plane
+            boundary(2).surface  = bdy::z_plane;
+            boundary(2).value    = 0.0;
+            boundary(2).hydro_bc = bdy::reflected;
+
+            // Tag X plane
+            boundary(3).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(3).value    = 1.2;
+            boundary(3).hydro_bc = bdy::reflected;
+
+            // Tag Y plane
+            boundary(4).surface  = bdy::y_plane;
+            boundary(4).value    = 1.2;
+            boundary(4).hydro_bc = bdy::reflected;
+
+            // Tag Z plane
+            boundary(5).surface  = bdy::z_plane;
+            boundary(5).value    = 1.2;
+            boundary(5).hydro_bc = bdy::reflected;
+        });  // end RUN
     } // end if Sedov
-    
+
     // 2D RZ Sedov blast wave test case
-    if (test_problem == test::SedovRZ){
+    if (test_problem == test::SedovRZ)
+    {
         time_final = 1.0;  // 1.0 for Sedov
         RUN({
             // gamma law model
@@ -214,189 +202,173 @@ void input(CArrayKokkos <material_t> &material,
             // statev(3) = ref temperature
             // statev(4) = ref density
             // statev(5) = ref specific internal energy
-            
+
             material(0).eos_model = ideal_gas; // EOS model is required
-            
+
             material(0).strength_type  = model::none;
             material(0).strength_model = NULL;  // not needed, but illistrates the syntax
-            
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
+
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
             material(0).num_state_vars = 3;  // actual num_state_vars
-            state_vars(0,0) = 5.0/3.0; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat
-            
+            state_vars(0, 0) = 5.0 / 3.0; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat
+
             // global initial conditions
             mat_fill(0).volume = region::global; // fill everywhere
             mat_fill(0).mat_id = 0;              // material id
-            mat_fill(0).den = 1.0;               // intial density
-            mat_fill(0).sie = 1.e-10;            // intial specific internal energy
-            
+            mat_fill(0).den    = 1.0;            // intial density
+            mat_fill(0).sie    = 1.e-10;         // intial specific internal energy
+
             mat_fill(0).velocity = init_conds::cartesian;
             mat_fill(0).u = 0.0;   // initial x-dir velocity
             mat_fill(0).v = 0.0;   // initial y-dir velocity
             mat_fill(0).w = 0.0;   // initial z-dir velocity
-            
+
             // energy source initial conditions
-            mat_fill(1).volume = region::sphere; // fill a sphere
-            mat_fill(1).mat_id = 0;              // material id
+            mat_fill(1).volume  = region::sphere; // fill a sphere
+            mat_fill(1).mat_id  = 0;             // material id
             mat_fill(1).radius1 = 0.0;           // inner radius of fill region
-            mat_fill(1).radius2 = 1.2/8.0;       // outer radius of fill region
-            mat_fill(1).den = 1.0;               // initial density
-            double vol = PI*( pow((mat_fill(1).radius2),3)
-                            - pow((mat_fill(1).radius1),3) );
-            //vol = 4./3.* PI * ( pow((mat_fill(1).radius2),3) - pow((mat_fill(1).radius1),3) )/2.0;
-            mat_fill(1).sie = (0.5*0.49339/vol);
-            
+            mat_fill(1).radius2 = 1.2 / 8.0;       // outer radius of fill region
+            mat_fill(1).den     = 1.0;           // initial density
+            double vol = PI * (pow((mat_fill(1).radius2), 3)
+                               - pow((mat_fill(1).radius1), 3) );
+            // vol = 4./3.* PI * ( pow((mat_fill(1).radius2),3) - pow((mat_fill(1).radius1),3) )/2.0;
+            mat_fill(1).sie = (0.5 * 0.49339 / vol);
+
             mat_fill(1).velocity = init_conds::cartesian;
             mat_fill(1).u = 0.0;   // initial x-dir velocity
             mat_fill(1).v = 0.0;   // initial y-dir velocity
             mat_fill(1).w = 0.0;   // initial z-dir velocity
 
-
-
             // ---- boundary conditions ---- //
-            
+
             // Tag X plane
-            boundary(0).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(0).value = 0.0;
+            boundary(0).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(0).value    = 0.0;
             boundary(0).hydro_bc = bdy::reflected;
-            
+
             // Tag Y plane
-            boundary(1).surface = bdy::y_plane;
-            boundary(1).value = 0.0;
+            boundary(1).surface  = bdy::y_plane;
+            boundary(1).value    = 0.0;
             boundary(1).hydro_bc = bdy::reflected;
-            
-            
+
             // Tag X plane
-            //boundary(2).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            //boundary(2).value = 1.2;
-            //boundary(2).hydro_bc = bdy::reflected;
+            // boundary(2).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
+            // boundary(2).value = 1.2;
+            // boundary(2).hydro_bc = bdy::reflected;
             //
             //// Tag Y plane
-            //boundary(3).surface = bdy::y_plane;
-            //boundary(3).value = 1.2;
-            //boundary(3).hydro_bc = bdy::reflected;
-            
-            
+            // boundary(3).surface = bdy::y_plane;
+            // boundary(3).value = 1.2;
+            // boundary(3).hydro_bc = bdy::reflected;
+
             // Tag inner cylinder
-            boundary(2).surface = bdy::cylinder;
-            boundary(2).value = 0.01;
+            boundary(2).surface  = bdy::cylinder;
+            boundary(2).value    = 0.01;
             boundary(2).hydro_bc = bdy::fixed;
-            
         });  // end RUN
-
     } // end if Sedov
-    
-    
+
     // Noh 3D
-    if (test_problem == test::Noh3D){
-
+    if (test_problem == test::Noh3D)
+    {
         time_final = 0.6;
-        
+
         RUN({
-            
             material(0).eos_model = ideal_gas; // EOS model
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
             material(0).num_state_vars = 6;  // actual num_state_vars
-            state_vars(0,0) = 5.0/3.0; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat c_v
-            
-            // Global instructions
-            mat_fill(0).volume = region::global;   // fill everywhere
-            mat_fill(0).mat_id = 0;                // material id
-            mat_fill(0).den = 1.0;                   // intial density
-            mat_fill(0).sie = 1e-9;             // intial specific internal energy
-            
-            mat_fill(0).velocity = init_conds::spherical;
-            mat_fill(0).speed = -1.0;
-            
-            // ---- boundary conditions ---- //
-            
-            // Tag X plane
-            boundary(0).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(0).value = 0.0;
-            boundary(0).hydro_bc = bdy::reflected;
-            
-            // Tag Y plane
-            boundary(1).surface = bdy::y_plane;
-            boundary(1).value = 0.0;
-            boundary(1).hydro_bc = bdy::reflected;
-            
-            // Tag Z plane
-            boundary(2).surface = bdy::z_plane;
-            boundary(2).value = 0.0;
-            boundary(2).hydro_bc = bdy::reflected;
-            
-        });  // end RUN
-            
-    } // end if Noh
-    
-    
-    // Noh 2D
-    if (test_problem == test::NohRZ){
+            state_vars(0, 0) = 5.0 / 3.0; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat c_v
 
-        time_final = 0.6;
-        
-        RUN({
-            
-            material(0).eos_model = ideal_gas; // EOS model
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
-            material(0).num_state_vars = 3;  // actual num_state_vars
-            state_vars(0,0) = 5.0/3.0; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat c_v
-            
             // Global instructions
             mat_fill(0).volume = region::global;   // fill everywhere
             mat_fill(0).mat_id = 0;                // material id
-            mat_fill(0).den = 1.0;                   // intial density
-            mat_fill(0).sie = 1e-9;             // intial specific internal energy
-            
-            mat_fill(0).velocity = init_conds::radial;
-            mat_fill(0).speed = -1.0;
-            
+            mat_fill(0).den    = 1.0;                // intial density
+            mat_fill(0).sie    = 1e-9;          // intial specific internal energy
+
+            mat_fill(0).velocity = init_conds::spherical;
+            mat_fill(0).speed    = -1.0;
+
             // ---- boundary conditions ---- //
-            
+
             // Tag X plane
-            boundary(0).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(0).value = 0.0;
+            boundary(0).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(0).value    = 0.0;
             boundary(0).hydro_bc = bdy::reflected;
-            
+
             // Tag Y plane
-            boundary(1).surface = bdy::y_plane;
-            boundary(1).value = 0.0;
+            boundary(1).surface  = bdy::y_plane;
+            boundary(1).value    = 0.0;
             boundary(1).hydro_bc = bdy::reflected;
-            
-            // Tag Y plane
-            boundary(2).surface = bdy::cylinder;
-            boundary(2).value = 0.01;
-            boundary(2).hydro_bc = bdy::fixed;
-            
-            
+
+            // Tag Z plane
+            boundary(2).surface  = bdy::z_plane;
+            boundary(2).value    = 0.0;
+            boundary(2).hydro_bc = bdy::reflected;
         });  // end RUN
-            
     } // end if Noh
-    
-    
+
+    // Noh 2D
+    if (test_problem == test::NohRZ)
+    {
+        time_final = 0.6;
+
+        RUN({
+            material(0).eos_model = ideal_gas; // EOS model
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
+            material(0).num_state_vars = 3;  // actual num_state_vars
+            state_vars(0, 0) = 5.0 / 3.0; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat c_v
+
+            // Global instructions
+            mat_fill(0).volume = region::global;   // fill everywhere
+            mat_fill(0).mat_id = 0;                // material id
+            mat_fill(0).den    = 1.0;                // intial density
+            mat_fill(0).sie    = 1e-9;          // intial specific internal energy
+
+            mat_fill(0).velocity = init_conds::radial;
+            mat_fill(0).speed    = -1.0;
+
+            // ---- boundary conditions ---- //
+
+            // Tag X plane
+            boundary(0).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(0).value    = 0.0;
+            boundary(0).hydro_bc = bdy::reflected;
+
+            // Tag Y plane
+            boundary(1).surface  = bdy::y_plane;
+            boundary(1).value    = 0.0;
+            boundary(1).hydro_bc = bdy::reflected;
+
+            // Tag Y plane
+            boundary(2).surface  = bdy::cylinder;
+            boundary(2).value    = 0.01;
+            boundary(2).hydro_bc = bdy::fixed;
+        });  // end RUN
+    } // end if Noh
+
     // Sod in Z direction in RZ coordinates (eq. to x-dir)
-    if (test_problem == test::SodZ){
-        
+    if (test_problem == test::SodZ)
+    {
         time_final = 0.2;  // 1.0 for Sedov
-        
+
         RUN({
             // gamma law model
             // statev(0) = gamma
@@ -405,86 +377,79 @@ void input(CArrayKokkos <material_t> &material,
             // statev(3) = ref temperature
             // statev(4) = ref density
             // statev(5) = ref specific internal energy
-            
+
             material(0).eos_model = ideal_gas; // EOS model is required
-            
-            material(0).strength_type = model::none;
+
+            material(0).strength_type  = model::none;
             material(0).strength_model = NULL;  // not needed, but illistrates the syntax
-            
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
+
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
             material(0).num_state_vars = 3;  // actual num_state_vars
-            state_vars(0,0) = 1.4; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat
-            
+            state_vars(0, 0) = 1.4; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat
+
             // global initial conditions
             mat_fill(0).volume = region::global; // fill everywhere
             mat_fill(0).mat_id = 0;              // material id
-            mat_fill(0).den = 1.0;               // intial density
-            mat_fill(0).sie = 2.5;            // intial specific internal energy
-            
+            mat_fill(0).den    = 1.0;            // intial density
+            mat_fill(0).sie    = 2.5;         // intial specific internal energy
+
             mat_fill(0).velocity = init_conds::cartesian;
             mat_fill(0).u = 0.0;   // initial x-dir velocity
             mat_fill(0).v = 0.0;   // initial y-dir velocity
             mat_fill(0).w = 0.0;   // initial z-dir velocity
-            
+
             // energy source initial conditions
             mat_fill(1).volume = region::box;    // fill a box
             mat_fill(1).mat_id = 0;              // material id
-            mat_fill(1).x1 = 0.5;           //
-            mat_fill(1).x2 = 1.0;           //
-            mat_fill(1).y1 = 0.0;           //
-            mat_fill(1).y2 = 1.0;           //
-            mat_fill(1).z1 = 0.0;           //
-            mat_fill(1).z2 = 1.0;           //
-            mat_fill(1).den = 0.125;        // initial density
-            mat_fill(1).sie = 2.5;          // initial specific internal energy
-            
-            
+            mat_fill(1).x1     = 0.5;       //
+            mat_fill(1).x2     = 1.0;       //
+            mat_fill(1).y1     = 0.0;       //
+            mat_fill(1).y2     = 1.0;       //
+            mat_fill(1).z1     = 0.0;       //
+            mat_fill(1).z2     = 1.0;       //
+            mat_fill(1).den    = 0.125;     // initial density
+            mat_fill(1).sie    = 2.5;       // initial specific internal energy
+
             mat_fill(1).velocity = init_conds::cartesian;
             mat_fill(1).u = 0.0;   // initial x-dir velocity
             mat_fill(1).v = 0.0;   // initial y-dir velocity
             mat_fill(1).w = 0.0;   // initial z-dir velocity
 
-
-
             // ---- boundary conditions ---- //
-            
+
             // Tag X plane
-            boundary(0).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(0).value = 0.0;
+            boundary(0).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(0).value    = 0.0;
             boundary(0).hydro_bc = bdy::reflected;
-            
+
             // Tag Y plane
-            boundary(1).surface = bdy::y_plane;
-            boundary(1).value = 0.0;
+            boundary(1).surface  = bdy::y_plane;
+            boundary(1).value    = 0.0;
             boundary(1).hydro_bc = bdy::reflected;
-            
-            
+
             // Tag X plane
-            boundary(2).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(2).value = 1.0;
+            boundary(2).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(2).value    = 1.0;
             boundary(2).hydro_bc = bdy::reflected;
 
             // Tag Y plane
-            boundary(3).surface = bdy::y_plane;
-            boundary(3).value = 0.1;
+            boundary(3).surface  = bdy::y_plane;
+            boundary(3).value    = 0.1;
             boundary(3).hydro_bc = bdy::reflected;
-            
         });  // end RUN
-
     } // end if SodZ
-    
-    
+
     // Triple point
-    if (test_problem == test::TriplePoint){
-        
-        time_final = 4.0; 
-        
+    if (test_problem == test::TriplePoint)
+    {
+        time_final = 4.0;
+
         RUN({
             // gamma law model
             // statev(0) = gamma
@@ -493,166 +458,153 @@ void input(CArrayKokkos <material_t> &material,
             // statev(3) = ref temperature
             // statev(4) = ref density
             // statev(5) = ref specific internal energy
-            
+
             material(0).eos_model = ideal_gas; // EOS model is required
-            
-            material(0).strength_type = model::none;
+
+            material(0).strength_type  = model::none;
             material(0).strength_model = NULL;  // not needed, but illistrates the syntax
-            
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
+
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
             material(0).num_state_vars = 3;  // actual num_state_vars
-            state_vars(0,0) = 5.0/3.0; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat
-            
+            state_vars(0, 0) = 5.0 / 3.0; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat
+
             // global initial conditions
             mat_fill(0).volume = region::global; // fill everywhere
             mat_fill(0).mat_id = 0;              // material id
-            mat_fill(0).den = 1.0;               // intial density
-            mat_fill(0).sie = 2.5;            // intial specific internal energy
-            
+            mat_fill(0).den    = 1.0;            // intial density
+            mat_fill(0).sie    = 2.5;         // intial specific internal energy
+
             mat_fill(0).velocity = init_conds::cartesian;
             mat_fill(0).u = 0.0;   // initial x-dir velocity
             mat_fill(0).v = 0.0;   // initial y-dir velocity
             mat_fill(0).w = 0.0;   // initial z-dir velocity
-            
-            
+
             // initial conditions, region 1
             mat_fill(1).volume = region::box;    // fill a box
             mat_fill(1).mat_id = 0;              // material id
-            mat_fill(1).x1 = 1.0;           //
-            mat_fill(1).x2 = 7.0;           //
-            mat_fill(1).y1 = 0.0;           //
-            mat_fill(1).y2 = 1.5;           //
-            mat_fill(1).z1 = 0.0;           //
-            mat_fill(1).z2 = 1.0;           //
-            mat_fill(1).den = 1.0;          // initial density
-            mat_fill(1).sie = 0.25;         // initial specific internal energy
-            
+            mat_fill(1).x1     = 1.0;       //
+            mat_fill(1).x2     = 7.0;       //
+            mat_fill(1).y1     = 0.0;       //
+            mat_fill(1).y2     = 1.5;       //
+            mat_fill(1).z1     = 0.0;       //
+            mat_fill(1).z2     = 1.0;       //
+            mat_fill(1).den    = 1.0;       // initial density
+            mat_fill(1).sie    = 0.25;      // initial specific internal energy
+
             mat_fill(1).velocity = init_conds::cartesian;
             mat_fill(1).u = 0.0;   // initial x-dir velocity
             mat_fill(1).v = 0.0;   // initial y-dir velocity
             mat_fill(1).w = 0.0;   // initial z-dir velocity
-            
+
             // initial conditions, region 2
             mat_fill(2).volume = region::box;    // fill a box
             mat_fill(2).mat_id = 0;              // material id
-            mat_fill(2).x1 = 1.0;           //
-            mat_fill(2).x2 = 7.0;           //
-            mat_fill(2).y1 = 1.5;           //
-            mat_fill(2).y2 = 3.0;           //
-            mat_fill(2).z1 = 0.0;           //
-            mat_fill(2).z2 = 1.0;           //
-            mat_fill(2).den = 0.1;        // initial density
-            mat_fill(2).sie = 2.5;          // initial specific internal energy
-            
+            mat_fill(2).x1     = 1.0;       //
+            mat_fill(2).x2     = 7.0;       //
+            mat_fill(2).y1     = 1.5;       //
+            mat_fill(2).y2     = 3.0;       //
+            mat_fill(2).z1     = 0.0;       //
+            mat_fill(2).z2     = 1.0;       //
+            mat_fill(2).den    = 0.1;     // initial density
+            mat_fill(2).sie    = 2.5;       // initial specific internal energy
+
             mat_fill(2).velocity = init_conds::cartesian;
             mat_fill(2).u = 0.0;   // initial x-dir velocity
             mat_fill(2).v = 0.0;   // initial y-dir velocity
             mat_fill(2).w = 0.0;   // initial z-dir velocity
 
-
-
             // ---- boundary conditions ---- //
-            
+
             // Tag X = 0 plane
-            boundary(0).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(0).value = 0.0;
+            boundary(0).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(0).value    = 0.0;
             boundary(0).hydro_bc = bdy::reflected;
-            
+
             // Tag Y = 0 plane
-            boundary(1).surface = bdy::y_plane;
-            boundary(1).value = 0.0;
+            boundary(1).surface  = bdy::y_plane;
+            boundary(1).value    = 0.0;
             boundary(1).hydro_bc = bdy::reflected;
-            
+
             // Tag Z = 0 plane
-            boundary(2).surface = bdy::z_plane;
-            boundary(2).value = 0.0;
+            boundary(2).surface  = bdy::z_plane;
+            boundary(2).value    = 0.0;
             boundary(2).hydro_bc = bdy::reflected;
 
-
             // Tag X = 7 plane
-            boundary(3).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(3).value = 6.0;  // some meshes are 7 and others are 6
+            boundary(3).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(3).value    = 6.0; // some meshes are 7 and others are 6
             boundary(3).hydro_bc = bdy::reflected;
-            
+
             // Tag Y = 3 plane
-            boundary(4).surface = bdy::y_plane;
-            boundary(4).value = 3.0;
+            boundary(4).surface  = bdy::y_plane;
+            boundary(4).value    = 3.0;
             boundary(4).hydro_bc = bdy::reflected;
-            
+
             // Tag Z = 1 plane
-            boundary(5).surface = bdy::z_plane;
-            boundary(5).value = 1.0;
+            boundary(5).surface  = bdy::z_plane;
+            boundary(5).value    = 1.0;
             boundary(5).hydro_bc = bdy::reflected;
-            
         });  // end RUN
-
     } // end if SodZ
-    
-    
-    // Taylor Anvil
-    if (test_problem == test::TaylorAnvil){
 
+    // Taylor Anvil
+    if (test_problem == test::TaylorAnvil)
+    {
         time_final = 25.0;
-        
+
         RUN({
-            
             material(0).eos_model = ideal_gas; // EOS model
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
             material(0).num_state_vars = 3;  // actual num_state_vars
-            state_vars(0,0) = 5.0/3.0; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat c_v
-            
+            state_vars(0, 0) = 5.0 / 3.0; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat c_v
+
             // Global instructions
             mat_fill(0).volume = region::global;   // fill everywhere
             mat_fill(0).mat_id = 0;                // material id
-            mat_fill(0).den = 1.0;                   // intial density
-            mat_fill(0).sie = 1e-9;             // intial specific internal energy
-            
+            mat_fill(0).den    = 1.0;                // intial density
+            mat_fill(0).sie    = 1e-9;          // intial specific internal energy
+
             mat_fill(0).velocity = init_conds::cartesian;
             mat_fill(0).u = 0.0;
             mat_fill(0).v = 0.0;
             mat_fill(0).w = -1.0;
-            
+
             // ---- boundary conditions ---- //
-            
+
             // Tag X plane
-            boundary(0).surface = bdy::x_plane; // planes, cylinder, spheres, or a files
-            boundary(0).value = 0.0;
+            boundary(0).surface  = bdy::x_plane; // planes, cylinder, spheres, or a files
+            boundary(0).value    = 0.0;
             boundary(0).hydro_bc = bdy::reflected;
-            
-            
+
             // Tag Y plane
-            boundary(1).surface = bdy::y_plane;
-            boundary(1).value = 0.0;
+            boundary(1).surface  = bdy::y_plane;
+            boundary(1).value    = 0.0;
             boundary(1).hydro_bc = bdy::reflected;
-            
+
             // Tag Z plane
-            boundary(2).surface = bdy::z_plane;
-            boundary(2).value = 0.0;
+            boundary(2).surface  = bdy::z_plane;
+            boundary(2).value    = 0.0;
             boundary(2).hydro_bc = bdy::reflected;
-            
-            
         });  // end RUN
-        
     } // end if Taylor Anvil
-    
-    
+
     // a voxel box mesh
-    if (test_problem == test::box){
+    if (test_problem == test::box)
+    {
         time_final = 10.0;  // 1.0 for Sedov
-        
-        
+
         RUN({
             // gamma law model
             // statev(0) = gamma
@@ -661,43 +613,40 @@ void input(CArrayKokkos <material_t> &material,
             // statev(3) = ref temperature
             // statev(4) = ref density
             // statev(5) = ref specific internal energy
-            
+
             material(0).eos_model = ideal_gas; // EOS model is required
-            
-            material(0).strength_type = model::none;
+
+            material(0).strength_type  = model::none;
             material(0).strength_setup = model_init::input; // not need, the input is the default
             material(0).strength_model = NULL;  // not needed, but illistrates the syntax
-            
-            material(0).q1        = 1.0;       // accoustic coefficient
-            material(0).q2        = 1.3333;    // linear slope of UsUp for Riemann solver
-            material(0).q1ex      = 1.0;       // accoustic coefficient in expansion
-            material(0).q2ex      = 0.0;       // linear slope of UsUp in expansion
-            
+
+            material(0).q1   = 1.0;            // accoustic coefficient
+            material(0).q2   = 1.3333;         // linear slope of UsUp for Riemann solver
+            material(0).q1ex = 1.0;            // accoustic coefficient in expansion
+            material(0).q2ex = 0.0;            // linear slope of UsUp in expansion
+
             material(0).num_state_vars = 3;  // actual num_state_vars
-            state_vars(0,0) = 5.0/3.0; // gamma value
-            state_vars(0,1) = 1.0E-14; // minimum sound speed
-            state_vars(0,2) = 1.0;     // specific heat
-            
-            
-            
-            
+            state_vars(0, 0) = 5.0 / 3.0; // gamma value
+            state_vars(0, 1) = 1.0E-14; // minimum sound speed
+            state_vars(0, 2) = 1.0;     // specific heat
+
             // global initial conditions
             mat_fill(0).volume = region::global; // fill everywhere
             mat_fill(0).mat_id = 0;              // material id
-            mat_fill(0).den = 0.5;               // intial density
-            mat_fill(0).sie = 1.e-10;            // intial specific internal energy
-            
+            mat_fill(0).den    = 0.5;            // intial density
+            mat_fill(0).sie    = 1.e-10;         // intial specific internal energy
+
             mat_fill(0).velocity = init_conds::cartesian;
             mat_fill(0).u = 0.0;   // initial x-dir velocity
             mat_fill(0).v = 0.0;   // initial y-dir velocity
             mat_fill(0).w = 0.0;   // initial z-dir velocity
-            
+
             // read a voxel mesh and paint material onto the mesh
             mat_fill(1).volume = region::readVoxelFile; // fill in voxel structure
             mat_fill(1).mat_id = 0;              // material id
-            mat_fill(1).den = 2.7;               // intial density
-            mat_fill(1).sie = 1.e-10;            // intial specific internal energy
-            
+            mat_fill(1).den    = 2.7;            // intial density
+            mat_fill(1).sie    = 1.e-10;         // intial specific internal energy
+
             mat_fill(1).velocity = init_conds::cartesian;
             mat_fill(1).u = 0.0;   // initial x-dir velocity
             mat_fill(1).v = 0.0;   // initial y-dir velocity
@@ -705,30 +654,21 @@ void input(CArrayKokkos <material_t> &material,
 
             // ---- boundary conditions ---- //
 
-            
             // Tag Y plane
-            boundary(0).surface = bdy::y_plane;
-            boundary(0).value = -0.381;
+            boundary(0).surface  = bdy::y_plane;
+            boundary(0).value    = -0.381;
             boundary(0).hydro_bc = bdy::reflected;
-            
-            
-            
-            // Tag top y plane
-            boundary(1).surface = bdy::y_plane; // planes, cylinder, spheres, or a files
-            boundary(1).value = 37.719;
-            boundary(1).hydro_bc = bdy::velocity;
-            boundary(1).hydro_bc_vel_0 = -1.0;  // velocity is downward
-            boundary(1).hydro_bc_vel_1 = 0.5;
-            boundary(1).hydro_bc_vel_t_start = 0;
-            boundary(1).hydro_bc_vel_t_end = 10000.0; // mu seconds
-            
-        });  // end RUN
 
+            // Tag top y plane
+            boundary(1).surface              = bdy::y_plane; // planes, cylinder, spheres, or a files
+            boundary(1).value                = 37.719;
+            boundary(1).hydro_bc             = bdy::velocity;
+            boundary(1).hydro_bc_vel_0       = -1.0; // velocity is downward
+            boundary(1).hydro_bc_vel_1       = 0.5;
+            boundary(1).hydro_bc_vel_t_start = 0;
+            boundary(1).hydro_bc_vel_t_end   = 10000.0; // mu seconds
+        });  // end RUN
     } // end if box
-        
 
     return;
-
 } // end of input
-
-

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/mesh.h
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/mesh.h
@@ -52,8 +52,7 @@ patch 6: [4,5,6,7]  zeta-plus  dir
 
 // sort in ascending order using bubble sort
 KOKKOS_INLINE_FUNCTION
-void
-bubble_sort(size_t arr[], const size_t num)
+void bubble_sort(size_t arr[], const size_t num)
 {
     for (size_t i = 0; i < (num - 1); i++)
     {
@@ -158,8 +157,7 @@ struct mesh_t
     DCArrayKokkos<size_t> num_bdy_nodes_in_set;
 
     // initialization methods
-    void
-    initialize_nodes(const size_t num_nodes_inp)
+    void initialize_nodes(const size_t num_nodes_inp)
     {
         num_nodes = num_nodes_inp;
 
@@ -167,8 +165,7 @@ struct mesh_t
     }; // end method
 
     // initialization methods
-    void
-    initialize_elems(const size_t num_elems_inp, const size_t num_dims_inp)
+    void initialize_elems(const size_t num_elems_inp, const size_t num_dims_inp)
     {
         num_dims = num_dims_inp;
         num_nodes_in_elem = 1;
@@ -184,8 +181,7 @@ struct mesh_t
     }; // end method
 
     // initialization methods
-    void
-    initialize_corners(const size_t num_corners_inp)
+    void initialize_corners(const size_t num_corners_inp)
     {
         num_corners = num_corners_inp;
 
@@ -193,8 +189,7 @@ struct mesh_t
     }; // end method
 
     // build the corner mesh connectivity arrays
-    void
-    build_corner_connectivity()
+    void build_corner_connectivity()
     {
         num_corners_in_node = CArrayKokkos<size_t>(num_nodes); // stride sizes
 
@@ -256,8 +251,7 @@ struct mesh_t
     } // end of build_corner_connectivity
 
     // build elem connectivity arrays
-    void
-    build_elem_elem_connectivity()
+    void build_elem_elem_connectivity()
     {
         // find the max number of elems around a node
         size_t max_num_elems_in_node;
@@ -345,8 +339,7 @@ struct mesh_t
     } // end of build_elem_elem_connectivity
 
     // build the patches
-    void
-    build_patch_connectivity()
+    void build_patch_connectivity()
     {
         size_t high_order = 0;
 
@@ -696,8 +689,7 @@ struct mesh_t
     } // end patch connectivity method
 
     // build the patches
-    void
-    build_node_node_connectivity()
+    void build_node_node_connectivity()
     {
         // find the max number of elems around a node
         size_t max_num_elems_in_node;
@@ -836,8 +828,7 @@ struct mesh_t
         }); // end parallel for over nodes
     } // end of node node connectivity
 
-    void
-    init_bdy_sets(size_t num_bcs)
+    void init_bdy_sets(size_t num_bcs)
     {
         if (num_bcs == 0)
         {

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/mesh.h
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/mesh.h
@@ -1,6 +1,8 @@
+// -------------------------------------------------------
+// Mesh data
+// --------------------------------------------------------
 #ifndef MESH_H
 #define MESH_H
-
 
 #include "matar.h"
 #include "state.h"
@@ -50,29 +52,30 @@ patch 6: [4,5,6,7]  zeta-plus  dir
 
 // sort in ascending order using bubble sort
 KOKKOS_INLINE_FUNCTION
-void bubble_sort(size_t arr[], const size_t num){
-    
-    for (size_t i=0; i<(num-1); i++){
-        for (size_t j=0; j<(num-i-1); j++){
-            
-            if (arr[j]>arr[j+1]){
+void
+bubble_sort(size_t arr[], const size_t num)
+{
+    for (size_t i = 0; i < (num - 1); i++)
+    {
+        for (size_t j = 0; j < (num - i - 1); j++)
+        {
+            if (arr[j] > arr[j + 1])
+            {
                 size_t temp = arr[j];
-                arr[j] = arr[j+1];
-                arr[j+1] = temp;
+                arr[j]     = arr[j + 1];
+                arr[j + 1] = temp;
             } // end if
-            
         } // end for j
     } // end for i
 } // end function
 
-
 // mesh sizes and connectivity data structures
-struct mesh_t {
-    
+struct mesh_t
+{
     size_t num_dims;
-    
+
     size_t num_nodes;
-    
+
     size_t num_elems;
     size_t num_nodes_in_elem;
     size_t num_patches_in_elem;
@@ -80,174 +83,164 @@ struct mesh_t {
     size_t num_patches_in_surf;  // high-order mesh class
 
     size_t num_corners;
-    
+
     size_t num_patches;
     size_t num_surfs;           // high_order mesh class
-    
+
     size_t num_bdy_patches;
     size_t num_bdy_nodes;
     size_t num_bdy_sets;
     size_t num_nodes_in_patch;
 
-    
     // ---- nodes ----
-    
+
     // corner ids in node
-    RaggedRightArrayKokkos <size_t> corners_in_node;
-    CArrayKokkos <size_t> num_corners_in_node;
-    
+    RaggedRightArrayKokkos<size_t> corners_in_node;
+    CArrayKokkos<size_t> num_corners_in_node;
+
     // elem ids in node
-    RaggedRightArrayKokkos <size_t> elems_in_node;
-    
+    RaggedRightArrayKokkos<size_t> elems_in_node;
+
     // node ids in node
-    RaggedRightArrayKokkos <size_t> nodes_in_node;
-    CArrayKokkos <size_t> num_nodes_in_node;
-    
-    
+    RaggedRightArrayKokkos<size_t> nodes_in_node;
+    CArrayKokkos<size_t> num_nodes_in_node;
+
     // ---- elems ----
-    
+
     // node ids in elem
-    DCArrayKokkos <size_t> nodes_in_elem;
-    
+    DCArrayKokkos<size_t> nodes_in_elem;
+
     // corner ids in elem
-    CArrayKokkos <size_t> corners_in_elem;
-    
+    CArrayKokkos<size_t> corners_in_elem;
+
     // elem ids in elem
-    RaggedRightArrayKokkos <size_t> elems_in_elem;
-    CArrayKokkos <size_t> num_elems_in_elem;
-    
+    RaggedRightArrayKokkos<size_t> elems_in_elem;
+    CArrayKokkos<size_t> num_elems_in_elem;
+
     // patch ids in elem
-    CArrayKokkos <size_t> patches_in_elem;
-    
+    CArrayKokkos<size_t> patches_in_elem;
+
     // surface ids in elem
-    CArrayKokkos <size_t> surfs_in_elem;  // high-order mesh class
-    
+    CArrayKokkos<size_t> surfs_in_elem;  // high-order mesh class
+
     // surface ids in elem
-    CArrayKokkos <size_t> zones_in_elem;     // high-order mesh class
-    
-    
-    
+    CArrayKokkos<size_t> zones_in_elem;     // high-order mesh class
+
     // ---- patches / surfaces ----
-    
+
     // node ids in a patch
-    CArrayKokkos <size_t> nodes_in_patch;
-    
+    CArrayKokkos<size_t> nodes_in_patch;
+
     // element ids in a patch
-    CArrayKokkos <size_t> elems_in_patch;
-    
+    CArrayKokkos<size_t> elems_in_patch;
+
     // the two element ids sharing a surface
-    CArrayKokkos <size_t> elems_in_surf;
-    
+    CArrayKokkos<size_t> elems_in_surf;
+
     // patch ids in a surface
-    CArrayKokkos <size_t> patches_in_surf;  // high-order mesh class
-    
-    CArrayKokkos <size_t> surf_in_patch;       // high-order mesh class
-    
-    
+    CArrayKokkos<size_t> patches_in_surf;  // high-order mesh class
+
+    CArrayKokkos<size_t> surf_in_patch;       // high-order mesh class
+
     // ---- bdy ----
-    
+
     // bdy_patches
-    CArrayKokkos <size_t> bdy_patches;
-    
+    CArrayKokkos<size_t> bdy_patches;
+
     // bdy nodes
-    CArrayKokkos <size_t> bdy_nodes;
-    
+    CArrayKokkos<size_t> bdy_nodes;
+
     // patch ids in bdy set
-    DynamicRaggedRightArrayKokkos <size_t> bdy_patches_in_set;
-    
+    DynamicRaggedRightArrayKokkos<size_t> bdy_patches_in_set;
+
     // node ids in bdy_patch set
-    RaggedRightArrayKokkos <size_t> bdy_nodes_in_set;
-    DCArrayKokkos <size_t> num_bdy_nodes_in_set;
-    
+    RaggedRightArrayKokkos<size_t> bdy_nodes_in_set;
+    DCArrayKokkos<size_t> num_bdy_nodes_in_set;
+
     // initialization methods
-    void initialize_nodes(const size_t num_nodes_inp)
+    void
+    initialize_nodes(const size_t num_nodes_inp)
     {
         num_nodes = num_nodes_inp;
-        
+
         return;
-        
     }; // end method
-    
-    
+
     // initialization methods
-    void initialize_elems(const size_t num_elems_inp, const size_t num_dims_inp)
+    void
+    initialize_elems(const size_t num_elems_inp, const size_t num_dims_inp)
     {
         num_dims = num_dims_inp;
         num_nodes_in_elem = 1;
-        for (int dim=0; dim<num_dims; dim++){
+        for (int dim = 0; dim < num_dims; dim++)
+        {
             num_nodes_in_elem *= 2;
         }
-        num_elems = num_elems_inp;
-        nodes_in_elem = DCArrayKokkos <size_t> (num_elems, num_nodes_in_elem);
-        corners_in_elem = CArrayKokkos <size_t> (num_elems, num_nodes_in_elem);
-        
+        num_elems       = num_elems_inp;
+        nodes_in_elem   = DCArrayKokkos<size_t>(num_elems, num_nodes_in_elem);
+        corners_in_elem = CArrayKokkos<size_t>(num_elems, num_nodes_in_elem);
+
         return;
-        
     }; // end method
-    
-    
+
     // initialization methods
-    void initialize_corners(const size_t num_corners_inp)
+    void
+    initialize_corners(const size_t num_corners_inp)
     {
         num_corners = num_corners_inp;
-        
+
         return;
-        
     }; // end method
-    
-    
+
     // build the corner mesh connectivity arrays
-    void build_corner_connectivity(){
-        
-        num_corners_in_node = CArrayKokkos <size_t> (num_nodes); // stride sizes
-        
+    void
+    build_corner_connectivity()
+    {
+        num_corners_in_node = CArrayKokkos<size_t>(num_nodes); // stride sizes
+
         // initializing the number of corners (node-cell pair) to be zero
         FOR_ALL_CLASS(node_gid, 0, num_nodes, {
             num_corners_in_node(node_gid) = 0;
         });
-        
-        
-        for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++){
-            FOR_ALL_CLASS(node_lid, 0, num_nodes_in_elem,{
-                
+
+        for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++)
+        {
+            FOR_ALL_CLASS(node_lid, 0, num_nodes_in_elem, {
                 // get the global_id of the node
                 size_t node_gid = nodes_in_elem(elem_gid, node_lid);
 
                 // increment the number of corners attached to this point
                 num_corners_in_node(node_gid) = num_corners_in_node(node_gid) + 1;
-                
             });  // end FOR_ALL over nodes in element
         } // end for elem_gid
-        
-        
-        // the stride sizes are the num_corners_in_node at the node
-        corners_in_node = RaggedRightArrayKokkos <size_t> (num_corners_in_node);
 
-        CArrayKokkos <size_t> count_saved_corners_in_node(num_nodes);
+        // the stride sizes are the num_corners_in_node at the node
+        corners_in_node = RaggedRightArrayKokkos<size_t>(num_corners_in_node);
+
+        CArrayKokkos<size_t> count_saved_corners_in_node(num_nodes);
 
         // reset num_corners to zero
         FOR_ALL_CLASS(node_gid, 0, num_nodes, {
             count_saved_corners_in_node(node_gid) = 0;
         });
-        
-        
+
         // he elems_in_elem data type
-        elems_in_node = RaggedRightArrayKokkos <size_t> (num_corners_in_node);
-        
+        elems_in_node = RaggedRightArrayKokkos<size_t>(num_corners_in_node);
+
         // populate the elems connected to a node list and corners in a node
-        for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++){
+        for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++)
+        {
             FOR_ALL_CLASS(node_lid, 0, num_nodes_in_elem, {
-                
                 // get the global_id of the node
                 size_t node_gid = nodes_in_elem(elem_gid, node_lid);
-                
+
                 // the column index is the num corners saved
                 size_t j = count_saved_corners_in_node(node_gid);
 
                 // Save corner index to this node_gid
-                size_t corner_gid = node_lid + elem_gid*num_nodes_in_elem;
+                size_t corner_gid = node_lid + elem_gid * num_nodes_in_elem;
                 corners_in_node(node_gid, j) = corner_gid;
-                
+
                 elems_in_node(node_gid, j) = elem_gid; // save the elem_gid
 
                 // Save corner index to element
@@ -256,136 +249,131 @@ struct mesh_t {
 
                 // increment the number of corners saved to this node_gid
                 count_saved_corners_in_node(node_gid) = count_saved_corners_in_node(node_gid) + 1;
-
             });  // end FOR_ALL over nodes in element
         } // end for elem_gid
-     
+
         return;
-        
     } // end of build_corner_connectivity
-    
-    
+
     // build elem connectivity arrays
-    void build_elem_elem_connectivity(){
-        
+    void
+    build_elem_elem_connectivity()
+    {
         // find the max number of elems around a node
         size_t max_num_elems_in_node;
         size_t max_num_lcl;
         REDUCE_MAX_CLASS(node_gid, 0, num_nodes, max_num_lcl, {
-            
             // num_corners_in_node = num_elems_in_node
             size_t max_num = num_corners_in_node(node_gid);
-            
-            if (max_num > max_num_lcl) max_num_lcl = max_num;
-                    
+
+            if (max_num > max_num_lcl)
+            {
+                max_num_lcl = max_num;
+            }
         }, max_num_elems_in_node); // end parallel reduction on max
         Kokkos::fence();
-        
+
         // a temporary ragged array to save the elems around an elem
-        DynamicRaggedRightArrayKokkos <size_t> temp_elems_in_elem(num_nodes, num_nodes_in_elem*max_num_elems_in_node);
-        
-        num_elems_in_elem = CArrayKokkos <size_t> (num_elems);
+        DynamicRaggedRightArrayKokkos<size_t> temp_elems_in_elem(num_nodes, num_nodes_in_elem * max_num_elems_in_node);
+
+        num_elems_in_elem = CArrayKokkos<size_t>(num_elems);
         FOR_ALL_CLASS(elem_gid, 0, num_elems, {
             num_elems_in_elem(elem_gid) = 0;
         });
         Kokkos::fence();
-        
+
         // find and save neighboring elem_gids of an elem
         FOR_ALL_CLASS(elem_gid, 0, num_elems, {
-            for (int node_lid=0; node_lid<num_nodes_in_elem; node_lid++){
-                
+            for (int node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+            {
                 // get the gid for the node
                 size_t node_id = nodes_in_elem(elem_gid, node_lid);
-                
+
                 // loop over all elems connected to node_gid
-                for (int elem_lid = 0; elem_lid < num_corners_in_node(node_id); elem_lid++){
-                    
+                for (int elem_lid = 0; elem_lid < num_corners_in_node(node_id); elem_lid++)
+                {
                     // get the global id for the neighboring elem
                     size_t neighbor_elem_gid = elems_in_node(node_id, elem_lid);
-                    
+
                     // a flag to save (=1) or not (=0)
                     size_t save = 1;
-                    
+
                     // a true neighbor_elem_id is not equal to elem_gid
-                    if (neighbor_elem_gid == elem_gid ){
+                    if (neighbor_elem_gid == elem_gid)
+                    {
                         save = 0;  // don't save
                     } // end if
-                    
+
                     // check to see if the neighbor_elem_gid has been saved already
                     size_t num_saved = temp_elems_in_elem.stride(elem_gid);
-                    for (size_t i=0; i<num_saved; i++){
-                        
-                        if (neighbor_elem_gid == temp_elems_in_elem(elem_gid,i)){
-                            save=0;   // don't save, it has been saved already
+                    for (size_t i = 0; i < num_saved; i++)
+                    {
+                        if (neighbor_elem_gid == temp_elems_in_elem(elem_gid, i))
+                        {
+                            save = 0;   // don't save, it has been saved already
                         } // end if
-                        
                     } // end for i
-                    
-                    if (save==1){
-                        
+
+                    if (save == 1)
+                    {
                         // increment the number of neighboring elements saved
                         temp_elems_in_elem.stride(elem_gid)++;
-                        
+
                         // save the neighboring elem_gid
                         temp_elems_in_elem(elem_gid, num_saved) = neighbor_elem_gid;
-                        
-                        
                     } // end if save
-                    
                 } // end for elem_lid in a node
-
             }  // end for node_lid in an elem
-            
+
             // save the actial stride size
             num_elems_in_elem(elem_gid) = temp_elems_in_elem.stride(elem_gid);
-            
         }); // end FOR_ALL elems
         Kokkos::fence();
-        
-        
+
         // compress out the extra space in the temp_elems_in_elem
-        elems_in_elem = RaggedRightArrayKokkos <size_t> (num_elems_in_elem);
-        
+        elems_in_elem = RaggedRightArrayKokkos<size_t>(num_elems_in_elem);
+
         FOR_ALL_CLASS(elem_gid, 0, num_elems, {
-            for (size_t i=0; i<num_elems_in_elem(elem_gid); i++){
+            for (size_t i = 0; i < num_elems_in_elem(elem_gid); i++)
+            {
                 elems_in_elem(elem_gid, i) = temp_elems_in_elem(elem_gid, i);
             } // end for i
         });  // end FOR_ALL elems
         Kokkos::fence();
-      
+
         return;
-        
     } // end of build_elem_elem_connectivity
-        
-    
+
     // build the patches
-    void build_patch_connectivity(){
-        
+    void
+    build_patch_connectivity()
+    {
         size_t high_order = 0;
-        
+
         // building patches
-        DViewCArrayKokkos <size_t> node_ordering_in_elem;  // node lids in a patch
-        
-        num_nodes_in_patch = 2*(num_dims-1);  // 2 (2D) or 4 (3D)
-        num_patches_in_elem = 2*num_dims; // 4 (2D) or 6 (3D)
-        
-        
+        DViewCArrayKokkos<size_t> node_ordering_in_elem;  // node lids in a patch
+
+        num_nodes_in_patch  = 2 * (num_dims - 1); // 2 (2D) or 4 (3D)
+        num_patches_in_elem = 2 * num_dims; // 4 (2D) or 6 (3D)
+
         size_t node_lids_in_patch_in_elem[24];
-        
-        if(num_dims == 3) {
-            size_t temp_node_lids[24] = {0,4,7,3,
-                                         1,2,6,5,
-                                         0,1,5,4,
-                                         2,3,7,6,
-                                         0,3,2,1,
-                                         4,5,6,7};
-            
-            for (size_t i=0; i<24; i++){
+
+        if (num_dims == 3)
+        {
+            size_t temp_node_lids[24] = { 0, 4, 7, 3,
+                                          1, 2, 6, 5,
+                                          0, 1, 5, 4,
+                                          2, 3, 7, 6,
+                                          0, 3, 2, 1,
+                                          4, 5, 6, 7 };
+
+            for (size_t i = 0; i < 24; i++)
+            {
                 node_lids_in_patch_in_elem[i] = temp_node_lids[i];
             } // end for i
-
         }
-        else {
+        else
+        {
             //   J
             //   |
             // 3---2
@@ -393,582 +381,517 @@ struct mesh_t {
             // 0---1
             //
             size_t temp_node_lids[8] =
-               {0,3,
-                1,2,
-                0,1,
-                3,2};
-            
-            for (size_t i=0; i<8; i++){
+            { 0, 3,
+              1, 2,
+              0, 1,
+              3, 2 };
+
+            for (size_t i = 0; i < 8; i++)
+            {
                 node_lids_in_patch_in_elem[i] = temp_node_lids[i];
             } // end for i
-
         } // end if on dims
-        
-        node_ordering_in_elem = DViewCArrayKokkos <size_t> (&node_lids_in_patch_in_elem[0],num_patches_in_elem,num_nodes_in_patch);
-        
-        
-        // for saviong the hash keys of the patches and then the nighboring elem_gid
-        CArrayKokkos <int> hash_keys_in_elem (num_elems, num_patches_in_elem, num_nodes_in_patch); // always 4 ids in 3D
-        
-        
-        
-        // for saving the adjacient patch_lid, which is the slide_lid
-        //CArrayKokkos <size_t> neighboring_side_lids (num_elems, num_patches_in_elem);
-        
 
-        
+        node_ordering_in_elem = DViewCArrayKokkos<size_t>(&node_lids_in_patch_in_elem[0], num_patches_in_elem, num_nodes_in_patch);
+
+        // for saviong the hash keys of the patches and then the nighboring elem_gid
+        CArrayKokkos<int> hash_keys_in_elem(num_elems, num_patches_in_elem, num_nodes_in_patch); // always 4 ids in 3D
+
+        // for saving the adjacient patch_lid, which is the slide_lid
+        // CArrayKokkos <size_t> neighboring_side_lids (num_elems, num_patches_in_elem);
+
         // allocate memory for the patches in the elem
-        patches_in_elem = CArrayKokkos <size_t> (num_elems, num_patches_in_elem);
-        
-        
+        patches_in_elem = CArrayKokkos<size_t>(num_elems, num_patches_in_elem);
+
         // a temporary storaage for the patch_gids that are on the mesh boundary
-        CArrayKokkos <size_t> temp_bdy_patches(num_elems*num_patches_in_elem);
-        
+        CArrayKokkos<size_t> temp_bdy_patches(num_elems * num_patches_in_elem);
+
         // step 1) calculate the hash values for each patch in the element
         FOR_ALL_CLASS(elem_gid, 0, num_elems, {
-            
-            for (size_t patch_lid = 0; patch_lid<num_patches_in_elem; patch_lid++) {
-                
+            for (size_t patch_lid = 0; patch_lid < num_patches_in_elem; patch_lid++)
+            {
                 size_t sorted_patch_nodes[4];  // note: cannot be allocated with num_nodes_in_patch
-                
+
                 // first save the patch nodes
-                for (size_t patch_node_lid = 0; patch_node_lid<num_nodes_in_patch; patch_node_lid++){
-                    
+                for (size_t patch_node_lid = 0; patch_node_lid < num_nodes_in_patch; patch_node_lid++)
+                {
                     // get the local node index of the element for this patch and node in patch
                     size_t node_lid = node_ordering_in_elem(patch_lid, patch_node_lid);
-                    
+
                     // get and save the global index of the node
                     sorted_patch_nodes[patch_node_lid] = nodes_in_elem(elem_gid, node_lid);
-                    
                 }  // end for node_lid
-                
+
                 // sort nodes from smallest to largest
                 bubble_sort(sorted_patch_nodes, num_nodes_in_patch);
-                
+
                 // save hash_keys in the this elem
-                for (size_t key_lid=0; key_lid<num_nodes_in_patch; key_lid++){
+                for (size_t key_lid = 0; key_lid < num_nodes_in_patch; key_lid++)
+                {
                     hash_keys_in_elem(elem_gid, patch_lid, key_lid) = sorted_patch_nodes[key_lid];  // 4 node values are keys
                 } // for
-                
             } // end for patch_lid
-            
         }); // end FOR_ALL elem_gid
-        
-        DCArrayKokkos <size_t> num_values(2);
-        
-    // 8x8x8 mesh
-    // num_patches = 8*8*9*3 = 1728
-	// bdy_patches = 8*8*6 = 384
-    //
-        
+
+        DCArrayKokkos<size_t> num_values(2);
+
+        // 8x8x8 mesh
+        // num_patches = 8*8*9*3 = 1728
+        // bdy_patches = 8*8*6 = 384
+        //
+
         // step 2: walk around the elements and save the elem pairs that have the same hash_key
         RUN_CLASS({
             // serial execution on GPU
-            
-            size_t patch_gid = 0;
+
+            size_t patch_gid     = 0;
             size_t bdy_patch_gid = 0;
-            
-            for (size_t elem_gid = 0; elem_gid<num_elems; elem_gid++) {
-                
+
+            for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++)
+            {
                 // loop over the patches in this elem
-                for (size_t patch_lid = 0; patch_lid<num_patches_in_elem; patch_lid++) {
-                    
+                for (size_t patch_lid = 0; patch_lid < num_patches_in_elem; patch_lid++)
+                {
                     size_t exit = 0;
-                    
+
                     // negative values mean the patch has not been saved
-                    if (hash_keys_in_elem(elem_gid, patch_lid, 0)>=0){
-                        
+                    if (hash_keys_in_elem(elem_gid, patch_lid, 0) >= 0)
+                    {
                         // find the nighboring patch with the same hash_key
-                        
-                        for (size_t neighbor_elem_lid=0; neighbor_elem_lid<num_elems_in_elem(elem_gid); neighbor_elem_lid++){
-                             
-                            
+
+                        for (size_t neighbor_elem_lid = 0; neighbor_elem_lid < num_elems_in_elem(elem_gid); neighbor_elem_lid++)
+                        {
                             // get the neighboring element global index
                             size_t neighbor_elem_gid = elems_in_elem(elem_gid, neighbor_elem_lid);
-                            
-                            for (size_t neighbor_patch_lid=0; neighbor_patch_lid<num_patches_in_elem; neighbor_patch_lid++){
-                                
+
+                            for (size_t neighbor_patch_lid = 0; neighbor_patch_lid < num_patches_in_elem; neighbor_patch_lid++)
+                            {
                                 size_t save_it = 0;
-                                for (size_t key_lid=0; key_lid<num_nodes_in_patch; key_lid++){
-                                    
-                                    if (hash_keys_in_elem(neighbor_elem_gid, neighbor_patch_lid, key_lid) == hash_keys_in_elem(elem_gid, patch_lid, key_lid)){
-                                        save_it ++; // if save_it == num_nodes after this loop, then it is a match
+                                for (size_t key_lid = 0; key_lid < num_nodes_in_patch; key_lid++)
+                                {
+                                    if (hash_keys_in_elem(neighbor_elem_gid, neighbor_patch_lid, key_lid) == hash_keys_in_elem(elem_gid, patch_lid, key_lid))
+                                    {
+                                        save_it++; // if save_it == num_nodes after this loop, then it is a match
                                     }
-                                    
                                 } // end key loop
-                                
-                                
-                                
+
                                 // this hash is from the nodes on the patch
-                                if (save_it == num_nodes_in_patch){
-                    
-                                    
+                                if (save_it == num_nodes_in_patch)
+                                {
                                     // make it negative, because we saved it
                                     hash_keys_in_elem(elem_gid, patch_lid, 0) = -1;
                                     hash_keys_in_elem(neighbor_elem_gid, neighbor_patch_lid, 0) = -1;
-                                    
+
                                     // save the patch_lids for the adjacient sides
-                                    //neighboring_side_lids(elem_gid, patch_lid) = neighbor_patch_lid;
-                                    //neighboring_side_lids(neighbor_elem_gid, neighbor_patch_lid) = patch_lid;
-                                    
+                                    // neighboring_side_lids(elem_gid, patch_lid) = neighbor_patch_lid;
+                                    // neighboring_side_lids(neighbor_elem_gid, neighbor_patch_lid) = patch_lid;
+
                                     // save the patch_gid
                                     patches_in_elem(elem_gid, patch_lid) = patch_gid;
                                     patches_in_elem(neighbor_elem_gid, neighbor_patch_lid) = patch_gid;
-                    
+
                                     patch_gid++;
-                                    
+
                                     exit = 1;
                                     break;
                                 } // end if
-                    
                             } // end for loop over a neighbors patch set
-                            
-                            if (exit==1) break;
-                            
+
+                            if (exit == 1)
+                            {
+                                break;
+                            }
                         } // end for loop over elem neighbors
-                    
-                    
                     } // end if hash<0
-    
                 } // end for patch_lid
-                
-                
+
                 // loop over the patches in this element again
                 // remaining postive hash key values are the boundary patches
-                for (size_t patch_lid=0; patch_lid<num_patches_in_elem; patch_lid++) {
-                
-                    if( hash_keys_in_elem(elem_gid, patch_lid, 0)>=0 ){
-                
+                for (size_t patch_lid = 0; patch_lid < num_patches_in_elem; patch_lid++)
+                {
+                    if (hash_keys_in_elem(elem_gid, patch_lid, 0) >= 0)
+                    {
                         hash_keys_in_elem(elem_gid, patch_lid, 0) = -1;  // make it negative, because we saved it
-                        
-                        //neighboring_side_lids(elem_gid, patch_lid) = patch_lid;
-                        
+
+                        // neighboring_side_lids(elem_gid, patch_lid) = patch_lid;
+
                         patches_in_elem(elem_gid, patch_lid) = patch_gid;
-                        temp_bdy_patches(bdy_patch_gid) = patch_gid;
-                        
+                        temp_bdy_patches(bdy_patch_gid)      = patch_gid;
+
                         patch_gid++;
-                        bdy_patch_gid++;  
-                
+                        bdy_patch_gid++;
                     } // end if
-		    
-                
                 }  // end for over patch_lid
-                
             }  // end for over elem_gid
-            
-	    
+
             // the num_values is because the values passed in are const, so a const pointer is needed
             num_values(0) = patch_gid;     // num_patches = patch_gid;
             num_values(1) = bdy_patch_gid; // num_bdy_patches = bdy_patch_gid;
-	    
         }); // end RUN
         Kokkos::fence();
-        
+
         num_values.update_host();
         Kokkos::fence();
-        
-        num_patches = num_values.host(0);
+
+        num_patches     = num_values.host(0);
         num_bdy_patches = num_values.host(1);
-	
-        
-        //size_t mesh_1D = 60;
-        //size_t exact_num_patches = (mesh_1D*mesh_1D)*(mesh_1D+1)*3;
-        //size_t exact_num_bdy_patches = (mesh_1D*mesh_1D)*6;
-        //printf("num_patches = %lu, exact = %lu \n", num_patches, exact_num_patches);
-        //printf("num_bdy_patches = %lu exact = %lu \n", num_bdy_patches, exact_num_bdy_patches);
+
+        // size_t mesh_1D = 60;
+        // size_t exact_num_patches = (mesh_1D*mesh_1D)*(mesh_1D+1)*3;
+        // size_t exact_num_bdy_patches = (mesh_1D*mesh_1D)*6;
+        // printf("num_patches = %lu, exact = %lu \n", num_patches, exact_num_patches);
+        // printf("num_bdy_patches = %lu exact = %lu \n", num_bdy_patches, exact_num_bdy_patches);
         printf("Num patches = %lu \n", num_patches);
         printf("Num boundary patches = %lu \n", num_bdy_patches);
-        
-        elems_in_patch = CArrayKokkos <size_t> (num_patches, 2);
-        nodes_in_patch = CArrayKokkos <size_t> (num_patches, num_nodes_in_patch);
-    
+
+        elems_in_patch = CArrayKokkos<size_t>(num_patches, 2);
+        nodes_in_patch = CArrayKokkos<size_t>(num_patches, num_nodes_in_patch);
+
         // a temporary variable to help populate patch structures
-        CArrayKokkos <size_t> num_elems_in_patch_saved (num_patches);
-        
+        CArrayKokkos<size_t> num_elems_in_patch_saved(num_patches);
+
         // initialize the number of elems in a patch saved to zero
         FOR_ALL_CLASS(patch_gid, 0, num_patches, {
             num_elems_in_patch_saved(patch_gid) = 0;
         });
-        
-        for(size_t elem_gid=0; elem_gid<num_elems; elem_gid++) {
-            
+
+        for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++)
+        {
             FOR_ALL_CLASS(patch_lid, 0, num_patches_in_elem, {
-                
                 size_t patch_gid = patches_in_elem(elem_gid, patch_lid);
-                
+
                 size_t num_saved = num_elems_in_patch_saved(patch_gid);
-                
+
                 elems_in_patch(patch_gid, num_saved) = elem_gid;
-                
+
                 // record that an elem_gid was saved
-                num_elems_in_patch_saved(patch_gid) ++;
-                
+                num_elems_in_patch_saved(patch_gid)++;
+
                 // save the nodes on this patch
-                for (size_t patch_node_lid = 0; patch_node_lid<num_nodes_in_patch; patch_node_lid++){
-                    
+                for (size_t patch_node_lid = 0; patch_node_lid < num_nodes_in_patch; patch_node_lid++)
+                {
                     // get the local node index of the element for this patch and node in patch
                     size_t node_lid = node_ordering_in_elem(patch_lid, patch_node_lid);
-                    
+
                     // get and save the global index of the node
                     nodes_in_patch(patch_gid, patch_node_lid) = nodes_in_elem(elem_gid, node_lid);
                 }  // end for node_lid
-                
             }); // end FOR_ALL patch_lid
-            
         } // end for
-        
-        
-        
-        // Surfaces and patches in surface
-        if(high_order==1) {
-            
-            num_surfs_in_elem = 2*num_dims; // 4 (2D) or 6 (3D)
-            num_patches_in_surf = 1;  // =Pn_order, must update for high-order mesh class
-        
-            // allocate memory for the surfaces in the elem
-            surfs_in_elem = CArrayKokkos <size_t> (num_elems, num_surfs_in_elem);
 
-            
+        // Surfaces and patches in surface
+        if (high_order == 1)
+        {
+            num_surfs_in_elem   = 2 * num_dims; // 4 (2D) or 6 (3D)
+            num_patches_in_surf = 1;  // =Pn_order, must update for high-order mesh class
+
+            // allocate memory for the surfaces in the elem
+            surfs_in_elem = CArrayKokkos<size_t>(num_elems, num_surfs_in_elem);
+
             // allocate memory for surface data structures
-            num_surfs = num_patches/num_patches_in_surf;
-            
-            patches_in_surf = CArrayKokkos <size_t> (num_surfs, num_patches_in_surf);
-            elems_in_surf = CArrayKokkos <size_t> (num_surfs, 2);
-            surf_in_patch = CArrayKokkos <size_t> (num_patches);
-            
+            num_surfs = num_patches / num_patches_in_surf;
+
+            patches_in_surf = CArrayKokkos<size_t>(num_surfs, num_patches_in_surf);
+            elems_in_surf   = CArrayKokkos<size_t>(num_surfs, 2);
+            surf_in_patch   = CArrayKokkos<size_t>(num_patches);
+
             FOR_ALL_CLASS(surf_gid, 0, num_surfs, {
-                
                 // loop over the patches in this surface
-                for(size_t patch_lid = 0; patch_lid < num_patches_in_surf; patch_lid++){
-                    
+                for (size_t patch_lid = 0; patch_lid < num_patches_in_surf; patch_lid++)
+                {
                     // get patch_gid
-                    size_t patch_gid = patch_lid + surf_gid*num_patches_in_surf;
-                    
+                    size_t patch_gid = patch_lid + surf_gid * num_patches_in_surf;
+
                     // save the patch_gids
                     patches_in_surf(surf_gid, patch_lid) = patch_gid;
-                    
+
                     // save the surface this patch belongs to
                     surf_in_patch(patch_gid) = surf_gid;
-                    
                 } // end for
-                
-                
+
                 // get first patch in the surface, and populate elem surface structures
-                size_t this_patch_gid = surf_gid*num_patches_in_surf;
-  
-                elems_in_surf(surf_gid,0) = elems_in_patch(this_patch_gid,0);  // elem_gid0
-                elems_in_surf(surf_gid,1) = elems_in_patch(this_patch_gid,1);  // elem_gid1
-                
+                size_t this_patch_gid = surf_gid * num_patches_in_surf;
+
+                elems_in_surf(surf_gid, 0) = elems_in_patch(this_patch_gid, 0);  // elem_gid0
+                elems_in_surf(surf_gid, 1) = elems_in_patch(this_patch_gid, 1);  // elem_gid1
             }); // end FOR_ALL over surfaces
-            
-            
+
             // save surfaces in elem
             FOR_ALL_CLASS(elem_gid, 0, num_elems, {
-                
-                for(size_t surf_lid = 0; surf_lid < num_surfs_in_elem; surf_lid++){
-                    
+                for (size_t surf_lid = 0; surf_lid < num_surfs_in_elem; surf_lid++)
+                {
                     // get the local patch_lid
-                    size_t patch_lid = surf_lid*num_patches_in_surf;
-                    
+                    size_t patch_lid = surf_lid * num_patches_in_surf;
+
                     // get the patch_gids in this element
                     size_t patch_gid = patches_in_elem(elem_gid, patch_lid);
-                    
-                    // save the surface gid
-                    surfs_in_elem(elem_gid,surf_lid) = surf_in_patch(patch_gid);
 
+                    // save the surface gid
+                    surfs_in_elem(elem_gid, surf_lid) = surf_in_patch(patch_gid);
                 } // end surf_lid
-                
             });
-            
-        
         } // end of high-order mesh objects
-                          
+
         // ----------------
-        
-        
+
         // allocate memory for boundary patches
-        bdy_patches = CArrayKokkos <size_t> (num_bdy_patches);
-        
+        bdy_patches = CArrayKokkos<size_t>(num_bdy_patches);
+
         FOR_ALL_CLASS(bdy_patch_gid, 0, num_bdy_patches, {
             bdy_patches(bdy_patch_gid) = temp_bdy_patches(bdy_patch_gid);
         }); // end FOR_ALL bdy_patch_gid
-        
-        
-        
-        
+
         // find and store the boundary nodes
-        CArrayKokkos <size_t> temp_bdy_nodes(num_nodes);
-        CArrayKokkos <long long int> hash_bdy_nodes(num_nodes);
-        
-        FOR_ALL_CLASS (node_gid, 0, num_nodes, {
+        CArrayKokkos<size_t>        temp_bdy_nodes(num_nodes);
+        CArrayKokkos<long long int> hash_bdy_nodes(num_nodes);
+
+        FOR_ALL_CLASS(node_gid, 0, num_nodes, {
             hash_bdy_nodes(node_gid) = -1;
         }); // end for node_gid
-        
+
         // Parallel loop over boundary patches
-        DCArrayKokkos <size_t> num_bdy_nodes_saved(1);
-        
+        DCArrayKokkos<size_t> num_bdy_nodes_saved(1);
+
         RUN_CLASS({
             num_bdy_nodes_saved(0) = 0;
-            for (size_t bdy_patch_gid=0; bdy_patch_gid<num_bdy_patches; bdy_patch_gid++) {
-                
+            for (size_t bdy_patch_gid = 0; bdy_patch_gid < num_bdy_patches; bdy_patch_gid++)
+            {
                 // get the global index of the patch that is on the boundary
                 size_t patch_gid = bdy_patches(bdy_patch_gid);
-                
+
                 // tag the boundary nodes
-                for (size_t node_lid=0; node_lid<num_nodes_in_patch; node_lid++){
-                    
+                for (size_t node_lid = 0; node_lid < num_nodes_in_patch; node_lid++)
+                {
                     size_t node_gid = nodes_in_patch(patch_gid, node_lid);
-                    
-                    if (hash_bdy_nodes(node_gid) < 0){
+
+                    if (hash_bdy_nodes(node_gid) < 0)
+                    {
                         hash_bdy_nodes(node_gid) = node_gid;
                         temp_bdy_nodes(num_bdy_nodes_saved(0)) = node_gid;
-                        
-                        //printf("bdy_node = %lu \n", node_gid);
+
+                        // printf("bdy_node = %lu \n", node_gid);
                         num_bdy_nodes_saved(0)++;
                     } // end if
-                    
                 } // end for node_lid
-                
             } // end for loop over bdy_patch_gid
-            
         });  // end RUN
         Kokkos::fence();
-        
+
         // copy value to host (CPU)
         num_bdy_nodes_saved.update_host();
         Kokkos::fence();
-        
+
         // save the number of bdy_nodes to mesh_t
         num_bdy_nodes = num_bdy_nodes_saved.host(0);
-        
-        bdy_nodes = CArrayKokkos <size_t> (num_bdy_nodes);
-        
-        FOR_ALL_CLASS (node_gid, 0, num_bdy_nodes, {
+
+        bdy_nodes = CArrayKokkos<size_t>(num_bdy_nodes);
+
+        FOR_ALL_CLASS(node_gid, 0, num_bdy_nodes, {
             bdy_nodes(node_gid) = temp_bdy_nodes(node_gid);
         }); // end for boundary node_gid
-        
+
         printf("Num boundary nodes = %lu \n", num_bdy_nodes);
-        
+
         return;
-        
     } // end patch connectivity method
-    
-    
-    
+
     // build the patches
-    void build_node_node_connectivity(){
-        
-        
+    void
+    build_node_node_connectivity()
+    {
         // find the max number of elems around a node
         size_t max_num_elems_in_node;
         size_t max_num_lcl;
         REDUCE_MAX_CLASS(node_gid, 0, num_nodes, max_num_lcl, {
-            
             // num_corners_in_node = num_elems_in_node
             size_t max_num = num_corners_in_node(node_gid);
-            
-            if (max_num > max_num_lcl) max_num_lcl = max_num;
-                    
+
+            if (max_num > max_num_lcl)
+            {
+                max_num_lcl = max_num;
+            }
         }, max_num_elems_in_node); // end parallel reduction on max
         Kokkos::fence();
-        
+
         // each elem corner will contribute 3 edges to the node. Those edges will likely be the same
         // ones from an adjacent element so it is a safe estimate to multiply by 3
-        DynamicRaggedRightArrayKokkos <size_t> temp_nodes_in_nodes(num_nodes, max_num_elems_in_node*3);
-        
-        num_nodes_in_node = CArrayKokkos <size_t> (num_nodes);
-        
+        DynamicRaggedRightArrayKokkos<size_t> temp_nodes_in_nodes(num_nodes, max_num_elems_in_node * 3);
+
+        num_nodes_in_node = CArrayKokkos<size_t>(num_nodes);
+
         // walk over the patches and save the node node connectivity
         RUN_CLASS({
-            if (num_dims==3){
-                
-                for (size_t patch_gid=0; patch_gid<num_patches; patch_gid++){
-                    for (size_t node_lid=0; node_lid<num_nodes_in_patch; node_lid++){
-                        
+            if (num_dims == 3)
+            {
+                for (size_t patch_gid = 0; patch_gid < num_patches; patch_gid++)
+                {
+                    for (size_t node_lid = 0; node_lid < num_nodes_in_patch; node_lid++)
+                    {
                         // the first node on the edge
                         size_t node_gid_0 = nodes_in_patch(patch_gid, node_lid);
-                        
+
                         // second node on this edge
                         size_t node_gid_1;
-                        
-                        if (node_lid == num_nodes_in_patch-1){
+
+                        if (node_lid == num_nodes_in_patch - 1)
+                        {
                             node_gid_1 = nodes_in_patch(patch_gid, 0);
                         }
-                        else {
-                            node_gid_1 = nodes_in_patch(patch_gid, node_lid+1);
+                        else
+                        {
+                            node_gid_1 = nodes_in_patch(patch_gid, node_lid + 1);
                         } // end if
-                        
+
                         size_t num_saved_0 = temp_nodes_in_nodes.stride(node_gid_0);
                         size_t num_saved_1 = temp_nodes_in_nodes.stride(node_gid_1);
-                        
+
                         size_t save_0 = 1;
                         size_t save_1 = 1;
-                        
+
                         // check to see if the node_gid_1 was already saved
-                        for (size_t contents_lid=0; contents_lid<num_saved_0; contents_lid++){
-                            if (temp_nodes_in_nodes(node_gid_0, contents_lid) == node_gid_1){
+                        for (size_t contents_lid = 0; contents_lid < num_saved_0; contents_lid++)
+                        {
+                            if (temp_nodes_in_nodes(node_gid_0, contents_lid) == node_gid_1)
+                            {
                                 save_0 = 0; // don't save, it was already saved
                             }
                         }
-                        
+
                         // check to see if the node_gid_0 was already saved
-                        for (size_t contents_lid=0; contents_lid<num_saved_1; contents_lid++){
-                            if (temp_nodes_in_nodes(node_gid_1, contents_lid) == node_gid_0){
+                        for (size_t contents_lid = 0; contents_lid < num_saved_1; contents_lid++)
+                        {
+                            if (temp_nodes_in_nodes(node_gid_1, contents_lid) == node_gid_0)
+                            {
                                 save_1 = 0;  // don't save, it was already saved
                             }
                         }
-                        
-                        if (save_0 == 1){
+
+                        if (save_0 == 1)
+                        {
                             // increment the number of nodes in a node saved
                             temp_nodes_in_nodes.stride(node_gid_0)++;
-                            
+
                             // save the second node to the first node
                             temp_nodes_in_nodes(node_gid_0, num_saved_0) = node_gid_1;
-                            
-                            
                         }
-                        
-                        if (save_1 == 1){
+
+                        if (save_1 == 1)
+                        {
                             // increment the number of nodes in a node saved
                             temp_nodes_in_nodes.stride(node_gid_1)++;
-                            
+
                             // save the first node to the second node
                             temp_nodes_in_nodes(node_gid_1, num_saved_1) = node_gid_0;
-                            
-                            
                         }
-                        
+
                         // save the strides
                         num_nodes_in_node(node_gid_0) = temp_nodes_in_nodes.stride(node_gid_0);
                         num_nodes_in_node(node_gid_1) = temp_nodes_in_nodes.stride(node_gid_1);
-                        
                     } // end for node in patch
                 } // end for patches
-                
             } // end if 3D
-            else {
-                for (size_t patch_gid=0; patch_gid<num_patches; patch_gid++){
-                    
+            else
+            {
+                for (size_t patch_gid = 0; patch_gid < num_patches; patch_gid++)
+                {
                     // the first node on the edge
                     size_t node_gid_0 = nodes_in_patch(patch_gid, 0);
-                    
+
                     // second node on this edge
                     size_t node_gid_1 = nodes_in_patch(patch_gid, 1);
-                    
+
                     size_t num_saved_0 = temp_nodes_in_nodes.stride(node_gid_0);
                     size_t num_saved_1 = temp_nodes_in_nodes.stride(node_gid_1);
-                    
+
                     // increment the number of nodes in a node saved
                     temp_nodes_in_nodes.stride(node_gid_0)++;
                     temp_nodes_in_nodes.stride(node_gid_1)++;
-                    
+
                     // save the second node to the first node
                     temp_nodes_in_nodes(node_gid_0, num_saved_0) = node_gid_1;
-                    
+
                     // save the first node to the second node
                     temp_nodes_in_nodes(node_gid_1, num_saved_1) = node_gid_0;
-                    
-                    
+
                     // save the strides
                     num_nodes_in_node(node_gid_0) = temp_nodes_in_nodes.stride(node_gid_0);
                     num_nodes_in_node(node_gid_1) = temp_nodes_in_nodes.stride(node_gid_1);
-                        
                 } // end for patches
-                
             } // end if 2D
-            
         });  // end RUN
         Kokkos::fence();
-        
-        nodes_in_node = RaggedRightArrayKokkos <size_t> (num_nodes_in_node);
-        
+
+        nodes_in_node = RaggedRightArrayKokkos<size_t>(num_nodes_in_node);
+
         // save the connectivity
         FOR_ALL_CLASS(node_gid, 0, num_nodes, {
-            
             size_t num_saved = 0;
-            for (size_t node_lid=0; node_lid<num_nodes_in_node(node_gid); node_lid++){
-                
+            for (size_t node_lid = 0; node_lid < num_nodes_in_node(node_gid); node_lid++)
+            {
                 nodes_in_node(node_gid, num_saved) = temp_nodes_in_nodes(node_gid, num_saved);
-                
-                // increment the number of nodes in node saved
-                num_saved ++;
-                
-            } // end for node_lid
-            
-            
-        }); // end parallel for over nodes
-        
-    } // end of node node connectivity
-    
-    
 
-    
-    
-    void init_bdy_sets (size_t num_bcs){
-        
-        if(num_bcs == 0){
+                // increment the number of nodes in node saved
+                num_saved++;
+            } // end for node_lid
+        }); // end parallel for over nodes
+    } // end of node node connectivity
+
+    void
+    init_bdy_sets(size_t num_bcs)
+    {
+        if (num_bcs == 0)
+        {
             printf("ERROR: number of boundary sets = 0, set it = 1");
             num_bcs = 1;
         }
-        num_bdy_sets = num_bcs;
-        bdy_patches_in_set = DynamicRaggedRightArrayKokkos <size_t> (num_bcs, num_bdy_patches);
-        
+        num_bdy_sets       = num_bcs;
+        bdy_patches_in_set = DynamicRaggedRightArrayKokkos<size_t>(num_bcs, num_bdy_patches);
+
         return;
-        
     } // end of init_bdy_sets method
-    
-
-    
 }; // end mesh_t
-
 
 namespace region
 {
-
-    // for tagging boundary faces
-    enum vol_tag
-    {
-        global = 0,     // tag every elements in the mesh
-        box = 1,        // tag all elements inside a box
-        cylinder = 2,   // tag all elements inside a cylinder
-        sphere = 3,     // tag all elements inside a sphere
-        readVoxelFile = 4       // tag all elements in a voxel mesh input
-    };
-
+// for tagging boundary faces
+enum vol_tag
+{
+    global = 0,         // tag every elements in the mesh
+    box = 1,            // tag all elements inside a box
+    cylinder = 2,       // tag all elements inside a cylinder
+    sphere = 3,         // tag all elements inside a sphere
+    readVoxelFile = 4           // tag all elements in a voxel mesh input
+};
 } // end of namespace
-
 
 namespace init_conds
 {
-    
-    // applying initial conditions
-    enum init_velocity_conds
-    {
-        // uniform
-        cartesian = 0,   // cart velocity
-        radial = 1,      // radial in the (x,y) plane where x=r*cos(theta) and y=r*sin(theta)
-        spherical = 2,   // spherical
-    
-        // linear variation
-        radial_linear = 3,     // linear variation from 0,0,0
-        spherical_linear = 4,   // linear variation from 0,0,0
-    
-        // vortical initial conditions
-        tg_vortex = 5
-    };
-    
+// applying initial conditions
+enum init_velocity_conds
+{
+    // uniform
+    cartesian = 0,       // cart velocity
+    radial = 1,          // radial in the (x,y) plane where x=r*cos(theta) and y=r*sin(theta)
+    spherical = 2,       // spherical
+
+    // linear variation
+    radial_linear = 3,         // linear variation from 0,0,0
+    spherical_linear = 4,       // linear variation from 0,0,0
+
+    // vortical initial conditions
+    tg_vortex = 5
+};
 } // end of initial conditions namespace
 
-
 // fill instructions
-struct mat_fill_t {
-    
+struct mat_fill_t
+{
     // type
     region::vol_tag volume; // 1 is global, 2 are planes, 3 is a sphere
-    
+
     // material id
     size_t mat_id;
-    
+
     // planes
     double x1;
     double x2;
@@ -976,68 +899,61 @@ struct mat_fill_t {
     double y2;
     double z1;
     double z2;
-    
+
     // radius
     double radius1;
     double radius2;
 
-    
     // initial conditions
     init_conds::init_velocity_conds velocity;
-    
+
     // velocity coefficients by component
-    double u,v,w;
-    
+    double u, v, w;
+
     // velocity magnitude for radial velocity initialization
     double speed;
-    
+
     double sie;  // specific internal energy
     double den;  // density
 };
 
-
 namespace bdy
 {
-    
-    // for tagging boundary faces
-    enum bdy_tag
-    {
-        x_plane  = 0,   // tag an x-plane
-        y_plane  = 1,   // tag an y-plane
-        z_plane  = 2,   // tag an z-plane
-        cylinder = 3,   // tag an cylindrical surface
-        sphere   = 4,   // tag a spherical surface
-        readFile = 5    // read from a file
-    };
-    
-    
-    
-    // for enforcing boundary conditions
-    enum bdy_hydro_conds
-    {
-        fixed = 0,          // zero velocity
-        reflected = 1,      // reflected or wall condition
-        velocity = 2,       // constant velocity
-        pressure = 3,       // constant pressure
-        acceleration = 4,   // constant acceleration
-        contact = 5         // contact surface
-    };
+// for tagging boundary faces
+enum bdy_tag
+{
+    x_plane = 0,        // tag an x-plane
+    y_plane = 1,        // tag an y-plane
+    z_plane = 2,        // tag an z-plane
+    cylinder = 3,       // tag an cylindrical surface
+    sphere = 4,         // tag a spherical surface
+    readFile = 5        // read from a file
+};
 
+// for enforcing boundary conditions
+enum bdy_hydro_conds
+{
+    fixed = 0,              // zero velocity
+    reflected = 1,          // reflected or wall condition
+    velocity = 2,           // constant velocity
+    pressure = 3,           // constant pressure
+    acceleration = 4,       // constant acceleration
+    contact = 5             // contact surface
+};
 } // end of bdy namespace
 
-
 // tag mesh points on bdy's and set the BC type
-struct boundary_t {
-
+struct boundary_t
+{
     // tag surface type
     bdy::bdy_tag surface;    // 0=xplane, 1=yplane, 2=zplane, 3=cylinder, 4=sphere, 5=read file
-    
+
     // tag surface value or radius
     real_t value;
-    
+
     // BC type
     bdy::bdy_hydro_conds hydro_bc;
-    
+
     // velocity
     // if t_end > time > t_start
     // v(t) = v0 exp(-v1*(time - time_start) )
@@ -1047,469 +963,428 @@ struct boundary_t {
     double hydro_bc_vel_t_end;
 };
 
-
-void read_mesh_ensight(char* MESH,
-                       mesh_t &mesh,
-                       node_t &node,
-                       elem_t &elem,
-                       corner_t &corner,
+void read_mesh_ensight(char*        MESH,
+                       mesh_t&      mesh,
+                       node_t&      node,
+                       elem_t&      elem,
+                       corner_t&    corner,
                        const size_t num_dims,
                        const size_t rk_num_bins);
 
+void input(CArrayKokkos<material_t>& material,
+           CArrayKokkos<mat_fill_t>& mat_fill,
+           CArrayKokkos<boundary_t>& boundary,
+           CArrayKokkos<double>&     state_vars,
+           size_t&                   num_materials,
+           size_t&                   num_fills,
+           size_t&                   num_boundaries,
+           size_t&                   num_dims,
+           size_t&                   num_state_vars,
+           double&                   dt_start,
+           double&                   time_final,
+           double&                   dt_max,
+           double&                   dt_min,
+           double&                   dt_cfl,
+           double&                   graphics_dt_ival,
+           size_t&                   graphics_cyc_ival,
+           size_t&                   cycle_stop,
+           size_t&                   rk_num_stages);
 
-void input(CArrayKokkos <material_t> &material,
-           CArrayKokkos <mat_fill_t> &mat_fill,
-           CArrayKokkos <boundary_t> &boundary,
-           CArrayKokkos <double> &state_vars,
-           size_t &num_materials,
-           size_t &num_fills,
-           size_t &num_boundaries,
-           size_t &num_dims,
-           size_t &num_state_vars,
-           double &dt_start,
-           double &time_final,
-           double &dt_max,
-           double &dt_min,
-           double &dt_cfl,
-           double &graphics_dt_ival,
-           size_t &graphics_cyc_ival,
-           size_t &cycle_stop,
-           size_t &rk_num_stages);
-
-
-void get_vol(const DViewCArrayKokkos <double> &elem_vol,
-             const DViewCArrayKokkos <double> &node_coords,
-             const mesh_t &mesh);
-
+void get_vol(const DViewCArrayKokkos<double>& elem_vol,
+             const DViewCArrayKokkos<double>& node_coords,
+             const mesh_t&                    mesh);
 
 KOKKOS_FUNCTION
-void get_vol_hex(const DViewCArrayKokkos <double> &elem_vol,
-                 const size_t elem_gid,
-                 const DViewCArrayKokkos <double> &node_coords,
-                 const ViewCArrayKokkos <size_t>  &elem_node_gids);
-
-
-KOKKOS_FUNCTION
-void get_vol_quad(const DViewCArrayKokkos <double> &elem_vol,
-                  const size_t elem_gid,
-                  const DViewCArrayKokkos <double> &node_coords,
-                  const ViewCArrayKokkos <size_t>  &elem_node_gids);
-
+void get_vol_hex(const DViewCArrayKokkos<double>& elem_vol,
+                 const size_t                     elem_gid,
+                 const DViewCArrayKokkos<double>& node_coords,
+                 const ViewCArrayKokkos<size_t>&  elem_node_gids);
 
 KOKKOS_FUNCTION
-double get_area_quad(const size_t elem_gid,
-                     const DViewCArrayKokkos <double> &node_coords,
-                     const ViewCArrayKokkos <size_t>  &elem_node_gids);
-
-
-KOKKOS_FUNCTION
-void get_bmatrix(const ViewCArrayKokkos <double> &B_matrix,
-                 const size_t elem_gid,
-                 const DViewCArrayKokkos <double> &node_coords,
-                 const ViewCArrayKokkos <size_t>  &elem_node_gids);
-
+void get_vol_quad(const DViewCArrayKokkos<double>& elem_vol,
+                  const size_t                     elem_gid,
+                  const DViewCArrayKokkos<double>& node_coords,
+                  const ViewCArrayKokkos<size_t>&  elem_node_gids);
 
 KOKKOS_FUNCTION
-void get_bmatrix2D(const ViewCArrayKokkos <double> &B_matrix,
-                   const size_t elem_gid,
-                   const DViewCArrayKokkos <double> &node_coords,
-                   const ViewCArrayKokkos <size_t>  &elem_node_gids);
-
-
-void setup(const CArrayKokkos <material_t> &material,
-           const CArrayKokkos <mat_fill_t> &mat_fill,
-           const CArrayKokkos <boundary_t> &boundary,
-           mesh_t &mesh,
-           const DViewCArrayKokkos <double> &node_coords,
-           DViewCArrayKokkos <double> &node_vel,
-           DViewCArrayKokkos <double> &node_mass,
-           const DViewCArrayKokkos <double> &elem_den,
-           const DViewCArrayKokkos <double> &elem_pres,
-           const DViewCArrayKokkos <double> &elem_stress,
-           const DViewCArrayKokkos <double> &elem_sspd,
-           const DViewCArrayKokkos <double> &elem_sie,
-           const DViewCArrayKokkos <double> &elem_vol,
-           const DViewCArrayKokkos <double> &elem_mass,
-           const DViewCArrayKokkos <size_t> &elem_mat_id,
-           const DViewCArrayKokkos <double> &elem_statev,
-           const CArrayKokkos <double> &state_vars,
-           const DViewCArrayKokkos <double> &corner_mass,
-           const size_t num_fills,
-           const size_t rk_num_bins,
-           const size_t num_bdy_sets,
-           const size_t num_materials,
-           const size_t num_state_vars);
-
-
-void write_outputs (const mesh_t &mesh,
-                    DViewCArrayKokkos <double> &node_coords,
-                    DViewCArrayKokkos <double> &node_vel,
-                    DViewCArrayKokkos <double> &node_mass,
-                    DViewCArrayKokkos <double> &elem_den,
-                    DViewCArrayKokkos <double> &elem_pres,
-                    DViewCArrayKokkos <double> &elem_stress,
-                    DViewCArrayKokkos <double> &elem_sspd,
-                    DViewCArrayKokkos <double> &elem_sie,
-                    DViewCArrayKokkos <double> &elem_vol,
-                    DViewCArrayKokkos <double> &elem_mass,
-                    DViewCArrayKokkos <size_t> &elem_mat_id,
-                    CArray <double> &graphics_times,
-                    size_t &graphics_id,
-                    const double time_value);
-
-
-void ensight(const mesh_t &mesh,
-             const DViewCArrayKokkos <double> &node_coords,
-             const DViewCArrayKokkos <double> &node_vel,
-             const DViewCArrayKokkos <double> &node_mass,
-             const DViewCArrayKokkos <double> &elem_den,
-             const DViewCArrayKokkos <double> &elem_pres,
-             const DViewCArrayKokkos <double> &elem_stress,
-             const DViewCArrayKokkos <double> &elem_sspd,
-             const DViewCArrayKokkos <double> &elem_sie,
-             const DViewCArrayKokkos <double> &elem_vol,
-             const DViewCArrayKokkos <double> &elem_mass,
-             const DViewCArrayKokkos <size_t> &elem_mat_id,
-             CArray <double> &graphics_times,
-             size_t &graphics_id,
-             const double time_value);
-
-
-void state_file(const mesh_t &mesh,
-                const DViewCArrayKokkos <double> &node_coords,
-                const DViewCArrayKokkos <double> &node_vel,
-                const DViewCArrayKokkos <double> &node_mass,
-                const DViewCArrayKokkos <double> &elem_den,
-                const DViewCArrayKokkos <double> &elem_pres,
-                const DViewCArrayKokkos <double> &elem_stress,
-                const DViewCArrayKokkos <double> &elem_sspd,
-                const DViewCArrayKokkos <double> &elem_sie,
-                const DViewCArrayKokkos <double> &elem_vol,
-                const DViewCArrayKokkos <double> &elem_mass,
-                const DViewCArrayKokkos <size_t> &elem_mat_id,
-                const double time_value );
-
-
-void tag_bdys(const CArrayKokkos <boundary_t> &boundary,
-              mesh_t &mesh,
-              const DViewCArrayKokkos <double> &node_coords);
-
+double get_area_quad(const size_t                     elem_gid,
+                     const DViewCArrayKokkos<double>& node_coords,
+                     const ViewCArrayKokkos<size_t>&  elem_node_gids);
 
 KOKKOS_FUNCTION
-size_t check_bdy(const size_t patch_gid,
-                 const int this_bc_tag,
-                 const double val,
-                 const mesh_t &mesh,
-                 const DViewCArrayKokkos <double> &node_coords);
-
-
-void build_boundry_node_sets(const CArrayKokkos <boundary_t> &boundary,
-                             mesh_t &mesh);
-
-
-void boundary_velocity(const mesh_t &mesh,
-                       const CArrayKokkos <boundary_t> &boundary,
-                       DViewCArrayKokkos <double> &node_vel,
-                       const double time_value);
-
+void get_bmatrix(const ViewCArrayKokkos<double>&  B_matrix,
+                 const size_t                     elem_gid,
+                 const DViewCArrayKokkos<double>& node_coords,
+                 const ViewCArrayKokkos<size_t>&  elem_node_gids);
 
 KOKKOS_FUNCTION
-void ideal_gas(const DViewCArrayKokkos <double> &elem_pres,
-               const DViewCArrayKokkos <double> &elem_stress,
-               const size_t elem_gid,
-               const size_t mat_id,
-               const DViewCArrayKokkos <double> &elem_state_vars,
-               const DViewCArrayKokkos <double> &elem_sspd,
-               const double den,
-               const double sie);
+void get_bmatrix2D(const ViewCArrayKokkos<double>&  B_matrix,
+                   const size_t                     elem_gid,
+                   const DViewCArrayKokkos<double>& node_coords,
+                   const ViewCArrayKokkos<size_t>&  elem_node_gids);
 
+void setup(const CArrayKokkos<material_t>&  material,
+           const CArrayKokkos<mat_fill_t>&  mat_fill,
+           const CArrayKokkos<boundary_t>&  boundary,
+           mesh_t&                          mesh,
+           const DViewCArrayKokkos<double>& node_coords,
+           DViewCArrayKokkos<double>&       node_vel,
+           DViewCArrayKokkos<double>&       node_mass,
+           const DViewCArrayKokkos<double>& elem_den,
+           const DViewCArrayKokkos<double>& elem_pres,
+           const DViewCArrayKokkos<double>& elem_stress,
+           const DViewCArrayKokkos<double>& elem_sspd,
+           const DViewCArrayKokkos<double>& elem_sie,
+           const DViewCArrayKokkos<double>& elem_vol,
+           const DViewCArrayKokkos<double>& elem_mass,
+           const DViewCArrayKokkos<size_t>& elem_mat_id,
+           const DViewCArrayKokkos<double>& elem_statev,
+           const CArrayKokkos<double>&      state_vars,
+           const DViewCArrayKokkos<double>& corner_mass,
+           const size_t                     num_fills,
+           const size_t                     rk_num_bins,
+           const size_t                     num_bdy_sets,
+           const size_t                     num_materials,
+           const size_t                     num_state_vars);
+
+void write_outputs(const mesh_t&              mesh,
+                   DViewCArrayKokkos<double>& node_coords,
+                   DViewCArrayKokkos<double>& node_vel,
+                   DViewCArrayKokkos<double>& node_mass,
+                   DViewCArrayKokkos<double>& elem_den,
+                   DViewCArrayKokkos<double>& elem_pres,
+                   DViewCArrayKokkos<double>& elem_stress,
+                   DViewCArrayKokkos<double>& elem_sspd,
+                   DViewCArrayKokkos<double>& elem_sie,
+                   DViewCArrayKokkos<double>& elem_vol,
+                   DViewCArrayKokkos<double>& elem_mass,
+                   DViewCArrayKokkos<size_t>& elem_mat_id,
+                   CArray<double>&            graphics_times,
+                   size_t&                    graphics_id,
+                   const double               time_value);
+
+void ensight(const mesh_t&                    mesh,
+             const DViewCArrayKokkos<double>& node_coords,
+             const DViewCArrayKokkos<double>& node_vel,
+             const DViewCArrayKokkos<double>& node_mass,
+             const DViewCArrayKokkos<double>& elem_den,
+             const DViewCArrayKokkos<double>& elem_pres,
+             const DViewCArrayKokkos<double>& elem_stress,
+             const DViewCArrayKokkos<double>& elem_sspd,
+             const DViewCArrayKokkos<double>& elem_sie,
+             const DViewCArrayKokkos<double>& elem_vol,
+             const DViewCArrayKokkos<double>& elem_mass,
+             const DViewCArrayKokkos<size_t>& elem_mat_id,
+             CArray<double>&                  graphics_times,
+             size_t&                          graphics_id,
+             const double                     time_value);
+
+void state_file(const mesh_t&                    mesh,
+                const DViewCArrayKokkos<double>& node_coords,
+                const DViewCArrayKokkos<double>& node_vel,
+                const DViewCArrayKokkos<double>& node_mass,
+                const DViewCArrayKokkos<double>& elem_den,
+                const DViewCArrayKokkos<double>& elem_pres,
+                const DViewCArrayKokkos<double>& elem_stress,
+                const DViewCArrayKokkos<double>& elem_sspd,
+                const DViewCArrayKokkos<double>& elem_sie,
+                const DViewCArrayKokkos<double>& elem_vol,
+                const DViewCArrayKokkos<double>& elem_mass,
+                const DViewCArrayKokkos<size_t>& elem_mat_id,
+                const double                     time_value);
+
+void tag_bdys(const CArrayKokkos<boundary_t>&  boundary,
+              mesh_t&                          mesh,
+              const DViewCArrayKokkos<double>& node_coords);
 
 KOKKOS_FUNCTION
-void user_eos_model(const DViewCArrayKokkos <double> &elem_pres,
-                    const DViewCArrayKokkos <double> &elem_stress,
-                    const size_t elem_gid,
-                    const size_t mat_id,
-                    const DViewCArrayKokkos <double> &elem_state_vars,
-                    const DViewCArrayKokkos <double> &elem_sspd,
-                    const double den,
-                    const double sie);
+size_t check_bdy(const size_t                     patch_gid,
+                 const int                        this_bc_tag,
+                 const double                     val,
+                 const mesh_t&                    mesh,
+                 const DViewCArrayKokkos<double>& node_coords);
 
+void build_boundry_node_sets(const CArrayKokkos<boundary_t>& boundary,
+                             mesh_t&                         mesh);
 
-KOKKOS_FUNCTION
-void user_strength_model(const DViewCArrayKokkos <double> &elem_pres,
-                         const DViewCArrayKokkos <double> &elem_stress,
-                         const size_t elem_gid,
-                         const size_t mat_id,
-                         const DViewCArrayKokkos <double> &elem_state_vars,
-                         const DViewCArrayKokkos <double> &elem_sspd,
-                         const double den,
-                         const double sie,
-                         const ViewCArrayKokkos <double> &vel_grad,
-                         const ViewCArrayKokkos <size_t> &elem_node_gids,
-                         const DViewCArrayKokkos <double> &node_coords,
-                         const DViewCArrayKokkos <double> &node_vel,
-                         const double vol,
-                         const double dt,
-                         const double rk_alpha);
-
+void boundary_velocity(const mesh_t&                   mesh,
+                       const CArrayKokkos<boundary_t>& boundary,
+                       DViewCArrayKokkos<double>&      node_vel,
+                       const double                    time_value);
 
 KOKKOS_FUNCTION
-void user_strength_model_vpsc(const DViewCArrayKokkos <double> &elem_pres,
-                              const DViewCArrayKokkos <double> &elem_stress,
-                              const size_t elem_gid,
-                              const size_t mat_id,
-                              const DViewCArrayKokkos <double> &elem_state_vars,
-                              const DViewCArrayKokkos <double> &elem_sspd,
-                              const double den,
-                              const double sie,
-                              const ViewCArrayKokkos <double> &vel_grad,
-                              const ViewCArrayKokkos <size_t> &elem_node_gids,
-                              const DViewCArrayKokkos <double> &node_coords,
-                              const DViewCArrayKokkos <double> &node_vel,
-                              const double vol,
-                              const double dt,
-                              const double rk_alpha);
+void ideal_gas(const DViewCArrayKokkos<double>& elem_pres,
+               const DViewCArrayKokkos<double>& elem_stress,
+               const size_t                     elem_gid,
+               const size_t                     mat_id,
+               const DViewCArrayKokkos<double>& elem_state_vars,
+               const DViewCArrayKokkos<double>& elem_sspd,
+               const double                     den,
+               const double                     sie);
 
+KOKKOS_FUNCTION
+void user_eos_model(const DViewCArrayKokkos<double>& elem_pres,
+                    const DViewCArrayKokkos<double>& elem_stress,
+                    const size_t                     elem_gid,
+                    const size_t                     mat_id,
+                    const DViewCArrayKokkos<double>& elem_state_vars,
+                    const DViewCArrayKokkos<double>& elem_sspd,
+                    const double                     den,
+                    const double                     sie);
 
-void user_model_init(const DCArrayKokkos <double> &file_state_vars,
-                     const size_t num_state_vars,
-                     const size_t mat_id,
-                     const size_t num_elems);
+KOKKOS_FUNCTION
+void user_strength_model(const DViewCArrayKokkos<double>& elem_pres,
+                         const DViewCArrayKokkos<double>& elem_stress,
+                         const size_t                     elem_gid,
+                         const size_t                     mat_id,
+                         const DViewCArrayKokkos<double>& elem_state_vars,
+                         const DViewCArrayKokkos<double>& elem_sspd,
+                         const double                     den,
+                         const double                     sie,
+                         const ViewCArrayKokkos<double>&  vel_grad,
+                         const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                         const DViewCArrayKokkos<double>& node_coords,
+                         const DViewCArrayKokkos<double>& node_vel,
+                         const double                     vol,
+                         const double                     dt,
+                         const double                     rk_alpha);
 
+KOKKOS_FUNCTION
+void user_strength_model_vpsc(const DViewCArrayKokkos<double>& elem_pres,
+                              const DViewCArrayKokkos<double>& elem_stress,
+                              const size_t                     elem_gid,
+                              const size_t                     mat_id,
+                              const DViewCArrayKokkos<double>& elem_state_vars,
+                              const DViewCArrayKokkos<double>& elem_sspd,
+                              const double                     den,
+                              const double                     sie,
+                              const ViewCArrayKokkos<double>&  vel_grad,
+                              const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                              const DViewCArrayKokkos<double>& node_coords,
+                              const DViewCArrayKokkos<double>& node_vel,
+                              const double                     vol,
+                              const double                     dt,
+                              const double                     rk_alpha);
+
+void user_model_init(const DCArrayKokkos<double>& file_state_vars,
+                     const size_t                 num_state_vars,
+                     const size_t                 mat_id,
+                     const size_t                 num_elems);
 
 KOKKOS_FUNCTION
 double max_Eigen3D(const ViewCArrayKokkos<double> tensor);
 
-
 KOKKOS_FUNCTION
 double max_Eigen2D(const ViewCArrayKokkos<double> tensor);
 
+void sgh_solve(CArrayKokkos<material_t>&  material,
+               CArrayKokkos<boundary_t>&  boundary,
+               mesh_t&                    mesh,
+               DViewCArrayKokkos<double>& node_coords,
+               DViewCArrayKokkos<double>& node_vel,
+               DViewCArrayKokkos<double>& node_mass,
+               DViewCArrayKokkos<double>& elem_den,
+               DViewCArrayKokkos<double>& elem_pres,
+               DViewCArrayKokkos<double>& elem_stress,
+               DViewCArrayKokkos<double>& elem_sspd,
+               DViewCArrayKokkos<double>& elem_sie,
+               DViewCArrayKokkos<double>& elem_vol,
+               DViewCArrayKokkos<double>& elem_div,
+               DViewCArrayKokkos<double>& elem_mass,
+               DViewCArrayKokkos<size_t>& elem_mat_id,
+               DViewCArrayKokkos<double>& elem_statev,
+               DViewCArrayKokkos<double>& corner_force,
+               DViewCArrayKokkos<double>& corner_mass,
+               double&                    time_value,
+               const double               time_final,
+               const double               dt_max,
+               const double               dt_min,
+               const double               dt_cfl,
+               double&                    graphics_time,
+               size_t                     graphics_cyc_ival,
+               double                     graphics_dt_ival,
+               const size_t               cycle_stop,
+               const size_t               rk_num_stages,
+               double                     dt,
+               const double               fuzz,
+               const double               tiny,
+               const double               small,
+               CArray<double>&            graphics_times,
+               size_t&                    graphics_id);
 
+void rk_init(DViewCArrayKokkos<double>& node_coords,
+             DViewCArrayKokkos<double>& node_vel,
+             DViewCArrayKokkos<double>& elem_sie,
+             DViewCArrayKokkos<double>& elem_stress,
+             const size_t               num_dims,
+             const size_t               num_elems,
+             const size_t               num_nodes);
 
-void sgh_solve(CArrayKokkos <material_t> &material,
-               CArrayKokkos <boundary_t> &boundary,
-               mesh_t &mesh,
-               DViewCArrayKokkos <double> &node_coords,
-               DViewCArrayKokkos <double> &node_vel,
-               DViewCArrayKokkos <double> &node_mass,
-               DViewCArrayKokkos <double> &elem_den,
-               DViewCArrayKokkos <double> &elem_pres,
-               DViewCArrayKokkos <double> &elem_stress,
-               DViewCArrayKokkos <double> &elem_sspd,
-               DViewCArrayKokkos <double> &elem_sie,
-               DViewCArrayKokkos <double> &elem_vol,
-               DViewCArrayKokkos <double> &elem_div,
-               DViewCArrayKokkos <double> &elem_mass,
-               DViewCArrayKokkos <size_t> &elem_mat_id,
-               DViewCArrayKokkos <double> &elem_statev,
-               DViewCArrayKokkos <double> &corner_force,
-               DViewCArrayKokkos <double> &corner_mass,
-               double &time_value,
-               const double time_final,
-               const double dt_max,
-               const double dt_min,
-               const double dt_cfl,
-               double &graphics_time,
-               size_t graphics_cyc_ival,
-               double graphics_dt_ival,
-               const size_t cycle_stop,
-               const size_t rk_num_stages,
-               double dt,
-               const double fuzz,
-               const double tiny,
-               const double small,
-               CArray <double> &graphics_times,
-               size_t &graphics_id);
+void get_timestep(mesh_t&                    mesh,
+                  DViewCArrayKokkos<double>& node_coords,
+                  DViewCArrayKokkos<double>& node_vel,
+                  DViewCArrayKokkos<double>& elem_sspd,
+                  DViewCArrayKokkos<double>& elem_vol,
+                  double                     time_value,
+                  const double               graphics_time,
+                  const double               time_final,
+                  const double               dt_max,
+                  const double               dt_min,
+                  const double               dt_cfl,
+                  double&                    dt,
+                  const double               fuzz);
 
+void get_timestep2D(mesh_t&                    mesh,
+                    DViewCArrayKokkos<double>& node_coords,
+                    DViewCArrayKokkos<double>& node_vel,
+                    DViewCArrayKokkos<double>& elem_sspd,
+                    DViewCArrayKokkos<double>& elem_vol,
+                    double                     time_value,
+                    const double               graphics_time,
+                    const double               time_final,
+                    const double               dt_max,
+                    const double               dt_min,
+                    const double               dt_cfl,
+                    double&                    dt,
+                    const double               fuzz);
 
-void rk_init(DViewCArrayKokkos <double> &node_coords,
-             DViewCArrayKokkos <double> &node_vel,
-             DViewCArrayKokkos <double> &elem_sie,
-             DViewCArrayKokkos <double> &elem_stress,
-             const size_t num_dims,
-             const size_t num_elems,
-             const size_t num_nodes);
+void get_divergence(DViewCArrayKokkos<double>&       elem_div,
+                    const mesh_t                     mesh,
+                    const DViewCArrayKokkos<double>& node_coords,
+                    const DViewCArrayKokkos<double>& node_vel,
+                    const DViewCArrayKokkos<double>& elem_vol);
 
-
-void get_timestep(mesh_t &mesh,
-                  DViewCArrayKokkos <double> &node_coords,
-                  DViewCArrayKokkos <double> &node_vel,
-                  DViewCArrayKokkos <double> &elem_sspd,
-                  DViewCArrayKokkos <double> &elem_vol,
-                  double time_value,
-                  const double graphics_time,
-                  const double time_final,
-                  const double dt_max,
-                  const double dt_min,
-                  const double dt_cfl,
-                  double &dt,
-                  const double fuzz);
-
-
-void get_timestep2D(mesh_t &mesh,
-                    DViewCArrayKokkos <double> &node_coords,
-                    DViewCArrayKokkos <double> &node_vel,
-                    DViewCArrayKokkos <double> &elem_sspd,
-                    DViewCArrayKokkos <double> &elem_vol,
-                    double time_value,
-                    const double graphics_time,
-                    const double time_final,
-                    const double dt_max,
-                    const double dt_min,
-                    const double dt_cfl,
-                    double &dt,
-                    const double fuzz);
-
-
-void get_divergence(DViewCArrayKokkos <double> &elem_div,
-                    const mesh_t mesh,
-                    const DViewCArrayKokkos <double> &node_coords,
-                    const DViewCArrayKokkos <double> &node_vel,
-                    const DViewCArrayKokkos <double> &elem_vol);
-
-
-void get_divergence2D(DViewCArrayKokkos <double> &elem_div,
-                      const mesh_t mesh,
-                      const DViewCArrayKokkos <double> &node_coords,
-                      const DViewCArrayKokkos <double> &node_vel,
-                      const DViewCArrayKokkos <double> &elem_vol);
-
+void get_divergence2D(DViewCArrayKokkos<double>&       elem_div,
+                      const mesh_t                     mesh,
+                      const DViewCArrayKokkos<double>& node_coords,
+                      const DViewCArrayKokkos<double>& node_vel,
+                      const DViewCArrayKokkos<double>& elem_vol);
 
 KOKKOS_FUNCTION
-void get_velgrad(ViewCArrayKokkos <double> &vel_grad,
-                 const ViewCArrayKokkos <size_t>  &elem_node_gids,
-                 const DViewCArrayKokkos <double> &node_vel,
-                 const ViewCArrayKokkos <double> &b_matrix,
-                 const double elem_vol,
-                 const size_t elem_gid);
-
-
-KOKKOS_FUNCTION
-void get_velgrad2D(ViewCArrayKokkos <double> &vel_grad,
-                   const ViewCArrayKokkos <size_t>  &elem_node_gids,
-                   const DViewCArrayKokkos <double> &node_vel,
-                   const ViewCArrayKokkos <double> &b_matrix,
-                   const double elem_vol,
-                   const double elem_area,
-                   const size_t elem_gid);
+void get_velgrad(ViewCArrayKokkos<double>&        vel_grad,
+                 const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                 const DViewCArrayKokkos<double>& node_vel,
+                 const ViewCArrayKokkos<double>&  b_matrix,
+                 const double                     elem_vol,
+                 const size_t                     elem_gid);
 
 KOKKOS_FUNCTION
-void decompose_vel_grad(ViewCArrayKokkos <double> &D_tensor,
-                        ViewCArrayKokkos <double> &W_tensor,
-                        const ViewCArrayKokkos <double> &vel_grad,
-                        const ViewCArrayKokkos <size_t>  &elem_node_gids,
-                        const size_t elem_gid,
-                        const DViewCArrayKokkos <double> &node_coords,
-                        const DViewCArrayKokkos <double> &node_vel,
-                        const double vol);
-
-
-void get_force_sgh(const CArrayKokkos <material_t> &material,
-                   const mesh_t &mesh,
-                   const DViewCArrayKokkos <double> &node_coords,
-                   const DViewCArrayKokkos <double> &node_vel,
-                   const DViewCArrayKokkos <double> &elem_den,
-                   const DViewCArrayKokkos <double> &elem_sie,
-                   const DViewCArrayKokkos <double> &elem_pres,
-                   const DViewCArrayKokkos <double> &elem_stress,
-                   const DViewCArrayKokkos <double> &elem_sspd,
-                   const DViewCArrayKokkos <double> &elem_vol,
-                   const DViewCArrayKokkos <double> &elem_div,
-                   const DViewCArrayKokkos <size_t> &elem_mat_id,
-                   DViewCArrayKokkos <double> &corner_force,
-                   const double fuzz,
-                   const double small,
-                   const DViewCArrayKokkos <double> &elem_statev,
-                   const double dt,
-                   const double rk_alpha);
-
-
-void get_force_sgh2D(const CArrayKokkos <material_t> &material,
-                     const mesh_t &mesh,
-                     const DViewCArrayKokkos <double> &node_coords,
-                     const DViewCArrayKokkos <double> &node_vel,
-                     const DViewCArrayKokkos <double> &elem_den,
-                     const DViewCArrayKokkos <double> &elem_sie,
-                     const DViewCArrayKokkos <double> &elem_pres,
-                     const DViewCArrayKokkos <double> &elem_stress,
-                     const DViewCArrayKokkos <double> &elem_sspd,
-                     const DViewCArrayKokkos <double> &elem_vol,
-                     const DViewCArrayKokkos <double> &elem_div,
-                     const DViewCArrayKokkos <size_t> &elem_mat_id,
-                     DViewCArrayKokkos <double> &corner_force,
-                     const double fuzz,
-                     const double small,
-                     const DViewCArrayKokkos <double> &elem_statev,
-                     const double dt,
-                     const double rk_alpha);
-
-
-void update_velocity_sgh(double rk_alpha,
-                         double dt,
-                         const mesh_t &mesh,
-                         DViewCArrayKokkos <double> &node_vel,
-                         const DViewCArrayKokkos <double> &node_mass,
-                         const DViewCArrayKokkos <double> &corner_force);
-
-
-void update_energy_sgh(double rk_alpha,
-                       double dt,
-                       const mesh_t &mesh,
-                       const DViewCArrayKokkos <double> &node_vel,
-                       const DViewCArrayKokkos <double> &node_coords,
-                       DViewCArrayKokkos <double> &elem_sie,
-                       const DViewCArrayKokkos <double> &elem_mass,
-                       const DViewCArrayKokkos <double> &corner_force);
-
-
-void update_position_sgh(double rk_alpha,
-                         double dt,
-                         const size_t num_dims,
-                         const size_t num_nodes,
-                         DViewCArrayKokkos <double> &node_coords,
-                         const DViewCArrayKokkos <double> &node_vel);
-
-
-void update_state(const CArrayKokkos <material_t> &material,
-                  const mesh_t &mesh,
-                  const DViewCArrayKokkos <double> &node_coords,
-                  const DViewCArrayKokkos <double> &node_vel,
-                  DViewCArrayKokkos <double> &elem_den,
-                  DViewCArrayKokkos <double> &elem_pres,
-                  DViewCArrayKokkos <double> &elem_stress,
-                  DViewCArrayKokkos <double> &elem_sspd,
-                  const DViewCArrayKokkos <double> &elem_sie,
-                  const DViewCArrayKokkos <double> &elem_vol,
-                  const DViewCArrayKokkos <double> &elem_mass,
-                  const DViewCArrayKokkos <size_t> &elem_mat_id,
-                  const DViewCArrayKokkos <double> &elem_statev,
-                  const double dt,
-                  const double rk_alpha);
-
-
-void update_state2D(const CArrayKokkos <material_t> &material,
-                    const mesh_t &mesh,
-                    const DViewCArrayKokkos <double> &node_coords,
-                    const DViewCArrayKokkos <double> &node_vel,
-                    DViewCArrayKokkos <double> &elem_den,
-                    DViewCArrayKokkos <double> &elem_pres,
-                    DViewCArrayKokkos <double> &elem_stress,
-                    DViewCArrayKokkos <double> &elem_sspd,
-                    const DViewCArrayKokkos <double> &elem_sie,
-                    const DViewCArrayKokkos <double> &elem_vol,
-                    const DViewCArrayKokkos <double> &elem_mass,
-                    const DViewCArrayKokkos <size_t> &elem_mat_id,
-                    const DViewCArrayKokkos <double> &elem_statev,
-                    const double dt,
-                    const double rk_alpha);
-
+void get_velgrad2D(ViewCArrayKokkos<double>&        vel_grad,
+                   const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                   const DViewCArrayKokkos<double>& node_vel,
+                   const ViewCArrayKokkos<double>&  b_matrix,
+                   const double                     elem_vol,
+                   const double                     elem_area,
+                   const size_t                     elem_gid);
 
 KOKKOS_FUNCTION
-void get_area_weights2D(const ViewCArrayKokkos <double> &corner_areas,
-                        const size_t elem_gid,
-                        const DViewCArrayKokkos <double> &node_coords,
-                        const ViewCArrayKokkos <size_t>  &elem_node_gids);
+void decompose_vel_grad(ViewCArrayKokkos<double>&        D_tensor,
+                        ViewCArrayKokkos<double>&        W_tensor,
+                        const ViewCArrayKokkos<double>&  vel_grad,
+                        const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                        const size_t                     elem_gid,
+                        const DViewCArrayKokkos<double>& node_coords,
+                        const DViewCArrayKokkos<double>& node_vel,
+                        const double                     vol);
 
+void get_force_sgh(const CArrayKokkos<material_t>&  material,
+                   const mesh_t&                    mesh,
+                   const DViewCArrayKokkos<double>& node_coords,
+                   const DViewCArrayKokkos<double>& node_vel,
+                   const DViewCArrayKokkos<double>& elem_den,
+                   const DViewCArrayKokkos<double>& elem_sie,
+                   const DViewCArrayKokkos<double>& elem_pres,
+                   const DViewCArrayKokkos<double>& elem_stress,
+                   const DViewCArrayKokkos<double>& elem_sspd,
+                   const DViewCArrayKokkos<double>& elem_vol,
+                   const DViewCArrayKokkos<double>& elem_div,
+                   const DViewCArrayKokkos<size_t>& elem_mat_id,
+                   DViewCArrayKokkos<double>&       corner_force,
+                   const double                     fuzz,
+                   const double                     small,
+                   const DViewCArrayKokkos<double>& elem_statev,
+                   const double                     dt,
+                   const double                     rk_alpha);
+
+void get_force_sgh2D(const CArrayKokkos<material_t>&  material,
+                     const mesh_t&                    mesh,
+                     const DViewCArrayKokkos<double>& node_coords,
+                     const DViewCArrayKokkos<double>& node_vel,
+                     const DViewCArrayKokkos<double>& elem_den,
+                     const DViewCArrayKokkos<double>& elem_sie,
+                     const DViewCArrayKokkos<double>& elem_pres,
+                     const DViewCArrayKokkos<double>& elem_stress,
+                     const DViewCArrayKokkos<double>& elem_sspd,
+                     const DViewCArrayKokkos<double>& elem_vol,
+                     const DViewCArrayKokkos<double>& elem_div,
+                     const DViewCArrayKokkos<size_t>& elem_mat_id,
+                     DViewCArrayKokkos<double>&       corner_force,
+                     const double                     fuzz,
+                     const double                     small,
+                     const DViewCArrayKokkos<double>& elem_statev,
+                     const double                     dt,
+                     const double                     rk_alpha);
+
+void update_velocity_sgh(double                           rk_alpha,
+                         double                           dt,
+                         const mesh_t&                    mesh,
+                         DViewCArrayKokkos<double>&       node_vel,
+                         const DViewCArrayKokkos<double>& node_mass,
+                         const DViewCArrayKokkos<double>& corner_force);
+
+void update_energy_sgh(double                           rk_alpha,
+                       double                           dt,
+                       const mesh_t&                    mesh,
+                       const DViewCArrayKokkos<double>& node_vel,
+                       const DViewCArrayKokkos<double>& node_coords,
+                       DViewCArrayKokkos<double>&       elem_sie,
+                       const DViewCArrayKokkos<double>& elem_mass,
+                       const DViewCArrayKokkos<double>& corner_force);
+
+void update_position_sgh(double                           rk_alpha,
+                         double                           dt,
+                         const size_t                     num_dims,
+                         const size_t                     num_nodes,
+                         DViewCArrayKokkos<double>&       node_coords,
+                         const DViewCArrayKokkos<double>& node_vel);
+
+void update_state(const CArrayKokkos<material_t>&  material,
+                  const mesh_t&                    mesh,
+                  const DViewCArrayKokkos<double>& node_coords,
+                  const DViewCArrayKokkos<double>& node_vel,
+                  DViewCArrayKokkos<double>&       elem_den,
+                  DViewCArrayKokkos<double>&       elem_pres,
+                  DViewCArrayKokkos<double>&       elem_stress,
+                  DViewCArrayKokkos<double>&       elem_sspd,
+                  const DViewCArrayKokkos<double>& elem_sie,
+                  const DViewCArrayKokkos<double>& elem_vol,
+                  const DViewCArrayKokkos<double>& elem_mass,
+                  const DViewCArrayKokkos<size_t>& elem_mat_id,
+                  const DViewCArrayKokkos<double>& elem_statev,
+                  const double                     dt,
+                  const double                     rk_alpha);
+
+void update_state2D(const CArrayKokkos<material_t>&  material,
+                    const mesh_t&                    mesh,
+                    const DViewCArrayKokkos<double>& node_coords,
+                    const DViewCArrayKokkos<double>& node_vel,
+                    DViewCArrayKokkos<double>&       elem_den,
+                    DViewCArrayKokkos<double>&       elem_pres,
+                    DViewCArrayKokkos<double>&       elem_stress,
+                    DViewCArrayKokkos<double>&       elem_sspd,
+                    const DViewCArrayKokkos<double>& elem_sie,
+                    const DViewCArrayKokkos<double>& elem_vol,
+                    const DViewCArrayKokkos<double>& elem_mass,
+                    const DViewCArrayKokkos<size_t>& elem_mat_id,
+                    const DViewCArrayKokkos<double>& elem_statev,
+                    const double                     dt,
+                    const double                     rk_alpha);
+
+KOKKOS_FUNCTION
+void get_area_weights2D(const ViewCArrayKokkos<double>&  corner_areas,
+                        const size_t                     elem_gid,
+                        const DViewCArrayKokkos<double>& node_coords,
+                        const ViewCArrayKokkos<size_t>&  elem_node_gids);
 
 KOKKOS_FUNCTION
 double heron(const double x1,
@@ -1519,5 +1394,4 @@ double heron(const double x1,
              const double x3,
              const double y3);
 
-
-#endif 
+#endif

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/momentum.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/momentum.cpp
@@ -1,418 +1,391 @@
 
-
 #include "mesh.h"
 #include "state.h"
 
-
-
 // -----------------------------------------------------------------------------
 // This function evolves the velocity at the nodes of the mesh
-//------------------------------------------------------------------------------
-void update_velocity_sgh(double rk_alpha,
-                         double dt,
-                         const mesh_t &mesh,
-                         DViewCArrayKokkos <double> &node_vel,
-                         const DViewCArrayKokkos <double> &node_mass,
-                         const DViewCArrayKokkos <double> &corner_force
-                         ){
-
-    
+// ------------------------------------------------------------------------------
+void
+update_velocity_sgh(double                           rk_alpha,
+                    double                           dt,
+                    const mesh_t&                    mesh,
+                    DViewCArrayKokkos<double>&       node_vel,
+                    const DViewCArrayKokkos<double>& node_mass,
+                    const DViewCArrayKokkos<double>& corner_force
+                    )
+{
     const size_t num_dims = mesh.num_dims;
-    
+
     // walk over the nodes to update the velocity
     FOR_ALL(node_gid, 0, mesh.num_nodes, {
-
         double node_force[3];
-        for (size_t dim = 0; dim < num_dims; dim++){
+        for (size_t dim = 0; dim < num_dims; dim++)
+        {
             node_force[dim] = 0.0;
         } // end for dim
-        
+
         // loop over all corners around the node and calculate the nodal force
-        for (size_t corner_lid=0; corner_lid<mesh.num_corners_in_node(node_gid); corner_lid++){
-        
+        for (size_t corner_lid = 0; corner_lid < mesh.num_corners_in_node(node_gid); corner_lid++)
+        {
             // Get corner gid
             size_t corner_gid = mesh.corners_in_node(node_gid, corner_lid);
-            
+
             // loop over dimension
-            for (size_t dim = 0; dim < num_dims; dim++){
+            for (size_t dim = 0; dim < num_dims; dim++)
+            {
                 node_force[dim] += corner_force(corner_gid, dim);
             } // end for dim
-            
         } // end for corner_lid
-        
-        // update the velocity
-        for (int dim = 0; dim < num_dims; dim++){
-            node_vel(1, node_gid, dim) = node_vel(0, node_gid, dim) +
-                                         rk_alpha * dt*node_force[dim]/node_mass(node_gid);
-        } // end for dim
-        
-    }); // end for parallel for over nodes
-    
-    return;
-    
-} // end subroutine update_velocity
 
+        // update the velocity
+        for (int dim = 0; dim < num_dims; dim++)
+        {
+            node_vel(1, node_gid, dim) = node_vel(0, node_gid, dim) +
+                                         rk_alpha * dt * node_force[dim] / node_mass(node_gid);
+        } // end for dim
+    }); // end for parallel for over nodes
+
+    return;
+} // end subroutine update_velocity
 
 // -----------------------------------------------------------------------------
 // This function calculates the velocity gradient
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void get_velgrad(ViewCArrayKokkos <double> &vel_grad,
-                 const ViewCArrayKokkos <size_t>  &elem_node_gids,
-                 const DViewCArrayKokkos <double> &node_vel,
-                 const ViewCArrayKokkos <double> &b_matrix,
-                 const double elem_vol,
-                 const size_t elem_gid
-                 ){
-    
-
+void
+get_velgrad(ViewCArrayKokkos<double>&        vel_grad,
+            const ViewCArrayKokkos<size_t>&  elem_node_gids,
+            const DViewCArrayKokkos<double>& node_vel,
+            const ViewCArrayKokkos<double>&  b_matrix,
+            const double                     elem_vol,
+            const size_t                     elem_gid
+            )
+{
     const size_t num_nodes_in_elem = 8;
-    
-    double u_array[num_nodes_in_elem];
-    double v_array[num_nodes_in_elem];
-    double w_array[num_nodes_in_elem];
-    ViewCArrayKokkos <double> u(u_array, num_nodes_in_elem); // x-dir vel component
-    ViewCArrayKokkos <double> v(v_array, num_nodes_in_elem); // y-dir vel component
-    ViewCArrayKokkos <double> w(w_array, num_nodes_in_elem); // z-dir vel component
-    
+
+    double                   u_array[num_nodes_in_elem];
+    double                   v_array[num_nodes_in_elem];
+    double                   w_array[num_nodes_in_elem];
+    ViewCArrayKokkos<double> u(u_array, num_nodes_in_elem); // x-dir vel component
+    ViewCArrayKokkos<double> v(v_array, num_nodes_in_elem); // y-dir vel component
+    ViewCArrayKokkos<double> w(w_array, num_nodes_in_elem); // z-dir vel component
+
     // get the vertex velocities for the cell
-    for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-        
+    for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+    {
         // Get node gid
         size_t node_gid = elem_node_gids(node_lid);
 
         u(node_lid) = node_vel(1, node_gid, 0);
         v(node_lid) = node_vel(1, node_gid, 1);
         w(node_lid) = node_vel(1, node_gid, 2);
-        
     } // end for
 
-    
     // --- calculate the velocity gradient terms ---
-    double inverse_vol = 1.0/elem_vol;
-    
+    double inverse_vol = 1.0 / elem_vol;
+
     // x-dir
-    vel_grad(0,0) = (u(0)*b_matrix(0,0) + u(1)*b_matrix(1,0)
-                   + u(2)*b_matrix(2,0) + u(3)*b_matrix(3,0)
-                   + u(4)*b_matrix(4,0) + u(5)*b_matrix(5,0)
-                   + u(6)*b_matrix(6,0) + u(7)*b_matrix(7,0))*inverse_vol;
-    
-    vel_grad(0,1) = (u(0)*b_matrix(0,1) + u(1)*b_matrix(1,1)
-                   + u(2)*b_matrix(2,1) + u(3)*b_matrix(3,1)
-                   + u(4)*b_matrix(4,1) + u(5)*b_matrix(5,1)
-                   + u(6)*b_matrix(6,1) + u(7)*b_matrix(7,1))*inverse_vol;
-    
-    vel_grad(0,2) = (u(0)*b_matrix(0,2) + u(1)*b_matrix(1,2)
-                   + u(2)*b_matrix(2,2) + u(3)*b_matrix(3,2)
-                   + u(4)*b_matrix(4,2) + u(5)*b_matrix(5,2)
-                   + u(6)*b_matrix(6,2) + u(7)*b_matrix(7,2))*inverse_vol;
-    
+    vel_grad(0, 0) = (u(0) * b_matrix(0, 0) + u(1) * b_matrix(1, 0)
+                      + u(2) * b_matrix(2, 0) + u(3) * b_matrix(3, 0)
+                      + u(4) * b_matrix(4, 0) + u(5) * b_matrix(5, 0)
+                      + u(6) * b_matrix(6, 0) + u(7) * b_matrix(7, 0)) * inverse_vol;
+
+    vel_grad(0, 1) = (u(0) * b_matrix(0, 1) + u(1) * b_matrix(1, 1)
+                      + u(2) * b_matrix(2, 1) + u(3) * b_matrix(3, 1)
+                      + u(4) * b_matrix(4, 1) + u(5) * b_matrix(5, 1)
+                      + u(6) * b_matrix(6, 1) + u(7) * b_matrix(7, 1)) * inverse_vol;
+
+    vel_grad(0, 2) = (u(0) * b_matrix(0, 2) + u(1) * b_matrix(1, 2)
+                      + u(2) * b_matrix(2, 2) + u(3) * b_matrix(3, 2)
+                      + u(4) * b_matrix(4, 2) + u(5) * b_matrix(5, 2)
+                      + u(6) * b_matrix(6, 2) + u(7) * b_matrix(7, 2)) * inverse_vol;
+
     // y-dir
-    vel_grad(1,0) = (v(0)*b_matrix(0,0) + v(1)*b_matrix(1,0)
-                   + v(2)*b_matrix(2,0) + v(3)*b_matrix(3,0)
-                   + v(4)*b_matrix(4,0) + v(5)*b_matrix(5,0)
-                   + v(6)*b_matrix(6,0) + v(7)*b_matrix(7,0))*inverse_vol;
-    
-    vel_grad(1,1) = (v(0)*b_matrix(0,1) + v(1)*b_matrix(1,1)
-                   + v(2)*b_matrix(2,1) + v(3)*b_matrix(3,1)
-                   + v(4)*b_matrix(4,1) + v(5)*b_matrix(5,1)
-                   + v(6)*b_matrix(6,1) + v(7)*b_matrix(7,1))*inverse_vol;
-    vel_grad(1,2) = (v(0)*b_matrix(0,2) + v(1)*b_matrix(1,2)
-                   + v(2)*b_matrix(2,2) + v(3)*b_matrix(3,2)
-                   + v(4)*b_matrix(4,2) + v(5)*b_matrix(5,2)
-                   + v(6)*b_matrix(6,2) + v(7)*b_matrix(7,2))*inverse_vol;
-    
+    vel_grad(1, 0) = (v(0) * b_matrix(0, 0) + v(1) * b_matrix(1, 0)
+                      + v(2) * b_matrix(2, 0) + v(3) * b_matrix(3, 0)
+                      + v(4) * b_matrix(4, 0) + v(5) * b_matrix(5, 0)
+                      + v(6) * b_matrix(6, 0) + v(7) * b_matrix(7, 0)) * inverse_vol;
+
+    vel_grad(1, 1) = (v(0) * b_matrix(0, 1) + v(1) * b_matrix(1, 1)
+                      + v(2) * b_matrix(2, 1) + v(3) * b_matrix(3, 1)
+                      + v(4) * b_matrix(4, 1) + v(5) * b_matrix(5, 1)
+                      + v(6) * b_matrix(6, 1) + v(7) * b_matrix(7, 1)) * inverse_vol;
+    vel_grad(1, 2) = (v(0) * b_matrix(0, 2) + v(1) * b_matrix(1, 2)
+                      + v(2) * b_matrix(2, 2) + v(3) * b_matrix(3, 2)
+                      + v(4) * b_matrix(4, 2) + v(5) * b_matrix(5, 2)
+                      + v(6) * b_matrix(6, 2) + v(7) * b_matrix(7, 2)) * inverse_vol;
+
     // z-dir
-    vel_grad(2,0) = (w(0)*b_matrix(0,0) + w(1)*b_matrix(1,0)
-                   + w(2)*b_matrix(2,0) + w(3)*b_matrix(3,0)
-                   + w(4)*b_matrix(4,0) + w(5)*b_matrix(5,0)
-                   + w(6)*b_matrix(6,0) + w(7)*b_matrix(7,0))*inverse_vol;
-    
-    vel_grad(2,1) = (w(0)*b_matrix(0,1) + w(1)*b_matrix(1,1)
-                   + w(2)*b_matrix(2,1) + w(3)*b_matrix(3,1)
-                   + w(4)*b_matrix(4,1) + w(5)*b_matrix(5,1)
-                   + w(6)*b_matrix(6,1) + w(7)*b_matrix(7,1))*inverse_vol;
-    
-    vel_grad(2,2) = (w(0)*b_matrix(0,2) + w(1)*b_matrix(1,2)
-                   + w(2)*b_matrix(2,2) + w(3)*b_matrix(3,2)
-                   + w(4)*b_matrix(4,2) + w(5)*b_matrix(5,2)
-                   + w(6)*b_matrix(6,2) + w(7)*b_matrix(7,2))*inverse_vol;
+    vel_grad(2, 0) = (w(0) * b_matrix(0, 0) + w(1) * b_matrix(1, 0)
+                      + w(2) * b_matrix(2, 0) + w(3) * b_matrix(3, 0)
+                      + w(4) * b_matrix(4, 0) + w(5) * b_matrix(5, 0)
+                      + w(6) * b_matrix(6, 0) + w(7) * b_matrix(7, 0)) * inverse_vol;
 
-    
+    vel_grad(2, 1) = (w(0) * b_matrix(0, 1) + w(1) * b_matrix(1, 1)
+                      + w(2) * b_matrix(2, 1) + w(3) * b_matrix(3, 1)
+                      + w(4) * b_matrix(4, 1) + w(5) * b_matrix(5, 1)
+                      + w(6) * b_matrix(6, 1) + w(7) * b_matrix(7, 1)) * inverse_vol;
+
+    vel_grad(2, 2) = (w(0) * b_matrix(0, 2) + w(1) * b_matrix(1, 2)
+                      + w(2) * b_matrix(2, 2) + w(3) * b_matrix(3, 2)
+                      + w(4) * b_matrix(4, 2) + w(5) * b_matrix(5, 2)
+                      + w(6) * b_matrix(6, 2) + w(7) * b_matrix(7, 2)) * inverse_vol;
+
     return;
-    
 } // end function
-
 
 // -----------------------------------------------------------------------------
 // This function calculates the velocity gradient
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void get_velgrad2D(ViewCArrayKokkos <double> &vel_grad,
-                   const ViewCArrayKokkos <size_t>  &elem_node_gids,
-                   const DViewCArrayKokkos <double> &node_vel,
-                   const ViewCArrayKokkos <double> &b_matrix,
-                   const double elem_vol,
-                   const double elem_area,
-                   const size_t elem_gid
-                   ){
-    
-
+void
+get_velgrad2D(ViewCArrayKokkos<double>&        vel_grad,
+              const ViewCArrayKokkos<size_t>&  elem_node_gids,
+              const DViewCArrayKokkos<double>& node_vel,
+              const ViewCArrayKokkos<double>&  b_matrix,
+              const double                     elem_vol,
+              const double                     elem_area,
+              const size_t                     elem_gid
+              )
+{
     const size_t num_nodes_in_elem = 4;
-    
-    double u_array[num_nodes_in_elem];
-    double v_array[num_nodes_in_elem];
-    ViewCArrayKokkos <double> u(u_array, num_nodes_in_elem); // x-dir vel component
-    ViewCArrayKokkos <double> v(v_array, num_nodes_in_elem); // y-dir vel component
-    
+
+    double                   u_array[num_nodes_in_elem];
+    double                   v_array[num_nodes_in_elem];
+    ViewCArrayKokkos<double> u(u_array, num_nodes_in_elem); // x-dir vel component
+    ViewCArrayKokkos<double> v(v_array, num_nodes_in_elem); // y-dir vel component
+
     // get the vertex velocities for the cell
-    for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-        
+    for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+    {
         // Get node gid
         size_t node_gid = elem_node_gids(node_lid);
 
         u(node_lid) = node_vel(1, node_gid, 0); // x-comp
         v(node_lid) = node_vel(1, node_gid, 1); // y-comp
-        
     } // end for
-    
+
     // initialize to zero
-    for (size_t i=0; i<3; i++){
-        for (size_t j=0; j<3; j++){
-            vel_grad(i,j) = 0.0;
+    for (size_t i = 0; i < 3; i++)
+    {
+        for (size_t j = 0; j < 3; j++)
+        {
+            vel_grad(i, j) = 0.0;
         }
     }
-    
 
-    double mean_radius = elem_vol/elem_area;
-    double elem_vel_r = 0.25*(v(0) + v(1) + v(2) + v(3));
-    
-    
+    double mean_radius = elem_vol / elem_area;
+    double elem_vel_r  = 0.25 * (v(0) + v(1) + v(2) + v(3));
+
     // --- calculate the velocity gradient terms ---
-    double inverse_area = 1.0/elem_area;
-    
+    double inverse_area = 1.0 / elem_area;
+
     // x-dir
-    vel_grad(0,0) = (u(0)*b_matrix(0,0) + u(1)*b_matrix(1,0)
-                   + u(2)*b_matrix(2,0) + u(3)*b_matrix(3,0))*inverse_area;
-    
-    vel_grad(0,1) = (u(0)*b_matrix(0,1) + u(1)*b_matrix(1,1)
-                   + u(2)*b_matrix(2,1) + u(3)*b_matrix(3,1))*inverse_area;
-    
-    
+    vel_grad(0, 0) = (u(0) * b_matrix(0, 0) + u(1) * b_matrix(1, 0)
+                      + u(2) * b_matrix(2, 0) + u(3) * b_matrix(3, 0)) * inverse_area;
+
+    vel_grad(0, 1) = (u(0) * b_matrix(0, 1) + u(1) * b_matrix(1, 1)
+                      + u(2) * b_matrix(2, 1) + u(3) * b_matrix(3, 1)) * inverse_area;
+
     // y-dir
-    vel_grad(1,0) = (v(0)*b_matrix(0,0) + v(1)*b_matrix(1,0)
-                   + v(2)*b_matrix(2,0) + v(3)*b_matrix(3,0))*inverse_area;
-    
-    vel_grad(1,1) = (v(0)*b_matrix(0,1) + v(1)*b_matrix(1,1)
-                   + v(2)*b_matrix(2,1) + v(3)*b_matrix(3,1))*inverse_area;
-    
-    vel_grad(2,2) = elem_vel_r/mean_radius;  // + avg(vel_R)/R
-    
+    vel_grad(1, 0) = (v(0) * b_matrix(0, 0) + v(1) * b_matrix(1, 0)
+                      + v(2) * b_matrix(2, 0) + v(3) * b_matrix(3, 0)) * inverse_area;
+
+    vel_grad(1, 1) = (v(0) * b_matrix(0, 1) + v(1) * b_matrix(1, 1)
+                      + v(2) * b_matrix(2, 1) + v(3) * b_matrix(3, 1)) * inverse_area;
+
+    vel_grad(2, 2) = elem_vel_r / mean_radius;  // + avg(vel_R)/R
+
     return;
-    
 } // end function
-
-
-
 
 // -----------------------------------------------------------------------------
 // This subroutine to calculate the velocity divergence in all elements
-//------------------------------------------------------------------------------
-void get_divergence(DViewCArrayKokkos <double> &elem_div,
-                    const mesh_t mesh,
-                    const DViewCArrayKokkos <double> &node_coords,
-                    const DViewCArrayKokkos <double> &node_vel,
-                    const DViewCArrayKokkos <double> &elem_vol
-                    ){
-    
+// ------------------------------------------------------------------------------
+void
+get_divergence(DViewCArrayKokkos<double>&       elem_div,
+               const mesh_t                     mesh,
+               const DViewCArrayKokkos<double>& node_coords,
+               const DViewCArrayKokkos<double>& node_vel,
+               const DViewCArrayKokkos<double>& elem_vol
+               )
+{
     // --- calculate the forces acting on the nodes from the element ---
-    FOR_ALL (elem_gid, 0, mesh.num_elems, {
-    
+    FOR_ALL(elem_gid, 0, mesh.num_elems, {
         const size_t num_nodes_in_elem = 8;
         const size_t num_dims = 3;
-        
+
         double u_array[num_nodes_in_elem];
         double v_array[num_nodes_in_elem];
         double w_array[num_nodes_in_elem];
-        ViewCArrayKokkos <double> u(u_array, num_nodes_in_elem); // x-dir vel component
-        ViewCArrayKokkos <double> v(v_array, num_nodes_in_elem); // y-dir vel component
-        ViewCArrayKokkos <double> w(w_array, num_nodes_in_elem); // z-dir vel component
-        
+        ViewCArrayKokkos<double> u(u_array, num_nodes_in_elem); // x-dir vel component
+        ViewCArrayKokkos<double> v(v_array, num_nodes_in_elem); // y-dir vel component
+        ViewCArrayKokkos<double> w(w_array, num_nodes_in_elem); // z-dir vel component
+
         // cut out the node_gids for this element
-        ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
-        
+        ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 8);
+
         // The b_matrix are the outward corner area normals
         double b_matrix_array[24];
-        ViewCArrayKokkos <double> b_matrix(b_matrix_array, num_nodes_in_elem, num_dims);
+        ViewCArrayKokkos<double> b_matrix(b_matrix_array, num_nodes_in_elem, num_dims);
         get_bmatrix(b_matrix,
                     elem_gid,
                     node_coords,
                     elem_node_gids);
-        
+
         // get the vertex velocities for the elem
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-        
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             // Get node gid
             size_t node_gid = elem_node_gids(node_lid);
-    
+
             u(node_lid) = node_vel(1, node_gid, 0);
             v(node_lid) = node_vel(1, node_gid, 1);
             w(node_lid) = node_vel(1, node_gid, 2);
-        
         } // end for
-    
-        
-        // --- calculate the velocity divergence terms ---
-        double inverse_vol = 1.0/elem_vol(elem_gid);
-        
-        elem_div(elem_gid) = 0.0;
-        
-        // x-dir
-        elem_div(elem_gid) += (u(0)*b_matrix(0,0) + u(1)*b_matrix(1,0)
-                             + u(2)*b_matrix(2,0) + u(3)*b_matrix(3,0)
-                             + u(4)*b_matrix(4,0) + u(5)*b_matrix(5,0)
-                             + u(6)*b_matrix(6,0) + u(7)*b_matrix(7,0))*inverse_vol;
-        
-        // y-dir
-        elem_div(elem_gid) += (v(0)*b_matrix(0,1) + v(1)*b_matrix(1,1)
-                             + v(2)*b_matrix(2,1) + v(3)*b_matrix(3,1)
-                             + v(4)*b_matrix(4,1) + v(5)*b_matrix(5,1)
-                             + v(6)*b_matrix(6,1) + v(7)*b_matrix(7,1))*inverse_vol;
-        
-        // z-dir
-        elem_div(elem_gid) += (w(0)*b_matrix(0,2) + w(1)*b_matrix(1,2)
-                             + w(2)*b_matrix(2,2) + w(3)*b_matrix(3,2)
-                             + w(4)*b_matrix(4,2) + w(5)*b_matrix(5,2)
-                             + w(6)*b_matrix(6,2) + w(7)*b_matrix(7,2))*inverse_vol;
-        
-    });  // end parallel for over elem_gid
-    
-    return;
-    
-} // end subroutine
 
+        // --- calculate the velocity divergence terms ---
+        double inverse_vol = 1.0 / elem_vol(elem_gid);
+
+        elem_div(elem_gid) = 0.0;
+
+        // x-dir
+        elem_div(elem_gid) += (u(0) * b_matrix(0, 0) + u(1) * b_matrix(1, 0)
+                               + u(2) * b_matrix(2, 0) + u(3) * b_matrix(3, 0)
+                               + u(4) * b_matrix(4, 0) + u(5) * b_matrix(5, 0)
+                               + u(6) * b_matrix(6, 0) + u(7) * b_matrix(7, 0)) * inverse_vol;
+
+        // y-dir
+        elem_div(elem_gid) += (v(0) * b_matrix(0, 1) + v(1) * b_matrix(1, 1)
+                               + v(2) * b_matrix(2, 1) + v(3) * b_matrix(3, 1)
+                               + v(4) * b_matrix(4, 1) + v(5) * b_matrix(5, 1)
+                               + v(6) * b_matrix(6, 1) + v(7) * b_matrix(7, 1)) * inverse_vol;
+
+        // z-dir
+        elem_div(elem_gid) += (w(0) * b_matrix(0, 2) + w(1) * b_matrix(1, 2)
+                               + w(2) * b_matrix(2, 2) + w(3) * b_matrix(3, 2)
+                               + w(4) * b_matrix(4, 2) + w(5) * b_matrix(5, 2)
+                               + w(6) * b_matrix(6, 2) + w(7) * b_matrix(7, 2)) * inverse_vol;
+    });  // end parallel for over elem_gid
+
+    return;
+} // end subroutine
 
 // -----------------------------------------------------------------------------
 // This subroutine to calculate the velocity divergence in all elements
-//------------------------------------------------------------------------------
-void get_divergence2D(DViewCArrayKokkos <double> &elem_div,
-                      const mesh_t mesh,
-                      const DViewCArrayKokkos <double> &node_coords,
-                      const DViewCArrayKokkos <double> &node_vel,
-                      const DViewCArrayKokkos <double> &elem_vol
-                      ){
-    
+// ------------------------------------------------------------------------------
+void
+get_divergence2D(DViewCArrayKokkos<double>&       elem_div,
+                 const mesh_t                     mesh,
+                 const DViewCArrayKokkos<double>& node_coords,
+                 const DViewCArrayKokkos<double>& node_vel,
+                 const DViewCArrayKokkos<double>& elem_vol
+                 )
+{
     // --- calculate the forces acting on the nodes from the element ---
-    FOR_ALL (elem_gid, 0, mesh.num_elems, {
-    
+    FOR_ALL(elem_gid, 0, mesh.num_elems, {
         const size_t num_nodes_in_elem = 4;
         const size_t num_dims = 2;
-        
+
         double u_array[num_nodes_in_elem];
         double v_array[num_nodes_in_elem];
-        ViewCArrayKokkos <double> u(u_array, num_nodes_in_elem); // x-dir vel component
-        ViewCArrayKokkos <double> v(v_array, num_nodes_in_elem); // y-dir vel component
-        
-        
+        ViewCArrayKokkos<double> u(u_array, num_nodes_in_elem); // x-dir vel component
+        ViewCArrayKokkos<double> v(v_array, num_nodes_in_elem); // y-dir vel component
+
         // true volume RZ
-        //double r_array[num_nodes_in_elem];
-        //ViewCArrayKokkos <double> r(r_array, num_nodes_in_elem); // r-dir coordinate
-        
-        
+        // double r_array[num_nodes_in_elem];
+        // ViewCArrayKokkos <double> r(r_array, num_nodes_in_elem); // r-dir coordinate
+
         // cut out the node_gids for this element
-        ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
-        
+        ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
+
         // The b_matrix are the outward corner area normals
         double b_matrix_array[24];
-        ViewCArrayKokkos <double> b_matrix(b_matrix_array, num_nodes_in_elem, num_dims);
+        ViewCArrayKokkos<double> b_matrix(b_matrix_array, num_nodes_in_elem, num_dims);
         get_bmatrix2D(b_matrix,
                       elem_gid,
                       node_coords,
                       elem_node_gids);
-        
+
         // calculate the area of the quad
         double elem_area = get_area_quad(elem_gid, node_coords, elem_node_gids);
         // true volume uses the elem_vol
-        
-        
+
         // get the vertex velocities and node coordinate for the elem
-        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-        
+        for (size_t node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
             // Get node gid
             size_t node_gid = elem_node_gids(node_lid);
-    
+
             u(node_lid) = node_vel(1, node_gid, 0);
             v(node_lid) = node_vel(1, node_gid, 1);
-            
-            //r(node_lid) = node_coords(1, node_gid, 1); // true volume RZ
-            
+
+            // r(node_lid) = node_coords(1, node_gid, 1); // true volume RZ
         } // end for
-    
-        
+
         // --- calculate the velocity divergence terms ---
-        double inverse_area = 1.0/elem_area;
-        
-        double mean_radius = elem_vol(elem_gid)/elem_area;
-        double elem_vel_r = 0.25*(v(0) + v(1) + v(2) + v(3));
-        
-        
+        double inverse_area = 1.0 / elem_area;
+
+        double mean_radius = elem_vol(elem_gid) / elem_area;
+        double elem_vel_r  = 0.25 * (v(0) + v(1) + v(2) + v(3));
+
         elem_div(elem_gid) = 0.0;
-        
+
         // x-dir
-        elem_div(elem_gid) += (u(0)*b_matrix(0,0)
-                             + u(1)*b_matrix(1,0)
-                             + u(2)*b_matrix(2,0)
-                             + u(3)*b_matrix(3,0))*inverse_area;
-        
+        elem_div(elem_gid) += (u(0) * b_matrix(0, 0)
+                               + u(1) * b_matrix(1, 0)
+                               + u(2) * b_matrix(2, 0)
+                               + u(3) * b_matrix(3, 0)) * inverse_area;
+
         // y-dir (i.e., r direction)
-        elem_div(elem_gid) += (v(0)*b_matrix(0,1)
-                             + v(1)*b_matrix(1,1)
-                             + v(2)*b_matrix(2,1)
-                             + v(3)*b_matrix(3,1))*inverse_area
-                             + elem_vel_r/mean_radius;  // + avg(u_R)/R
-
+        elem_div(elem_gid) += (v(0) * b_matrix(0, 1)
+                               + v(1) * b_matrix(1, 1)
+                               + v(2) * b_matrix(2, 1)
+                               + v(3) * b_matrix(3, 1)) * inverse_area
+                              + elem_vel_r / mean_radius; // + avg(u_R)/R
     });  // end parallel for over elem_gid
-    
-    return;
-    
-} // end subroutine
 
+    return;
+} // end subroutine
 
 // The velocity gradient can be decomposed into symmetric and antisymmetric tensors
 // L = vel_grad
 // D = sym(L)
 // W = antisym(L)
 KOKKOS_FUNCTION
-void decompose_vel_grad(ViewCArrayKokkos <double> &D_tensor,
-                        ViewCArrayKokkos <double> &W_tensor,
-                        const ViewCArrayKokkos <double> &vel_grad,
-                        const ViewCArrayKokkos <size_t>  &elem_node_gids,
-                        const size_t elem_gid,
-                        const DViewCArrayKokkos <double> &node_coords,
-                        const DViewCArrayKokkos <double> &node_vel,
-                        const double vol
-                        ){
-    
-    
+void
+decompose_vel_grad(ViewCArrayKokkos<double>&        D_tensor,
+                   ViewCArrayKokkos<double>&        W_tensor,
+                   const ViewCArrayKokkos<double>&  vel_grad,
+                   const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                   const size_t                     elem_gid,
+                   const DViewCArrayKokkos<double>& node_coords,
+                   const DViewCArrayKokkos<double>& node_vel,
+                   const double                     vol
+                   )
+{
     // --- Calculate the velocity gradient ---
-    
+
     const size_t num_dims = 3;
-    
+
     // initialize to zero
-    for(size_t i=0; i<num_dims; i++){
-        for(size_t j=0; j<num_dims; j++){
-            D_tensor(i,j) = 0.0;
-            W_tensor(i,j) = 0.0;
+    for (size_t i = 0; i < num_dims; i++)
+    {
+        for (size_t j = 0; j < num_dims; j++)
+        {
+            D_tensor(i, j) = 0.0;
+            W_tensor(i, j) = 0.0;
         }
     } // end for
-    
-    for(size_t i=0; i<num_dims; i++){
-        for(size_t j=0; j<num_dims; j++){
-            D_tensor(i,j) = 0.5*(vel_grad(i,j) + vel_grad(j,i));
-            W_tensor(i,j) = 0.5*(vel_grad(i,j) - vel_grad(j,i));
+
+    for (size_t i = 0; i < num_dims; i++)
+    {
+        for (size_t j = 0; j < num_dims; j++)
+        {
+            D_tensor(i, j) = 0.5 * (vel_grad(i, j) + vel_grad(j, i));
+            W_tensor(i, j) = 0.5 * (vel_grad(i, j) - vel_grad(j, i));
         }
     } // end for
-    
+
     return;
-    
 } // end function to calculate D and W

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/momentum.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/momentum.cpp
@@ -5,14 +5,13 @@
 // -----------------------------------------------------------------------------
 // This function evolves the velocity at the nodes of the mesh
 // ------------------------------------------------------------------------------
-void
-update_velocity_sgh(double                           rk_alpha,
-                    double                           dt,
-                    const mesh_t&                    mesh,
-                    DViewCArrayKokkos<double>&       node_vel,
-                    const DViewCArrayKokkos<double>& node_mass,
-                    const DViewCArrayKokkos<double>& corner_force
-                    )
+void update_velocity_sgh(double                           rk_alpha,
+                         double                           dt,
+                         const mesh_t&                    mesh,
+                         DViewCArrayKokkos<double>&       node_vel,
+                         const DViewCArrayKokkos<double>& node_mass,
+                         const DViewCArrayKokkos<double>& corner_force
+                         )
 {
     const size_t num_dims = mesh.num_dims;
 
@@ -52,14 +51,13 @@ update_velocity_sgh(double                           rk_alpha,
 // This function calculates the velocity gradient
 // ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void
-get_velgrad(ViewCArrayKokkos<double>&        vel_grad,
-            const ViewCArrayKokkos<size_t>&  elem_node_gids,
-            const DViewCArrayKokkos<double>& node_vel,
-            const ViewCArrayKokkos<double>&  b_matrix,
-            const double                     elem_vol,
-            const size_t                     elem_gid
-            )
+void get_velgrad(ViewCArrayKokkos<double>&        vel_grad,
+                 const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                 const DViewCArrayKokkos<double>& node_vel,
+                 const ViewCArrayKokkos<double>&  b_matrix,
+                 const double                     elem_vol,
+                 const size_t                     elem_gid
+                 )
 {
     const size_t num_nodes_in_elem = 8;
 
@@ -138,15 +136,14 @@ get_velgrad(ViewCArrayKokkos<double>&        vel_grad,
 // This function calculates the velocity gradient
 // ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void
-get_velgrad2D(ViewCArrayKokkos<double>&        vel_grad,
-              const ViewCArrayKokkos<size_t>&  elem_node_gids,
-              const DViewCArrayKokkos<double>& node_vel,
-              const ViewCArrayKokkos<double>&  b_matrix,
-              const double                     elem_vol,
-              const double                     elem_area,
-              const size_t                     elem_gid
-              )
+void get_velgrad2D(ViewCArrayKokkos<double>&        vel_grad,
+                   const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                   const DViewCArrayKokkos<double>& node_vel,
+                   const ViewCArrayKokkos<double>&  b_matrix,
+                   const double                     elem_vol,
+                   const double                     elem_area,
+                   const size_t                     elem_gid
+                   )
 {
     const size_t num_nodes_in_elem = 4;
 
@@ -202,13 +199,12 @@ get_velgrad2D(ViewCArrayKokkos<double>&        vel_grad,
 // -----------------------------------------------------------------------------
 // This subroutine to calculate the velocity divergence in all elements
 // ------------------------------------------------------------------------------
-void
-get_divergence(DViewCArrayKokkos<double>&       elem_div,
-               const mesh_t                     mesh,
-               const DViewCArrayKokkos<double>& node_coords,
-               const DViewCArrayKokkos<double>& node_vel,
-               const DViewCArrayKokkos<double>& elem_vol
-               )
+void get_divergence(DViewCArrayKokkos<double>&       elem_div,
+                    const mesh_t                     mesh,
+                    const DViewCArrayKokkos<double>& node_coords,
+                    const DViewCArrayKokkos<double>& node_vel,
+                    const DViewCArrayKokkos<double>& elem_vol
+                    )
 {
     // --- calculate the forces acting on the nodes from the element ---
     FOR_ALL(elem_gid, 0, mesh.num_elems, {
@@ -274,13 +270,12 @@ get_divergence(DViewCArrayKokkos<double>&       elem_div,
 // -----------------------------------------------------------------------------
 // This subroutine to calculate the velocity divergence in all elements
 // ------------------------------------------------------------------------------
-void
-get_divergence2D(DViewCArrayKokkos<double>&       elem_div,
-                 const mesh_t                     mesh,
-                 const DViewCArrayKokkos<double>& node_coords,
-                 const DViewCArrayKokkos<double>& node_vel,
-                 const DViewCArrayKokkos<double>& elem_vol
-                 )
+void get_divergence2D(DViewCArrayKokkos<double>&       elem_div,
+                      const mesh_t                     mesh,
+                      const DViewCArrayKokkos<double>& node_coords,
+                      const DViewCArrayKokkos<double>& node_vel,
+                      const DViewCArrayKokkos<double>& elem_vol
+                      )
 {
     // --- calculate the forces acting on the nodes from the element ---
     FOR_ALL(elem_gid, 0, mesh.num_elems, {
@@ -353,16 +348,15 @@ get_divergence2D(DViewCArrayKokkos<double>&       elem_div,
 // D = sym(L)
 // W = antisym(L)
 KOKKOS_FUNCTION
-void
-decompose_vel_grad(ViewCArrayKokkos<double>&        D_tensor,
-                   ViewCArrayKokkos<double>&        W_tensor,
-                   const ViewCArrayKokkos<double>&  vel_grad,
-                   const ViewCArrayKokkos<size_t>&  elem_node_gids,
-                   const size_t                     elem_gid,
-                   const DViewCArrayKokkos<double>& node_coords,
-                   const DViewCArrayKokkos<double>& node_vel,
-                   const double                     vol
-                   )
+void decompose_vel_grad(ViewCArrayKokkos<double>&        D_tensor,
+                        ViewCArrayKokkos<double>&        W_tensor,
+                        const ViewCArrayKokkos<double>&  vel_grad,
+                        const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                        const size_t                     elem_gid,
+                        const DViewCArrayKokkos<double>& node_coords,
+                        const DViewCArrayKokkos<double>& node_vel,
+                        const double                     vol
+                        )
 {
     // --- Calculate the velocity gradient ---
 

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/outputs.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/outputs.cpp
@@ -4,22 +4,21 @@
 #include <cstring>
 #include <sys/stat.h>
 
-void
-write_outputs(const mesh_t&              mesh,
-              DViewCArrayKokkos<double>& node_coords,
-              DViewCArrayKokkos<double>& node_vel,
-              DViewCArrayKokkos<double>& node_mass,
-              DViewCArrayKokkos<double>& elem_den,
-              DViewCArrayKokkos<double>& elem_pres,
-              DViewCArrayKokkos<double>& elem_stress,
-              DViewCArrayKokkos<double>& elem_sspd,
-              DViewCArrayKokkos<double>& elem_sie,
-              DViewCArrayKokkos<double>& elem_vol,
-              DViewCArrayKokkos<double>& elem_mass,
-              DViewCArrayKokkos<size_t>& elem_mat_id,
-              CArray<double>&            graphics_times,
-              size_t&                    graphics_id,
-              const double               time_value)
+void write_outputs(const mesh_t&              mesh,
+                   DViewCArrayKokkos<double>& node_coords,
+                   DViewCArrayKokkos<double>& node_vel,
+                   DViewCArrayKokkos<double>& node_mass,
+                   DViewCArrayKokkos<double>& elem_den,
+                   DViewCArrayKokkos<double>& elem_pres,
+                   DViewCArrayKokkos<double>& elem_stress,
+                   DViewCArrayKokkos<double>& elem_sspd,
+                   DViewCArrayKokkos<double>& elem_sie,
+                   DViewCArrayKokkos<double>& elem_vol,
+                   DViewCArrayKokkos<double>& elem_mass,
+                   DViewCArrayKokkos<size_t>& elem_mat_id,
+                   CArray<double>&            graphics_times,
+                   size_t&                    graphics_id,
+                   const double               time_value)
 {
     // ---------------------------------------------------------------------
     //   t=tval ensight and state output
@@ -77,22 +76,21 @@ write_outputs(const mesh_t&              mesh,
 // This function write outs the data to an ensight case file
 // ------------------------------------------------------------------------------
 
-void
-ensight(const mesh_t&                    mesh,
-        const DViewCArrayKokkos<double>& node_coords,
-        const DViewCArrayKokkos<double>& node_vel,
-        const DViewCArrayKokkos<double>& node_mass,
-        const DViewCArrayKokkos<double>& elem_den,
-        const DViewCArrayKokkos<double>& elem_pres,
-        const DViewCArrayKokkos<double>& elem_stress,
-        const DViewCArrayKokkos<double>& elem_sspd,
-        const DViewCArrayKokkos<double>& elem_sie,
-        const DViewCArrayKokkos<double>& elem_vol,
-        const DViewCArrayKokkos<double>& elem_mass,
-        const DViewCArrayKokkos<size_t>& elem_mat_id,
-        CArray<double>&                  graphics_times,
-        size_t&                          graphics_id,
-        const double                     time_value)
+void ensight(const mesh_t&                    mesh,
+             const DViewCArrayKokkos<double>& node_coords,
+             const DViewCArrayKokkos<double>& node_vel,
+             const DViewCArrayKokkos<double>& node_mass,
+             const DViewCArrayKokkos<double>& elem_den,
+             const DViewCArrayKokkos<double>& elem_pres,
+             const DViewCArrayKokkos<double>& elem_stress,
+             const DViewCArrayKokkos<double>& elem_sspd,
+             const DViewCArrayKokkos<double>& elem_sie,
+             const DViewCArrayKokkos<double>& elem_vol,
+             const DViewCArrayKokkos<double>& elem_mass,
+             const DViewCArrayKokkos<size_t>& elem_mat_id,
+             CArray<double>&                  graphics_times,
+             size_t&                          graphics_id,
+             const double                     time_value)
 {
     const int num_scalar_vars = 9;
     const int num_vec_vars    = 2;
@@ -412,20 +410,19 @@ ensight(const mesh_t&                    mesh,
     return;
 } // end of Ensight function
 
-void
-state_file(const mesh_t&                    mesh,
-           const DViewCArrayKokkos<double>& node_coords,
-           const DViewCArrayKokkos<double>& node_vel,
-           const DViewCArrayKokkos<double>& node_mass,
-           const DViewCArrayKokkos<double>& elem_den,
-           const DViewCArrayKokkos<double>& elem_pres,
-           const DViewCArrayKokkos<double>& elem_stress,
-           const DViewCArrayKokkos<double>& elem_sspd,
-           const DViewCArrayKokkos<double>& elem_sie,
-           const DViewCArrayKokkos<double>& elem_vol,
-           const DViewCArrayKokkos<double>& elem_mass,
-           const DViewCArrayKokkos<size_t>& elem_mat_id,
-           const double                     time_value)
+void state_file(const mesh_t&                    mesh,
+                const DViewCArrayKokkos<double>& node_coords,
+                const DViewCArrayKokkos<double>& node_vel,
+                const DViewCArrayKokkos<double>& node_mass,
+                const DViewCArrayKokkos<double>& elem_den,
+                const DViewCArrayKokkos<double>& elem_pres,
+                const DViewCArrayKokkos<double>& elem_stress,
+                const DViewCArrayKokkos<double>& elem_sspd,
+                const DViewCArrayKokkos<double>& elem_sie,
+                const DViewCArrayKokkos<double>& elem_vol,
+                const DViewCArrayKokkos<double>& elem_mass,
+                const DViewCArrayKokkos<size_t>& elem_mat_id,
+                const double                     time_value)
 {
     struct stat st;
 

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/outputs.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/outputs.cpp
@@ -4,25 +4,23 @@
 #include <cstring>
 #include <sys/stat.h>
 
-
-
-
-void write_outputs (const mesh_t &mesh,
-                    DViewCArrayKokkos <double> &node_coords,
-                    DViewCArrayKokkos <double> &node_vel,
-                    DViewCArrayKokkos <double> &node_mass,
-                    DViewCArrayKokkos <double> &elem_den,
-                    DViewCArrayKokkos <double> &elem_pres,
-                    DViewCArrayKokkos <double> &elem_stress,
-                    DViewCArrayKokkos <double> &elem_sspd,
-                    DViewCArrayKokkos <double> &elem_sie,
-                    DViewCArrayKokkos <double> &elem_vol,
-                    DViewCArrayKokkos <double> &elem_mass,
-                    DViewCArrayKokkos <size_t> &elem_mat_id,
-                    CArray <double> &graphics_times,
-                    size_t &graphics_id,
-                    const double time_value){
-    
+void
+write_outputs(const mesh_t&              mesh,
+              DViewCArrayKokkos<double>& node_coords,
+              DViewCArrayKokkos<double>& node_vel,
+              DViewCArrayKokkos<double>& node_mass,
+              DViewCArrayKokkos<double>& elem_den,
+              DViewCArrayKokkos<double>& elem_pres,
+              DViewCArrayKokkos<double>& elem_stress,
+              DViewCArrayKokkos<double>& elem_sspd,
+              DViewCArrayKokkos<double>& elem_sie,
+              DViewCArrayKokkos<double>& elem_vol,
+              DViewCArrayKokkos<double>& elem_mass,
+              DViewCArrayKokkos<size_t>& elem_mat_id,
+              CArray<double>&            graphics_times,
+              size_t&                    graphics_id,
+              const double               time_value)
+{
     // ---------------------------------------------------------------------
     //   t=tval ensight and state output
     // ---------------------------------------------------------------------
@@ -34,12 +32,12 @@ void write_outputs (const mesh_t &mesh,
     elem_vol.update_host();
     elem_mass.update_host();
     elem_mat_id.update_host();
-    
+
     node_coords.update_host();
     node_vel.update_host();
     node_mass.update_host();
     Kokkos::fence();
-    
+
     // write out state file
     state_file(mesh,
                node_coords,
@@ -54,8 +52,7 @@ void write_outputs (const mesh_t &mesh,
                elem_mass,
                elem_mat_id,
                time_value);
-    
-    
+
     // write out ensight file
     ensight(mesh,
             node_coords,
@@ -72,100 +69,98 @@ void write_outputs (const mesh_t &mesh,
             graphics_times,
             graphics_id,
             time_value);
-    
-    return;
-    
-} // end of write outputs
 
+    return;
+} // end of write outputs
 
 // -----------------------------------------------------------------------------
 // This function write outs the data to an ensight case file
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
-void ensight( const mesh_t &mesh,
-              const DViewCArrayKokkos <double> &node_coords,
-              const DViewCArrayKokkos <double> &node_vel,
-              const DViewCArrayKokkos <double> &node_mass,
-              const DViewCArrayKokkos <double> &elem_den,
-              const DViewCArrayKokkos <double> &elem_pres,
-              const DViewCArrayKokkos <double> &elem_stress,
-              const DViewCArrayKokkos <double> &elem_sspd,
-              const DViewCArrayKokkos <double> &elem_sie,
-              const DViewCArrayKokkos <double> &elem_vol,
-              const DViewCArrayKokkos <double> &elem_mass,
-              const DViewCArrayKokkos <size_t> &elem_mat_id,
-              CArray <double> &graphics_times,
-              size_t &graphics_id,
-              const double time_value) {
-
+void
+ensight(const mesh_t&                    mesh,
+        const DViewCArrayKokkos<double>& node_coords,
+        const DViewCArrayKokkos<double>& node_vel,
+        const DViewCArrayKokkos<double>& node_mass,
+        const DViewCArrayKokkos<double>& elem_den,
+        const DViewCArrayKokkos<double>& elem_pres,
+        const DViewCArrayKokkos<double>& elem_stress,
+        const DViewCArrayKokkos<double>& elem_sspd,
+        const DViewCArrayKokkos<double>& elem_sie,
+        const DViewCArrayKokkos<double>& elem_vol,
+        const DViewCArrayKokkos<double>& elem_mass,
+        const DViewCArrayKokkos<size_t>& elem_mat_id,
+        CArray<double>&                  graphics_times,
+        size_t&                          graphics_id,
+        const double                     time_value)
+{
     const int num_scalar_vars = 9;
-    const int num_vec_vars = 2;
-
+    const int num_vec_vars    = 2;
 
     std::string name_tmp;
     name_tmp = "Outputs_SGH";
 
-    char * name = new char [name_tmp.length()+1];
-    std::strcpy (name, name_tmp.c_str());
-
+    char* name = new char [name_tmp.length() + 1];
+    std::strcpy(name, name_tmp.c_str());
 
     const char scalar_var_names[num_scalar_vars][15] = {
-        "den" ,"pres","sie","vol", "mass", "sspd", "speed", "mat_id", "elem_switch"
+        "den", "pres", "sie", "vol", "mass", "sspd", "speed", "mat_id", "elem_switch"
     };
 
     const char vec_var_names[num_vec_vars][15] = {
         "pos", "vel"
     };
-    
+
     // short hand
     const size_t num_nodes = mesh.num_nodes;
     const size_t num_elems = mesh.num_elems;
     const size_t num_dims  = mesh.num_dims;
 
     // save the cell state to an array for exporting to graphics files
-    auto elem_fields = CArray <double> (num_elems, num_scalar_vars);
-    int elem_switch = 1;
+    auto elem_fields = CArray<double>(num_elems, num_scalar_vars);
+    int  elem_switch = 1;
 
-
-    DCArrayKokkos <double> speed(num_elems);
+    DCArrayKokkos<double> speed(num_elems);
     FOR_ALL(elem_gid, 0, num_elems, {
-            
         double elem_vel[3]; // note:initialization with a list won't work
         elem_vel[0] = 0.0;
         elem_vel[1] = 0.0;
         elem_vel[2] = 0.0;
         // get the coordinates of the element center
-        for (int node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++){
+        for (int node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++)
+        {
             elem_vel[0] += node_vel(1, mesh.nodes_in_elem(elem_gid, node_lid), 0);
             elem_vel[1] += node_vel(1, mesh.nodes_in_elem(elem_gid, node_lid), 1);
-            if (mesh.num_dims == 3){
+            if (mesh.num_dims == 3)
+            {
                 elem_vel[2] += node_vel(1, mesh.nodes_in_elem(elem_gid, node_lid), 2);
             }
-            else {
+            else
+            {
                 elem_vel[2] = 0.0;
             }
         } // end loop over nodes in element
-        elem_vel[0] = elem_vel[0]/mesh.num_nodes_in_elem;
-        elem_vel[1] = elem_vel[1]/mesh.num_nodes_in_elem;
-        elem_vel[2] = elem_vel[2]/mesh.num_nodes_in_elem;
+        elem_vel[0] = elem_vel[0] / mesh.num_nodes_in_elem;
+        elem_vel[1] = elem_vel[1] / mesh.num_nodes_in_elem;
+        elem_vel[2] = elem_vel[2] / mesh.num_nodes_in_elem;
 
         double speed_sqrd = 0.0;
-        for (int dim=0; dim<num_dims; dim++){
-           speed_sqrd += elem_vel[dim]*elem_vel[dim];
+        for (int dim = 0; dim < num_dims; dim++)
+        {
+            speed_sqrd += elem_vel[dim] * elem_vel[dim];
         }
         speed(elem_gid) = sqrt(speed_sqrd);
     }); // end parallel for
     speed.update_host();
 
-
     // save the output scale fields to a single 2D array
-    for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++){
-        
+    for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++)
+    {
         // save outputs
-        elem_fields(elem_gid, 0) = elem_den.host(elem_gid);   
-        elem_fields(elem_gid, 1) = elem_pres.host(elem_gid); 
-        elem_fields(elem_gid, 2) = elem_sie.host(1, elem_gid);  
-        elem_fields(elem_gid, 3) = elem_vol.host(elem_gid); 
+        elem_fields(elem_gid, 0) = elem_den.host(elem_gid);
+        elem_fields(elem_gid, 1) = elem_pres.host(elem_gid);
+        elem_fields(elem_gid, 2) = elem_sie.host(1, elem_gid);
+        elem_fields(elem_gid, 3) = elem_vol.host(elem_gid);
         elem_fields(elem_gid, 4) = elem_mass.host(elem_gid);
         elem_fields(elem_gid, 5) = elem_sspd.host(elem_gid);
         elem_fields(elem_gid, 6) = speed.host(elem_gid);
@@ -173,316 +168,326 @@ void ensight( const mesh_t &mesh,
         elem_fields(elem_gid, 8) = (double)elem_switch;
         elem_switch *= -1;
     } // end for elements
-    
-    
-    // save the vertex vector fields to an array for exporting to graphics files
-    CArray <double> vec_fields(num_nodes, num_vec_vars, 3);
 
-    for (size_t node_gid = 0; node_gid < num_nodes; node_gid++){
-        
+    // save the vertex vector fields to an array for exporting to graphics files
+    CArray<double> vec_fields(num_nodes, num_vec_vars, 3);
+
+    for (size_t node_gid = 0; node_gid < num_nodes; node_gid++)
+    {
         // position, var 0
-        vec_fields(node_gid,0,0) = node_coords.host(1, node_gid, 0); 
-        vec_fields(node_gid,0,1) = node_coords.host(1, node_gid, 1); 
-        if(num_dims == 2){ 
-            vec_fields(node_gid,0,2) = 0.0;
-        } else{
-            vec_fields(node_gid,0,2) = node_coords.host(1, node_gid, 2); 
+        vec_fields(node_gid, 0, 0) = node_coords.host(1, node_gid, 0);
+        vec_fields(node_gid, 0, 1) = node_coords.host(1, node_gid, 1);
+        if (num_dims == 2)
+        {
+            vec_fields(node_gid, 0, 2) = 0.0;
         }
-        
+        else
+        {
+            vec_fields(node_gid, 0, 2) = node_coords.host(1, node_gid, 2);
+        }
+
         // position, var 1
         vec_fields(node_gid, 1, 0) = node_vel.host(1, node_gid, 0);
         vec_fields(node_gid, 1, 1) = node_vel.host(1, node_gid, 1);
-        if(num_dims == 2){ 
-            vec_fields(node_gid,1,2) = 0.0;
-        } else{
+        if (num_dims == 2)
+        {
+            vec_fields(node_gid, 1, 2) = 0.0;
+        }
+        else
+        {
             vec_fields(node_gid, 1, 2) = node_vel.host(1, node_gid, 2);
         }
-
     } // end for loop over vertices
-     
-    
+
     //  ---------------------------------------------------------------------------
     //  Setup of file and directoring for exporting
     //  ---------------------------------------------------------------------------
-    FILE *out[20];   // the output files that are written to
-    char filename[128];
-    
+    FILE* out[20];   // the output files that are written to
+    char  filename[128];
+
     struct stat st;
-    
-    if(stat("ensight",&st) != 0)
+
+    if (stat("ensight", &st) != 0)
+    {
         system("mkdir ensight");
-    
-    if(stat("ensight/data",&st) != 0)
+    }
+
+    if (stat("ensight/data", &st) != 0)
+    {
         system("mkdir ensight/data");
-    
-    
+    }
+
     //  ---------------------------------------------------------------------------
     //  Write the Geometry file
     //  ---------------------------------------------------------------------------
     sprintf(filename, "ensight/data/%s.%05lu.geo", name, graphics_id);
     // filename has the full string
-    
-    out[0] = fopen(filename, "w");
-    
-    
-    fprintf(out[0],"A graphics dump by Fierro \n");
-    fprintf(out[0],"%s","EnSight Gold geometry\n");
-    fprintf(out[0],"%s","node id assign\n");
-    fprintf(out[0],"%s","element id assign\n");
-    
-    fprintf(out[0],"part\n");
-    fprintf(out[0],"%10d\n", 1);
-    fprintf(out[0],"Mesh\n");
 
-    
+    out[0] = fopen(filename, "w");
+
+    fprintf(out[0], "A graphics dump by Fierro \n");
+    fprintf(out[0], "%s", "EnSight Gold geometry\n");
+    fprintf(out[0], "%s", "node id assign\n");
+    fprintf(out[0], "%s", "element id assign\n");
+
+    fprintf(out[0], "part\n");
+    fprintf(out[0], "%10d\n", 1);
+    fprintf(out[0], "Mesh\n");
+
     // --- vertices ---
-    fprintf(out[0],"coordinates\n");
-    fprintf(out[0],"%10lu\n",num_nodes);
-    
+    fprintf(out[0], "coordinates\n");
+    fprintf(out[0], "%10lu\n", num_nodes);
+
     // write all components of the point coordinates
-    for (int node_gid = 0; node_gid < num_nodes; node_gid++){
-        fprintf(out[0],"%12.5e\n",node_coords.host(1, node_gid, 0));
+    for (int node_gid = 0; node_gid < num_nodes; node_gid++)
+    {
+        fprintf(out[0], "%12.5e\n", node_coords.host(1, node_gid, 0));
     }
-    
-    for (int node_gid = 0; node_gid < num_nodes; node_gid++){
-        fprintf(out[0],"%12.5e\n",node_coords.host(1, node_gid, 1));
+
+    for (int node_gid = 0; node_gid < num_nodes; node_gid++)
+    {
+        fprintf(out[0], "%12.5e\n", node_coords.host(1, node_gid, 1));
     }
-    
-    for (int node_gid = 0; node_gid < num_nodes; node_gid++){
-        if(num_dims==3){
-            fprintf(out[0],"%12.5e\n",node_coords.host(1, node_gid, 2));
+
+    for (int node_gid = 0; node_gid < num_nodes; node_gid++)
+    {
+        if (num_dims == 3)
+        {
+            fprintf(out[0], "%12.5e\n", node_coords.host(1, node_gid, 2));
         }
         else
         {
-            fprintf(out[0],"%12.5e\n",0.0);
+            fprintf(out[0], "%12.5e\n", 0.0);
         }
     }
-    
-    
+
     // --- elements ---
-    if(num_dims==3){
-        fprintf(out[0],"hexa8\n");
+    if (num_dims == 3)
+    {
+        fprintf(out[0], "hexa8\n");
     }
-    else {
-        fprintf(out[0],"quad4\n");
+    else
+    {
+        fprintf(out[0], "quad4\n");
     }
-    fprintf(out[0],"%10lu\n",num_elems);
+    fprintf(out[0], "%10lu\n", num_elems);
 
-    
     // write all global point numbers for this cell
-    for (int elem_gid = 0; elem_gid < num_elems; elem_gid++) {
-        for (int node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++){
-
-            fprintf(out[0],"%10lu\t",mesh.nodes_in_elem.host(elem_gid, node_lid) + 1); // note: node_gid starts at 1
+    for (int elem_gid = 0; elem_gid < num_elems; elem_gid++)
+    {
+        for (int node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++)
+        {
+            fprintf(out[0], "%10lu\t", mesh.nodes_in_elem.host(elem_gid, node_lid) + 1); // note: node_gid starts at 1
         }
-        fprintf(out[0],"\n");
+        fprintf(out[0], "\n");
     }
-    
+
     fclose(out[0]);
-    
- 
+
     // ---------------------------------------------------------------------------
     // Write the Scalar variable files
     // ---------------------------------------------------------------------------
-    
-    // ensight_vars = (den, pres,...)
-    for (int var=0; var<num_scalar_vars; var++){
-        
-        // write a scalar value
-        sprintf(filename,"ensight/data/%s.%05lu.%s", name, graphics_id, scalar_var_names[var]);
 
-        out[0]=fopen(filename,"w");
-        
-        fprintf(out[0],"Per_elem scalar values\n");
-        fprintf(out[0],"part\n");
-        fprintf(out[0],"%10d\n",1);
-        if(num_dims==3){
-            fprintf(out[0],"hexa8\n");
+    // ensight_vars = (den, pres,...)
+    for (int var = 0; var < num_scalar_vars; var++)
+    {
+        // write a scalar value
+        sprintf(filename, "ensight/data/%s.%05lu.%s", name, graphics_id, scalar_var_names[var]);
+
+        out[0] = fopen(filename, "w");
+
+        fprintf(out[0], "Per_elem scalar values\n");
+        fprintf(out[0], "part\n");
+        fprintf(out[0], "%10d\n", 1);
+        if (num_dims == 3)
+        {
+            fprintf(out[0], "hexa8\n");
         }
-        else {
-            fprintf(out[0],"quad4\n");
+        else
+        {
+            fprintf(out[0], "quad4\n");
         }
-        
-        for (int elem_id=0; elem_id<num_elems; elem_id++) {
-            fprintf(out[0],"%12.5e\n",elem_fields(elem_id, var));
+
+        for (int elem_id = 0; elem_id < num_elems; elem_id++)
+        {
+            fprintf(out[0], "%12.5e\n", elem_fields(elem_id, var));
         }
-        
+
         fclose(out[0]);
-        
     } // end for var
-    
-    
-    
+
     //  ---------------------------------------------------------------------------
     //  Write the Vector variable files
     //  ---------------------------------------------------------------------------
-    
+
     // ensight vector vars = (position, velocity, force)
-    for (int var=0; var<num_vec_vars; var++){
-        
-        sprintf(filename,"ensight/data/%s.%05lu.%s", name, graphics_id, vec_var_names[var]);
-        
-        out[0]=fopen(filename,"w");
+    for (int var = 0; var < num_vec_vars; var++)
+    {
+        sprintf(filename, "ensight/data/%s.%05lu.%s", name, graphics_id, vec_var_names[var]);
+
+        out[0] = fopen(filename, "w");
         // fprintf(out[0],"Per_node vector values\n");
         // fprintf(out[0],"part\n");
         // fprintf(out[0],"%10d \n",1);
         // fprintf(out[0],"hexa8\n"); // WARNING, maybe bug here?
 
-        fprintf(out[0],"Per_node vector values\n");
-        fprintf(out[0],"part\n");
-        fprintf(out[0],"%10d\n",1);
-        fprintf(out[0],"block\n");
-        
-        for (int node_gid=0; node_gid<num_nodes; node_gid++){
-            fprintf(out[0],"%12.5e\n",vec_fields(node_gid, var, 0));
+        fprintf(out[0], "Per_node vector values\n");
+        fprintf(out[0], "part\n");
+        fprintf(out[0], "%10d\n", 1);
+        fprintf(out[0], "block\n");
+
+        for (int node_gid = 0; node_gid < num_nodes; node_gid++)
+        {
+            fprintf(out[0], "%12.5e\n", vec_fields(node_gid, var, 0));
         }
-        
-        for (int node_gid=0; node_gid<num_nodes; node_gid++){
-            fprintf(out[0],"%12.5e\n",vec_fields(node_gid, var, 1));
+
+        for (int node_gid = 0; node_gid < num_nodes; node_gid++)
+        {
+            fprintf(out[0], "%12.5e\n", vec_fields(node_gid, var, 1));
         }
-        
-        for (int node_gid=0; node_gid<num_nodes; node_gid++){
-            fprintf(out[0],"%12.5e\n",vec_fields(node_gid, var, 2));
+
+        for (int node_gid = 0; node_gid < num_nodes; node_gid++)
+        {
+            fprintf(out[0], "%12.5e\n", vec_fields(node_gid, var, 2));
         }
-        
+
         fclose(out[0]);
-
     } // end for var
-    
 
-    
     // ---------------------------------------------------------------------------
     // Write the case file
     // ---------------------------------------------------------------------------
-    
-    sprintf(filename,"ensight/%s.case",name);
-    out[0]=fopen(filename,"w");
-    
-    fprintf(out[0],"FORMAT\n");
-    fprintf(out[0],"type: ensight gold\n");
-    fprintf(out[0],"GEOMETRY\n");
-    
-    sprintf(filename,"model: data/%s.*****.geo\n",name);
-    fprintf(out[0],"%s",filename);
-    fprintf(out[0],"VARIABLE\n");
-    
-    for (int var=0; var<num_scalar_vars; var++){
+
+    sprintf(filename, "ensight/%s.case", name);
+    out[0] = fopen(filename, "w");
+
+    fprintf(out[0], "FORMAT\n");
+    fprintf(out[0], "type: ensight gold\n");
+    fprintf(out[0], "GEOMETRY\n");
+
+    sprintf(filename, "model: data/%s.*****.geo\n", name);
+    fprintf(out[0], "%s", filename);
+    fprintf(out[0], "VARIABLE\n");
+
+    for (int var = 0; var < num_scalar_vars; var++)
+    {
         sprintf(filename,
                 "scalar per element: %s data/%s.*****.%s\n",
                 scalar_var_names[var], name, scalar_var_names[var]);
-        fprintf(out[0],"%s",filename);
+        fprintf(out[0], "%s", filename);
     }
-    
-    for (int var=0; var<num_vec_vars; var++){
+
+    for (int var = 0; var < num_vec_vars; var++)
+    {
         sprintf(filename,
                 "vector per node: %s data/%s.*****.%s\n",
                 vec_var_names[var], name, vec_var_names[var]);
-        fprintf(out[0],"%s",filename);
+        fprintf(out[0], "%s", filename);
     }
-    
-    fprintf(out[0],"TIME\n");
-    fprintf(out[0],"time set: 1\n");
-    fprintf(out[0],"number of steps: %4lu\n",graphics_id+1);
-    fprintf(out[0],"filename start number: 0\n");
-    fprintf(out[0],"filename increment: 1\n");
-    fprintf(out[0],"time values: \n");
-    
-    graphics_times(graphics_id)=time_value;
-    
-    for (int i=0;i<=graphics_id;i++) {
-        fprintf(out[0],"%12.5e\n",graphics_times(i));
+
+    fprintf(out[0], "TIME\n");
+    fprintf(out[0], "time set: 1\n");
+    fprintf(out[0], "number of steps: %4lu\n", graphics_id + 1);
+    fprintf(out[0], "filename start number: 0\n");
+    fprintf(out[0], "filename increment: 1\n");
+    fprintf(out[0], "time values: \n");
+
+    graphics_times(graphics_id) = time_value;
+
+    for (int i = 0; i <= graphics_id; i++)
+    {
+        fprintf(out[0], "%12.5e\n", graphics_times(i));
     }
     fclose(out[0]);
-    
-    
+
     // ---------------------------------------------------------------------------
     // Done writing the graphics dump
     // ---------------------------------------------------------------------------
-    
+
     // increment graphics id counter
     graphics_id++;
-    
+
     delete[] name;
-    
+
     return;
-    
 } // end of Ensight function
 
-
-
-void state_file( const mesh_t &mesh,
-                 const DViewCArrayKokkos <double> &node_coords,
-                 const DViewCArrayKokkos <double> &node_vel,
-                 const DViewCArrayKokkos <double> &node_mass,
-                 const DViewCArrayKokkos <double> &elem_den,
-                 const DViewCArrayKokkos <double> &elem_pres,
-                 const DViewCArrayKokkos <double> &elem_stress,
-                 const DViewCArrayKokkos <double> &elem_sspd,
-                 const DViewCArrayKokkos <double> &elem_sie,
-                 const DViewCArrayKokkos <double> &elem_vol,
-                 const DViewCArrayKokkos <double> &elem_mass,
-                 const DViewCArrayKokkos <size_t> &elem_mat_id,
-                 const double time_value ) {
-    
+void
+state_file(const mesh_t&                    mesh,
+           const DViewCArrayKokkos<double>& node_coords,
+           const DViewCArrayKokkos<double>& node_vel,
+           const DViewCArrayKokkos<double>& node_mass,
+           const DViewCArrayKokkos<double>& elem_den,
+           const DViewCArrayKokkos<double>& elem_pres,
+           const DViewCArrayKokkos<double>& elem_stress,
+           const DViewCArrayKokkos<double>& elem_sspd,
+           const DViewCArrayKokkos<double>& elem_sie,
+           const DViewCArrayKokkos<double>& elem_vol,
+           const DViewCArrayKokkos<double>& elem_mass,
+           const DViewCArrayKokkos<size_t>& elem_mat_id,
+           const double                     time_value)
+{
     struct stat st;
-    
-    if(stat("state",&st) != 0)
+
+    if (stat("state", &st) != 0)
+    {
         system("mkdir state");
-    
+    }
+
     size_t num_dims = mesh.num_dims;
-    
+
     //  ---------------------------------------------------------------------------
     //  Setup of file and directoring for exporting
     //  ---------------------------------------------------------------------------
-    
+
     // output file
-    FILE *out_elem_state;  //element average state
-    char filename[128];
-    
+    FILE* out_elem_state;  // element average state
+    char  filename[128];
+
     sprintf(filename, "state/elem_state_t%6.5e.txt", time_value);
-    
+
     // output files
-    out_elem_state  = fopen(filename, "w");
+    out_elem_state = fopen(filename, "w");
 
     // write state dump
     fprintf(out_elem_state, "# state dump file\n");
     fprintf(out_elem_state, "# x  y  z  radius_2D  radius_3D  den  pres  sie  sspd  vol  mass \n");
-    
 
-    
     // write out values for the elem
-    for (size_t elem_gid=0; elem_gid<mesh.num_elems; elem_gid++){
-        
+    for (size_t elem_gid = 0; elem_gid < mesh.num_elems; elem_gid++)
+    {
         double elem_coords[3];
         elem_coords[0] = 0.0;
         elem_coords[1] = 0.0;
         elem_coords[2] = 0.0;
-	
-	
+
         // get the coordinates of the element center
-        for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++){
+        for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++)
+        {
             elem_coords[0] += node_coords.host(1, mesh.nodes_in_elem.host(elem_gid, node_lid), 0);
             elem_coords[1] += node_coords.host(1, mesh.nodes_in_elem.host(elem_gid, node_lid), 1);
-            if(num_dims == 3){
+            if (num_dims == 3)
+            {
                 elem_coords[2] += node_coords.host(1, mesh.nodes_in_elem.host(elem_gid, node_lid), 2);
             }
-            else {
+            else
+            {
                 elem_coords[2] = 0.0;
             }
         } // end loop over nodes in element
-	
-        elem_coords[0] = elem_coords[0]/mesh.num_nodes_in_elem;
-        elem_coords[1] = elem_coords[1]/mesh.num_nodes_in_elem;
-        elem_coords[2] = elem_coords[2]/mesh.num_nodes_in_elem;
-        
-        double rad2 = sqrt(elem_coords[0]*elem_coords[0] +
-                           elem_coords[1]*elem_coords[1]);
-        
-        double rad3 = sqrt(elem_coords[0]*elem_coords[0] +
-                           elem_coords[1]*elem_coords[1] +
-                           elem_coords[2]*elem_coords[2]);
-        
-        fprintf( out_elem_state,"%f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t \n",
+
+        elem_coords[0] = elem_coords[0] / mesh.num_nodes_in_elem;
+        elem_coords[1] = elem_coords[1] / mesh.num_nodes_in_elem;
+        elem_coords[2] = elem_coords[2] / mesh.num_nodes_in_elem;
+
+        double rad2 = sqrt(elem_coords[0] * elem_coords[0] +
+                           elem_coords[1] * elem_coords[1]);
+
+        double rad3 = sqrt(elem_coords[0] * elem_coords[0] +
+                           elem_coords[1] * elem_coords[1] +
+                           elem_coords[2] * elem_coords[2]);
+
+        fprintf(out_elem_state, "%f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t %f\t \n",
                  elem_coords[0],
                  elem_coords[1],
                  elem_coords[2],
@@ -490,24 +495,14 @@ void state_file( const mesh_t &mesh,
                  rad3,
                  elem_den.host(elem_gid),
                  elem_pres.host(elem_gid),
-                 elem_sie.host(1,elem_gid),
+                 elem_sie.host(1, elem_gid),
                  elem_sspd.host(elem_gid),
                  elem_vol.host(elem_gid),
                  elem_mass.host(elem_gid) );
-	
-        
-    }; // end for
-    
-    
+    }
+    ;  // end for
+
     fclose(out_elem_state);
- 
+
     return;
-    
 }; // end of state output
-
-
-
-
-
-
-

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/properties.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/properties.cpp
@@ -5,23 +5,22 @@
 #include "state.h"
 #include "mesh.h"
 
-void
-update_state(const CArrayKokkos<material_t>&  material,
-             const mesh_t&                    mesh,
-             const DViewCArrayKokkos<double>& node_coords,
-             const DViewCArrayKokkos<double>& node_vel,
-             DViewCArrayKokkos<double>&       elem_den,
-             DViewCArrayKokkos<double>&       elem_pres,
-             DViewCArrayKokkos<double>&       elem_stress,
-             DViewCArrayKokkos<double>&       elem_sspd,
-             const DViewCArrayKokkos<double>& elem_sie,
-             const DViewCArrayKokkos<double>& elem_vol,
-             const DViewCArrayKokkos<double>& elem_mass,
-             const DViewCArrayKokkos<size_t>& elem_mat_id,
-             const DViewCArrayKokkos<double>& elem_statev,
-             const double                     dt,
-             const double                     rk_alpha
-             )
+void update_state(const CArrayKokkos<material_t>&  material,
+                  const mesh_t&                    mesh,
+                  const DViewCArrayKokkos<double>& node_coords,
+                  const DViewCArrayKokkos<double>& node_vel,
+                  DViewCArrayKokkos<double>&       elem_den,
+                  DViewCArrayKokkos<double>&       elem_pres,
+                  DViewCArrayKokkos<double>&       elem_stress,
+                  DViewCArrayKokkos<double>&       elem_sspd,
+                  const DViewCArrayKokkos<double>& elem_sie,
+                  const DViewCArrayKokkos<double>& elem_vol,
+                  const DViewCArrayKokkos<double>& elem_mass,
+                  const DViewCArrayKokkos<size_t>& elem_mat_id,
+                  const DViewCArrayKokkos<double>& elem_statev,
+                  const double                     dt,
+                  const double                     rk_alpha
+                  )
 {
     // loop over all the elements in the mesh
     FOR_ALL(elem_gid, 0, mesh.num_elems, {
@@ -101,23 +100,22 @@ update_state(const CArrayKokkos<material_t>&  material,
     return;
 } // end method to update state
 
-void
-update_state2D(const CArrayKokkos<material_t>&  material,
-               const mesh_t&                    mesh,
-               const DViewCArrayKokkos<double>& node_coords,
-               const DViewCArrayKokkos<double>& node_vel,
-               DViewCArrayKokkos<double>&       elem_den,
-               DViewCArrayKokkos<double>&       elem_pres,
-               DViewCArrayKokkos<double>&       elem_stress,
-               DViewCArrayKokkos<double>&       elem_sspd,
-               const DViewCArrayKokkos<double>& elem_sie,
-               const DViewCArrayKokkos<double>& elem_vol,
-               const DViewCArrayKokkos<double>& elem_mass,
-               const DViewCArrayKokkos<size_t>& elem_mat_id,
-               const DViewCArrayKokkos<double>& elem_statev,
-               const double                     dt,
-               const double                     rk_alpha
-               )
+void update_state2D(const CArrayKokkos<material_t>&  material,
+                    const mesh_t&                    mesh,
+                    const DViewCArrayKokkos<double>& node_coords,
+                    const DViewCArrayKokkos<double>& node_vel,
+                    DViewCArrayKokkos<double>&       elem_den,
+                    DViewCArrayKokkos<double>&       elem_pres,
+                    DViewCArrayKokkos<double>&       elem_stress,
+                    DViewCArrayKokkos<double>&       elem_sspd,
+                    const DViewCArrayKokkos<double>& elem_sie,
+                    const DViewCArrayKokkos<double>& elem_vol,
+                    const DViewCArrayKokkos<double>& elem_mass,
+                    const DViewCArrayKokkos<size_t>& elem_mat_id,
+                    const DViewCArrayKokkos<double>& elem_statev,
+                    const double                     dt,
+                    const double                     rk_alpha
+                    )
 {
     // loop over all the elements in the mesh
     FOR_ALL(elem_gid, 0, mesh.num_elems, {

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/properties.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/properties.cpp
@@ -1,71 +1,65 @@
-                                                           
+
 // -----------------------------------------------------------------------------
 // This calls the models to update state
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include "state.h"
 #include "mesh.h"
 
-
-void update_state(const CArrayKokkos <material_t> &material,
-                  const mesh_t &mesh,
-                  const DViewCArrayKokkos <double> &node_coords,
-                  const DViewCArrayKokkos <double> &node_vel,
-                  DViewCArrayKokkos <double> &elem_den,
-                  DViewCArrayKokkos <double> &elem_pres,
-                  DViewCArrayKokkos <double> &elem_stress,
-                  DViewCArrayKokkos <double> &elem_sspd,
-                  const DViewCArrayKokkos <double> &elem_sie,
-                  const DViewCArrayKokkos <double> &elem_vol,
-                  const DViewCArrayKokkos <double> &elem_mass,
-                  const DViewCArrayKokkos <size_t> &elem_mat_id,
-                  const DViewCArrayKokkos <double> &elem_statev,
-                  const double dt,
-                  const double rk_alpha
-                  ){
-
-
-    
-    
+void
+update_state(const CArrayKokkos<material_t>&  material,
+             const mesh_t&                    mesh,
+             const DViewCArrayKokkos<double>& node_coords,
+             const DViewCArrayKokkos<double>& node_vel,
+             DViewCArrayKokkos<double>&       elem_den,
+             DViewCArrayKokkos<double>&       elem_pres,
+             DViewCArrayKokkos<double>&       elem_stress,
+             DViewCArrayKokkos<double>&       elem_sspd,
+             const DViewCArrayKokkos<double>& elem_sie,
+             const DViewCArrayKokkos<double>& elem_vol,
+             const DViewCArrayKokkos<double>& elem_mass,
+             const DViewCArrayKokkos<size_t>& elem_mat_id,
+             const DViewCArrayKokkos<double>& elem_statev,
+             const double                     dt,
+             const double                     rk_alpha
+             )
+{
     // loop over all the elements in the mesh
-    FOR_ALL (elem_gid, 0, mesh.num_elems, {
-        
+    FOR_ALL(elem_gid, 0, mesh.num_elems, {
         const size_t num_dims = mesh.num_dims;
         const size_t num_nodes_in_elem = mesh.num_nodes_in_elem;
 
         // cut out the node_gids for this element
-        ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
-        
+        ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
+
         // --- Density ---
-        elem_den(elem_gid) = elem_mass(elem_gid)/elem_vol(elem_gid);
-        
+        elem_den(elem_gid) = elem_mass(elem_gid) / elem_vol(elem_gid);
+
         size_t mat_id = elem_mat_id(elem_gid);
-        
-        
+
         // --- Stress ---
         // hyper elastic plastic model
-        if(material(mat_id).strength_type == model::hyper){
-
+        if (material(mat_id).strength_type == model::hyper)
+        {
             // cut out the node_gids for this element
-            ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
-            
+            ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
+
             // --- Density ---
-            elem_den(elem_gid) = elem_mass(elem_gid)/elem_vol(elem_gid);
-            
+            elem_den(elem_gid) = elem_mass(elem_gid) / elem_vol(elem_gid);
+
             // corner area normals
             double area_array[24];
-            ViewCArrayKokkos <double> area(area_array, num_nodes_in_elem, num_dims);
-            
+            ViewCArrayKokkos<double> area(area_array, num_nodes_in_elem, num_dims);
+
             // velocity gradient
             double vel_grad_array[9];
-            ViewCArrayKokkos <double> vel_grad(vel_grad_array, num_dims, num_dims);
-            
+            ViewCArrayKokkos<double> vel_grad(vel_grad_array, num_dims, num_dims);
+
             // get the B matrix which are the OUTWARD corner area normals
             get_bmatrix(area,
                         elem_gid,
                         node_coords,
                         elem_node_gids);
-        
-            
+
             // --- Calculate the velocity gradient ---
             get_velgrad(vel_grad,
                         elem_node_gids,
@@ -73,8 +67,7 @@ void update_state(const CArrayKokkos <material_t> &material,
                         area,
                         elem_vol(elem_gid),
                         elem_gid);
-            
-            
+
             // --- call strength model ---
             material(mat_id).strength_model(elem_pres,
                                             elem_stress,
@@ -91,10 +84,8 @@ void update_state(const CArrayKokkos <material_t> &material,
                                             elem_vol(elem_gid),
                                             dt,
                                             rk_alpha);
-            
         } // end logical on hyper strength model
-        
-        
+
         // --- Pressure ---
         material(mat_id).eos_model(elem_pres,
                                    elem_stress,
@@ -103,76 +94,68 @@ void update_state(const CArrayKokkos <material_t> &material,
                                    elem_statev,
                                    elem_sspd,
                                    elem_den(elem_gid),
-                                   elem_sie(1,elem_gid));
-        
-        
+                                   elem_sie(1, elem_gid));
     }); // end parallel for
     Kokkos::fence();
-    
+
     return;
-    
 } // end method to update state
 
-
-
-void update_state2D(const CArrayKokkos <material_t> &material,
-                    const mesh_t &mesh,
-                    const DViewCArrayKokkos <double> &node_coords,
-                    const DViewCArrayKokkos <double> &node_vel,
-                    DViewCArrayKokkos <double> &elem_den,
-                    DViewCArrayKokkos <double> &elem_pres,
-                    DViewCArrayKokkos <double> &elem_stress,
-                    DViewCArrayKokkos <double> &elem_sspd,
-                    const DViewCArrayKokkos <double> &elem_sie,
-                    const DViewCArrayKokkos <double> &elem_vol,
-                    const DViewCArrayKokkos <double> &elem_mass,
-                    const DViewCArrayKokkos <size_t> &elem_mat_id,
-                    const DViewCArrayKokkos <double> &elem_statev,
-                    const double dt,
-                    const double rk_alpha
-                    ){
-    
-    
+void
+update_state2D(const CArrayKokkos<material_t>&  material,
+               const mesh_t&                    mesh,
+               const DViewCArrayKokkos<double>& node_coords,
+               const DViewCArrayKokkos<double>& node_vel,
+               DViewCArrayKokkos<double>&       elem_den,
+               DViewCArrayKokkos<double>&       elem_pres,
+               DViewCArrayKokkos<double>&       elem_stress,
+               DViewCArrayKokkos<double>&       elem_sspd,
+               const DViewCArrayKokkos<double>& elem_sie,
+               const DViewCArrayKokkos<double>& elem_vol,
+               const DViewCArrayKokkos<double>& elem_mass,
+               const DViewCArrayKokkos<size_t>& elem_mat_id,
+               const DViewCArrayKokkos<double>& elem_statev,
+               const double                     dt,
+               const double                     rk_alpha
+               )
+{
     // loop over all the elements in the mesh
-    FOR_ALL (elem_gid, 0, mesh.num_elems, {
-        
+    FOR_ALL(elem_gid, 0, mesh.num_elems, {
         const size_t num_dims = mesh.num_dims;
         const size_t num_nodes_in_elem = mesh.num_nodes_in_elem;
 
         // cut out the node_gids for this element
-        ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
-        
+        ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
+
         // --- Density ---
-        elem_den(elem_gid) = elem_mass(elem_gid)/elem_vol(elem_gid);
-        
+        elem_den(elem_gid) = elem_mass(elem_gid) / elem_vol(elem_gid);
+
         size_t mat_id = elem_mat_id(elem_gid);
-        
-        
+
         // --- Stress ---
         // hyper elastic plastic model
-        if(material(mat_id).strength_type == model::hyper){
-
+        if (material(mat_id).strength_type == model::hyper)
+        {
             // cut out the node_gids for this element
-            ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
-            
+            ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), num_nodes_in_elem);
+
             // --- Density ---
-            elem_den(elem_gid) = elem_mass(elem_gid)/elem_vol(elem_gid);
-            
+            elem_den(elem_gid) = elem_mass(elem_gid) / elem_vol(elem_gid);
+
             // corner area normals
             double area_array[8];
-            ViewCArrayKokkos <double> area(area_array, num_nodes_in_elem, num_dims);
-            
+            ViewCArrayKokkos<double> area(area_array, num_nodes_in_elem, num_dims);
+
             // velocity gradient
             double vel_grad_array[4];
-            ViewCArrayKokkos <double> vel_grad(vel_grad_array, num_dims, num_dims);
-            
+            ViewCArrayKokkos<double> vel_grad(vel_grad_array, num_dims, num_dims);
+
             // get the B matrix which are the OUTWARD corner area normals
             get_bmatrix(area,
                         elem_gid,
                         node_coords,
                         elem_node_gids);
-        
-            
+
             // --- Calculate the velocity gradient ---
             get_velgrad(vel_grad,
                         elem_node_gids,
@@ -180,8 +163,7 @@ void update_state2D(const CArrayKokkos <material_t> &material,
                         area,
                         elem_vol(elem_gid),
                         elem_gid);
-            
-            
+
             // --- call strength model ---
             material(mat_id).strength_model(elem_pres,
                                             elem_stress,
@@ -198,10 +180,8 @@ void update_state2D(const CArrayKokkos <material_t> &material,
                                             elem_vol(elem_gid),
                                             dt,
                                             rk_alpha);
-            
         } // end logical on hyper strength model
-        
-        
+
         // --- Pressure ---
         material(mat_id).eos_model(elem_pres,
                                    elem_stress,
@@ -210,15 +190,9 @@ void update_state2D(const CArrayKokkos <material_t> &material,
                                    elem_statev,
                                    elem_sspd,
                                    elem_den(elem_gid),
-                                   elem_sie(1,elem_gid));
-        
-        
+                                   elem_sie(1, elem_gid));
     }); // end parallel for
     Kokkos::fence();
-    
+
     return;
-    
 } // end method to update state
-
-
-

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/read_mesh.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/read_mesh.cpp
@@ -7,14 +7,13 @@
 // -----------------------------------------------------------------------------
 // Reads an ensight .geo mesh file
 // ------------------------------------------------------------------------------
-void
-read_mesh_ensight(char*        MESH,
-                  mesh_t&      mesh,
-                  node_t&      node,
-                  elem_t&      elem,
-                  corner_t&    corner,
-                  const size_t num_dims,
-                  const size_t rk_num_bins)
+void read_mesh_ensight(char*        MESH,
+                       mesh_t&      mesh,
+                       node_t&      node,
+                       elem_t&      elem,
+                       corner_t&    corner,
+                       const size_t num_dims,
+                       const size_t rk_num_bins)
 {
     const size_t rk_level = 0;
 

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/read_mesh.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/read_mesh.cpp
@@ -1,115 +1,116 @@
 // -----------------------------------------------------------------------------
 // This code reads the mesh in different formats
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include "mesh.h"
 #include "state.h"
 
-
-
 // -----------------------------------------------------------------------------
 // Reads an ensight .geo mesh file
-//------------------------------------------------------------------------------
-void read_mesh_ensight(char* MESH,
-                       mesh_t &mesh,
-                       node_t &node,
-                       elem_t &elem,
-                       corner_t &corner,
-                       const size_t num_dims,
-                       const size_t rk_num_bins){
-
+// ------------------------------------------------------------------------------
+void
+read_mesh_ensight(char*        MESH,
+                  mesh_t&      mesh,
+                  node_t&      node,
+                  elem_t&      elem,
+                  corner_t&    corner,
+                  const size_t num_dims,
+                  const size_t rk_num_bins)
+{
     const size_t rk_level = 0;
 
-	FILE *in;
-    char ch;
-    
-    
+    FILE* in;
+    char  ch;
+
     size_t num_nodes_in_elem = 1;
-    for (int dim=0; dim<num_dims; dim++){
+    for (int dim = 0; dim < num_dims; dim++)
+    {
         num_nodes_in_elem *= 2;
     }
 
+    // read the mesh    WARNING: assumes a .geo file
+    in = fopen(MESH, "r");
 
-    //read the mesh    WARNING: assumes a .geo file
-    in = fopen(MESH,"r");  
-    
-    //skip 8 lines
-    for (int j=1; j<=8;j++) {
-        int i=0;
-        while ((ch=(char)fgetc(in))!='\n') {
+    // skip 8 lines
+    for (int j = 1; j <= 8; j++)
+    {
+        int i = 0;
+        while ((ch = (char)fgetc(in)) != '\n') {
             i++;
-            //printf("%c",ch);
+            // printf("%c",ch);
         }
-        //printf("\n");
-    }  
-
-    
+        // printf("\n");
+    }
 
     // --- Read in the nodes in the mesh ---
-    
+
     size_t num_nodes = 0;
-    
-    fscanf(in,"%lu",&num_nodes);
-    printf("Num nodes read in %lu\n" , num_nodes);
-    
+
+    fscanf(in, "%lu", &num_nodes);
+    printf("Num nodes read in %lu\n", num_nodes);
+
     // intialize node variables
     mesh.initialize_nodes(num_nodes);
     node.initialize(rk_num_bins, num_nodes, num_dims);
-    
 
     // read the initial mesh coordinates
     // x-coords
-    for (int node_id = 0; node_id < mesh.num_nodes; node_id++) {
-        fscanf(in,"%le",&node.coords(rk_level,node_id, 0));
+    for (int node_id = 0; node_id < mesh.num_nodes; node_id++)
+    {
+        fscanf(in, "%le", &node.coords(rk_level, node_id, 0));
     }
 
     // y-coords
-    for (int node_id = 0; node_id < mesh.num_nodes; node_id++) {
-        fscanf(in,"%le",&node.coords(rk_level,node_id, 1));
-    }  
+    for (int node_id = 0; node_id < mesh.num_nodes; node_id++)
+    {
+        fscanf(in, "%le", &node.coords(rk_level, node_id, 1));
+    }
 
     // z-coords
-    for (int node_id = 0; node_id < mesh.num_nodes; node_id++) {
-        if(num_dims==3){
-            fscanf(in,"%le",&node.coords(rk_level,node_id, 2));
-        } else
+    for (int node_id = 0; node_id < mesh.num_nodes; node_id++)
+    {
+        if (num_dims == 3)
+        {
+            fscanf(in, "%le", &node.coords(rk_level, node_id, 2));
+        }
+        else
         {
             double dummy;
-            fscanf(in,"%le",&dummy);
-            
-            //printf("dummy = %le\n", dummy);
+            fscanf(in, "%le", &dummy);
+
+            // printf("dummy = %le\n", dummy);
         }
     } // end for
 
-    
     ch = (char)fgetc(in);
-    //printf("%c",ch);
+    // printf("%c",ch);
 
-    //skip 1 line
-    for (int j=1; j<=1; j++) {
-        int i=0;
-        while ((ch=(char)fgetc(in))!='\n') {
+    // skip 1 line
+    for (int j = 1; j <= 1; j++)
+    {
+        int i = 0;
+        while ((ch = (char)fgetc(in)) != '\n') {
             i++;
-            //printf("%c",ch);
+            // printf("%c",ch);
         }
-        //printf("\n");
+        // printf("\n");
     }
-    
 
     // --- read in the elements in the mesh ---
     size_t num_elem = 0;
-    
-    fscanf(in,"%lu",&num_elem);
-    printf("Num elements read in %lu\n" , num_elem);
+
+    fscanf(in, "%lu", &num_elem);
+    printf("Num elements read in %lu\n", num_elem);
 
     // intialize elem variables
     mesh.initialize_elems(num_elem, num_dims);
     elem.initialize(rk_num_bins, num_nodes, 3); // always 3D here, even for 2D
 
     // for each cell read the list of associated nodes
-    for (int elem_gid = 0; elem_gid < num_elem; elem_gid++) {
-        for (int node_lid = 0; node_lid < num_nodes_in_elem; node_lid++){
-            
-            fscanf(in,"%lu",&mesh.nodes_in_elem.host(elem_gid, node_lid));  // %d vs zu
+    for (int elem_gid = 0; elem_gid < num_elem; elem_gid++)
+    {
+        for (int node_lid = 0; node_lid < num_nodes_in_elem; node_lid++)
+        {
+            fscanf(in, "%lu", &mesh.nodes_in_elem.host(elem_gid, node_lid));  // %d vs zu
 
             // shift to start node index space at 0
             mesh.nodes_in_elem.host(elem_gid, node_lid) -= 1;
@@ -117,31 +118,26 @@ void read_mesh_ensight(char* MESH,
     }
     // update device side
     mesh.nodes_in_elem.update_device();
-    
-    
+
     // intialize corner variables
-    int num_corners = num_elem*mesh.num_nodes_in_elem;
+    int num_corners = num_elem * mesh.num_nodes_in_elem;
     mesh.initialize_corners(num_corners);
     corner.initialize(num_corners, num_dims);
 
-    
     // save the node coords to the current RK value
-    for (size_t node_gid=0; node_gid<num_nodes; node_gid++){
-        
-        for(int rk=1; rk<rk_num_bins; rk++){
-            for (int dim = 0; dim < num_dims; dim++){
+    for (size_t node_gid = 0; node_gid < num_nodes; node_gid++)
+    {
+        for (int rk = 1; rk < rk_num_bins; rk++)
+        {
+            for (int dim = 0; dim < num_dims; dim++)
+            {
                 node.coords(rk, node_gid, dim) = node.coords(0, node_gid, dim);
             } // end for dim
         } // end for rk
-        
     } // end parallel for
-
-
-
 
     // Close mesh input file
     fclose(in);
 
     return;
-    
 }

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/setup.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/setup.cpp
@@ -50,31 +50,30 @@ std::string trim(const std::string& s);
 KOKKOS_FUNCTION
 int get_id(int i, int j, int k, int num_i, int num_j);
 
-void
-setup(const CArrayKokkos<material_t>&  material,
-      const CArrayKokkos<mat_fill_t>&  mat_fill,
-      const CArrayKokkos<boundary_t>&  boundary,
-      mesh_t&                          mesh,
-      const DViewCArrayKokkos<double>& node_coords,
-      DViewCArrayKokkos<double>&       node_vel,
-      DViewCArrayKokkos<double>&       node_mass,
-      const DViewCArrayKokkos<double>& elem_den,
-      const DViewCArrayKokkos<double>& elem_pres,
-      const DViewCArrayKokkos<double>& elem_stress,
-      const DViewCArrayKokkos<double>& elem_sspd,
-      const DViewCArrayKokkos<double>& elem_sie,
-      const DViewCArrayKokkos<double>& elem_vol,
-      const DViewCArrayKokkos<double>& elem_mass,
-      const DViewCArrayKokkos<size_t>& elem_mat_id,
-      const DViewCArrayKokkos<double>& elem_statev,
-      const CArrayKokkos<double>&      state_vars,
-      const DViewCArrayKokkos<double>& corner_mass,
-      const size_t                     num_fills,
-      const size_t                     rk_num_bins,
-      const size_t                     num_bcs,
-      const size_t                     num_materials,
-      const size_t                     num_state_vars
-      )
+void setup(const CArrayKokkos<material_t>&  material,
+           const CArrayKokkos<mat_fill_t>&  mat_fill,
+           const CArrayKokkos<boundary_t>&  boundary,
+           mesh_t&                          mesh,
+           const DViewCArrayKokkos<double>& node_coords,
+           DViewCArrayKokkos<double>&       node_vel,
+           DViewCArrayKokkos<double>&       node_mass,
+           const DViewCArrayKokkos<double>& elem_den,
+           const DViewCArrayKokkos<double>& elem_pres,
+           const DViewCArrayKokkos<double>& elem_stress,
+           const DViewCArrayKokkos<double>& elem_sspd,
+           const DViewCArrayKokkos<double>& elem_sie,
+           const DViewCArrayKokkos<double>& elem_vol,
+           const DViewCArrayKokkos<double>& elem_mass,
+           const DViewCArrayKokkos<size_t>& elem_mat_id,
+           const DViewCArrayKokkos<double>& elem_statev,
+           const CArrayKokkos<double>&      state_vars,
+           const DViewCArrayKokkos<double>& corner_mass,
+           const size_t                     num_fills,
+           const size_t                     rk_num_bins,
+           const size_t                     num_bcs,
+           const size_t                     num_materials,
+           const size_t                     num_state_vars
+           )
 {
     // --- calculate bdy sets ---//
     mesh.init_bdy_sets(num_bcs);
@@ -520,10 +519,9 @@ setup(const CArrayKokkos<material_t>&  material,
 // set planes for tagging sub sets of boundary patches
 // bc_tag = 0 xplane, 1 yplane, 2 zplane, 3 cylinder, 4 is shell
 // val = plane value, cyl radius, sphere radius
-void
-tag_bdys(const CArrayKokkos<boundary_t>&  boundary,
-         mesh_t&                          mesh,
-         const DViewCArrayKokkos<double>& node_coords)
+void tag_bdys(const CArrayKokkos<boundary_t>&  boundary,
+              mesh_t&                          mesh,
+              const DViewCArrayKokkos<double>& node_coords)
 {
     size_t num_dims = mesh.num_dims;
 
@@ -570,12 +568,11 @@ tag_bdys(const CArrayKokkos<boundary_t>&  boundary,
 // bc_tag = 0 xplane, 1 yplane, 2 zplane, 3 cylinder, 4 is shell
 // val = plane value, radius, radius
 KOKKOS_FUNCTION
-size_t
-check_bdy(const size_t                     patch_gid,
-          const int                        this_bc_tag,
-          const double                     val,
-          const mesh_t&                    mesh,
-          const DViewCArrayKokkos<double>& node_coords)
+size_t check_bdy(const size_t                     patch_gid,
+                 const int                        this_bc_tag,
+                 const double                     val,
+                 const mesh_t&                    mesh,
+                 const DViewCArrayKokkos<double>& node_coords)
 {
     size_t num_dims = mesh.num_dims;
 
@@ -658,9 +655,8 @@ check_bdy(const size_t                     patch_gid,
     return is_on_bdy;
 } // end method to check bdy
 
-void
-build_boundry_node_sets(const CArrayKokkos<boundary_t>& boundary,
-                        mesh_t&                         mesh)
+void build_boundry_node_sets(const CArrayKokkos<boundary_t>& boundary,
+                             mesh_t&                         mesh)
 {
     // build boundary nodes in each boundary set
 
@@ -739,17 +735,16 @@ build_boundry_node_sets(const CArrayKokkos<boundary_t>& boundary,
 // -----------------------------------------------------------------------------
 // The function to read a voxel vtk file from Dream3d and intialize the mesh
 // ------------------------------------------------------------------------------
-void
-user_voxel_init(DCArrayKokkos<size_t>& elem_values,
-                double&                dx,
-                double&                dy,
-                double&                dz,
-                double&                orig_x,
-                double&                orig_y,
-                double&                orig_z,
-                size_t&                num_elems_i,
-                size_t&                num_elems_j,
-                size_t&                num_elems_k)
+void user_voxel_init(DCArrayKokkos<size_t>& elem_values,
+                     double&                dx,
+                     double&                dy,
+                     double&                dz,
+                     double&                orig_x,
+                     double&                orig_y,
+                     double&                orig_z,
+                     size_t&                num_elems_i,
+                     size_t&                num_elems_j,
+                     size_t&                num_elems_k)
 {
     std::string MESH = "voxel.vtk"; // user specified
 
@@ -1049,8 +1044,7 @@ user_voxel_init(DCArrayKokkos<size_t>& elem_values,
 } // end routine
 
 // Code from stackover flow for string delimiter parsing
-std::vector<std::string>
-split(std::string s, std::string delimiter)
+std::vector<std::string> split(std::string s, std::string delimiter)
 {
     size_t                   pos_start = 0, pos_end, delim_len = delimiter.length();
     std::string              token;
@@ -1067,8 +1061,7 @@ split(std::string s, std::string delimiter)
 } // end of split
 
 // retrieves multiple values between [ ]
-std::vector<double>
-extract_list(std::string str)
+std::vector<double> extract_list(std::string str)
 {
     // replace '[' with a space and ']' with a space
     std::replace(str.begin(), str.end(), '[', ' ');
@@ -1089,22 +1082,19 @@ extract_list(std::string str)
     return values;
 }  // end of extract_list
 
-std::string
-ltrim(const std::string& s)
+std::string ltrim(const std::string& s)
 {
     size_t start = s.find_first_not_of(WHITESPACE);
     return (start == std::string::npos) ? "" : s.substr(start);
 }
 
-std::string
-rtrim(const std::string& s)
+std::string rtrim(const std::string& s)
 {
     size_t end = s.find_last_not_of(WHITESPACE);
     return (end == std::string::npos) ? "" : s.substr(0, end + 1);
 }
 
-std::string
-trim(const std::string& s)
+std::string trim(const std::string& s)
 {
     return rtrim(ltrim(s));
 }
@@ -1117,8 +1107,7 @@ trim(const std::string& s)
 //
 // Returns a global id for a given i,j,k
 KOKKOS_FUNCTION
-int
-get_id(int i, int j, int k, int num_i, int num_j)
+int get_id(int i, int j, int k, int num_i, int num_j)
 {
     return i + j * num_i + k * num_i * num_j;
 }

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/setup.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/setup.cpp
@@ -1,7 +1,7 @@
-                                                           
+
 // -----------------------------------------------------------------------------
 // This code to setup the ICs and BCs
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 #include <string.h>
 #include <sys/stat.h>
@@ -15,182 +15,169 @@
 #include <vector>
 #include <algorithm>
 
-
 #include "matar.h"
 #include "state.h"
 #include "mesh.h"
 
-
-
-//==============================================================================
+// ==============================================================================
 //   Functions to read voxel mesh
-//==============================================================================
-void user_voxel_init(DCArrayKokkos <size_t> &elem_values,
-                     double &dx,
-                     double &dy,
-                     double &dz,
-                     double &orig_x,
-                     double &orig_y,
-                     double &orig_z,
-                     size_t &voxel_num_i,
-                     size_t &voxel_num_j,
-                     size_t &voxel_num_k);
+// ==============================================================================
+void user_voxel_init(DCArrayKokkos<size_t>& elem_values,
+                     double&                dx,
+                     double&                dy,
+                     double&                dz,
+                     double&                orig_x,
+                     double&                orig_y,
+                     double&                orig_z,
+                     size_t&                voxel_num_i,
+                     size_t&                voxel_num_j,
+                     size_t&                voxel_num_k);
 
 // for string delimiter parsing
-std::vector<std::string> split (std::string s, std::string delimiter);
+std::vector<std::string> split(std::string s, std::string delimiter);
 
 // retrieves multiple values between [ ]
 std::vector<double> extract_list(std::string str);
 
 const std::string WHITESPACE = " ";
 
-std::string ltrim(const std::string &s);
- 
-std::string rtrim(const std::string &s);
- 
-std::string trim(const std::string &s);
+std::string ltrim(const std::string& s);
+
+std::string rtrim(const std::string& s);
+
+std::string trim(const std::string& s);
 
 KOKKOS_FUNCTION
 int get_id(int i, int j, int k, int num_i, int num_j);
 
-
-
-void setup(const CArrayKokkos <material_t> &material,
-           const CArrayKokkos <mat_fill_t> &mat_fill,
-           const CArrayKokkos <boundary_t> &boundary,
-           mesh_t &mesh,
-           const DViewCArrayKokkos <double> &node_coords,
-           DViewCArrayKokkos <double> &node_vel,
-           DViewCArrayKokkos <double> &node_mass,
-           const DViewCArrayKokkos <double> &elem_den,
-           const DViewCArrayKokkos <double> &elem_pres,
-           const DViewCArrayKokkos <double> &elem_stress,
-           const DViewCArrayKokkos <double> &elem_sspd,
-           const DViewCArrayKokkos <double> &elem_sie,
-           const DViewCArrayKokkos <double> &elem_vol,
-           const DViewCArrayKokkos <double> &elem_mass,
-           const DViewCArrayKokkos <size_t> &elem_mat_id,
-           const DViewCArrayKokkos <double> &elem_statev,
-           const CArrayKokkos <double> &state_vars,
-           const DViewCArrayKokkos <double> &corner_mass,
-           const size_t num_fills,
-           const size_t rk_num_bins,
-           const size_t num_bcs,
-           const size_t num_materials,
-           const size_t num_state_vars
-           ){
-
-    
-    //--- calculate bdy sets ---//
+void
+setup(const CArrayKokkos<material_t>&  material,
+      const CArrayKokkos<mat_fill_t>&  mat_fill,
+      const CArrayKokkos<boundary_t>&  boundary,
+      mesh_t&                          mesh,
+      const DViewCArrayKokkos<double>& node_coords,
+      DViewCArrayKokkos<double>&       node_vel,
+      DViewCArrayKokkos<double>&       node_mass,
+      const DViewCArrayKokkos<double>& elem_den,
+      const DViewCArrayKokkos<double>& elem_pres,
+      const DViewCArrayKokkos<double>& elem_stress,
+      const DViewCArrayKokkos<double>& elem_sspd,
+      const DViewCArrayKokkos<double>& elem_sie,
+      const DViewCArrayKokkos<double>& elem_vol,
+      const DViewCArrayKokkos<double>& elem_mass,
+      const DViewCArrayKokkos<size_t>& elem_mat_id,
+      const DViewCArrayKokkos<double>& elem_statev,
+      const CArrayKokkos<double>&      state_vars,
+      const DViewCArrayKokkos<double>& corner_mass,
+      const size_t                     num_fills,
+      const size_t                     rk_num_bins,
+      const size_t                     num_bcs,
+      const size_t                     num_materials,
+      const size_t                     num_state_vars
+      )
+{
+    // --- calculate bdy sets ---//
     mesh.init_bdy_sets(num_bcs);
     printf("Num BC's = %lu\n", num_bcs);
-    
+
     // tag boundary patches in the set
     tag_bdys(boundary, mesh, node_coords);
 
     build_boundry_node_sets(boundary, mesh);
-    
+
     // loop over BCs
-    for (size_t this_bdy = 0; this_bdy < num_bcs; this_bdy++){
-        
+    for (size_t this_bdy = 0; this_bdy < num_bcs; this_bdy++)
+    {
         RUN({
             printf("Boundary Condition number %lu \n", this_bdy);
             printf("  Num bdy patches in this set = %lu \n", mesh.bdy_patches_in_set.stride(this_bdy));
             printf("  Num bdy nodes in this set = %lu \n", mesh.bdy_nodes_in_set.stride(this_bdy));
         });
         Kokkos::fence();
+    } // end for
 
-    }// end for
-    
-    
     // ---- Read model values from a file ----
     // check to see if state_vars come from an external file
-    DCArrayKokkos <size_t> read_from_file(num_materials);
+    DCArrayKokkos<size_t> read_from_file(num_materials);
     FOR_ALL(mat_id, 0, num_materials, {
-        
         read_from_file(mat_id) = material(mat_id).strength_setup;
-        
     }); // end parallel for
     Kokkos::fence();
-    
+
     read_from_file.update_host(); // copy to CPU if code is to read from a file
     Kokkos::fence();
-    
+
     // make memory to store state_vars from an external file
-       DCArrayKokkos <size_t> mat_num_state_vars(num_materials); // actual number of state_vars
+    DCArrayKokkos<size_t> mat_num_state_vars(num_materials);     // actual number of state_vars
     FOR_ALL(mat_id, 0, num_materials, {
-        
         mat_num_state_vars(mat_id) = material(mat_id).num_state_vars;
-        
     }); // end parallel for
     Kokkos::fence();
-    
+
     // copy actual number of state_vars to host
     mat_num_state_vars.update_host();
     Kokkos::fence();
-    
+
     // the state_vars from the file
-    DCArrayKokkos <double> file_state_vars(num_materials,mesh.num_elems,num_state_vars);
-    for (size_t mat_id=0; mat_id<num_materials; mat_id++){
-        
-        if (read_from_file.host(mat_id) == model_init::user_init){
-            
+    DCArrayKokkos<double> file_state_vars(num_materials, mesh.num_elems, num_state_vars);
+    for (size_t mat_id = 0; mat_id < num_materials; mat_id++)
+    {
+        if (read_from_file.host(mat_id) == model_init::user_init)
+        {
             size_t num_vars = mat_num_state_vars.host(mat_id);
-            
+
             user_model_init(file_state_vars,
                             num_vars,
                             mat_id,
                             mesh.num_elems);
-            
+
             // copy the values to the device
             file_state_vars.update_device();
             Kokkos::fence();
-            
         } // end if
-        
     } // end for
-    
 
     // for rading an external voxel mesh
-    DCArrayKokkos <size_t> voxel_elem_values;
-    double voxel_dx, voxel_dy, voxel_dz;           // voxel mesh resolution
-    double orig_x, orig_y, orig_z;                 // origin of voxel elem centers
-    size_t voxel_num_i, voxel_num_j, voxel_num_k;  // voxel elements in each direction
-    
+    DCArrayKokkos<size_t> voxel_elem_values;
+    double                voxel_dx, voxel_dy, voxel_dz; // voxel mesh resolution
+    double                orig_x, orig_y, orig_z;  // origin of voxel elem centers
+    size_t                voxel_num_i, voxel_num_j, voxel_num_k; // voxel elements in each direction
+
     // check to see if readVoxelFile
-    DCArrayKokkos <size_t> read_voxel_file(num_fills);
+    DCArrayKokkos<size_t> read_voxel_file(num_fills);
     FOR_ALL(f_id, 0, num_fills, {
-        if (mat_fill(f_id).volume == region::readVoxelFile){ 
-            read_voxel_file(f_id) = 1; 
-        }    
-        else {
-            read_voxel_file(f_id) = 0; 
-        }    
+        if (mat_fill(f_id).volume == region::readVoxelFile)
+        {
+            read_voxel_file(f_id) = 1;
+        }
+        else
+        {
+            read_voxel_file(f_id) = 0;
+        }
     }); // end parallel for
     read_voxel_file.update_host(); // copy to CPU if code is to read from a file
     Kokkos::fence();
-    
-    //--- apply the fill instructions over the Elements---//
-    
+
+    // --- apply the fill instructions over the Elements---//
+
     // loop over the fill instructures
-    for (int f_id = 0; f_id < num_fills; f_id++){
-        
-        
+    for (int f_id = 0; f_id < num_fills; f_id++)
+    {
         // voxel mesh setup
-        if (read_voxel_file.host(f_id) == 1){
+        if (read_voxel_file.host(f_id) == 1)
+        {
             // read voxel mesh
             user_voxel_init(voxel_elem_values,
                             voxel_dx, voxel_dy, voxel_dz,
                             orig_x, orig_y, orig_z,
                             voxel_num_i, voxel_num_j, voxel_num_k);
-            
+
             // copy values read from file to device
             voxel_elem_values.update_device();
         } // endif
-            
+
         // parallel loop over elements in mesh
         FOR_ALL(elem_gid, 0, mesh.num_elems, {
-
             const size_t rk_level = 1;
 
             // calculate the coordinates and radius of the element
@@ -200,133 +187,140 @@ void setup(const CArrayKokkos <material_t> &material,
             elem_coords[2] = 0.0;
 
             // get the coordinates of the element center
-            for (int node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++){
+            for (int node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++)
+            {
                 elem_coords[0] += node_coords(rk_level, mesh.nodes_in_elem(elem_gid, node_lid), 0);
                 elem_coords[1] += node_coords(rk_level, mesh.nodes_in_elem(elem_gid, node_lid), 1);
-                if (mesh.num_dims == 3){
+                if (mesh.num_dims == 3)
+                {
                     elem_coords[2] += node_coords(rk_level, mesh.nodes_in_elem(elem_gid, node_lid), 2);
-                } else
+                }
+                else
                 {
                     elem_coords[2] = 0.0;
                 }
             } // end loop over nodes in element
-            elem_coords[0] = elem_coords[0]/mesh.num_nodes_in_elem;
-            elem_coords[1] = elem_coords[1]/mesh.num_nodes_in_elem;
-            elem_coords[2] = elem_coords[2]/mesh.num_nodes_in_elem;
-                
-            
+            elem_coords[0] = elem_coords[0] / mesh.num_nodes_in_elem;
+            elem_coords[1] = elem_coords[1] / mesh.num_nodes_in_elem;
+            elem_coords[2] = elem_coords[2] / mesh.num_nodes_in_elem;
+
             // spherical radius
-            double radius = sqrt( elem_coords[0]*elem_coords[0] +
-                                  elem_coords[1]*elem_coords[1] +
-                                  elem_coords[2]*elem_coords[2] );
-                
+            double radius = sqrt(elem_coords[0] * elem_coords[0] +
+                                  elem_coords[1] * elem_coords[1] +
+                                  elem_coords[2] * elem_coords[2]);
+
             // cylinderical radius
-            double radius_cyl = sqrt( elem_coords[0]*elem_coords[0] +
-                                      elem_coords[1]*elem_coords[1] );   
-            
+            double radius_cyl = sqrt(elem_coords[0] * elem_coords[0] +
+                                      elem_coords[1] * elem_coords[1]);
+
             // default is not to fill the element
             size_t fill_this = 0;
-           
+
             // check to see if this element should be filled
-            switch(mat_fill(f_id).volume)
+            switch (mat_fill(f_id).volume)
             {
                 case region::global:
-                {
-                    fill_this = 1;
-                    break;
-                }
-                case region::box:
-                {
-                    if ( elem_coords[0] >= mat_fill(f_id).x1 && elem_coords[0] <= mat_fill(f_id).x2
-                      && elem_coords[1] >= mat_fill(f_id).y1 && elem_coords[1] <= mat_fill(f_id).y2
-                      && elem_coords[2] >= mat_fill(f_id).z1 && elem_coords[2] <= mat_fill(f_id).z2 )
+                    {
                         fill_this = 1;
-                    break;
-                }
+                        break;
+                    }
+                case region::box:
+                    {
+                        if (elem_coords[0] >= mat_fill(f_id).x1 && elem_coords[0] <= mat_fill(f_id).x2
+                            && elem_coords[1] >= mat_fill(f_id).y1 && elem_coords[1] <= mat_fill(f_id).y2
+                            && elem_coords[2] >= mat_fill(f_id).z1 && elem_coords[2] <= mat_fill(f_id).z2)
+                        {
+                            fill_this = 1;
+                        }
+                        break;
+                    }
                 case region::cylinder:
-                {
-                    if ( radius_cyl >= mat_fill(f_id).radius1
-                      && radius_cyl <= mat_fill(f_id).radius2 ) fill_this = 1;
-                    break;
-                }
+                    {
+                        if (radius_cyl >= mat_fill(f_id).radius1
+                            && radius_cyl <= mat_fill(f_id).radius2)
+                        {
+                            fill_this = 1;
+                        }
+                        break;
+                    }
                 case region::sphere:
-                {
-                    if ( radius >= mat_fill(f_id).radius1
-                      && radius <= mat_fill(f_id).radius2 ) fill_this = 1;
-                    break;
-                }
+                    {
+                        if (radius >= mat_fill(f_id).radius1
+                            && radius <= mat_fill(f_id).radius2)
+                        {
+                            fill_this = 1;
+                        }
+                        break;
+                    }
                 case region::readVoxelFile:
-                {
-                    fill_this = 0;  // default is no, don't fill it
-                    
-                    // find the closest element in the voxel mesh to this element
-                    double i0_real = (elem_coords[0] - orig_x)/(voxel_dx);
-                    double j0_real = (elem_coords[1] - orig_y)/(voxel_dy);
-                    double k0_real = (elem_coords[2] - orig_z)/(voxel_dz);
-                    
-                    int i0 = (int)i0_real;
-                    int j0 = (int)j0_real;
-                    int k0 = (int)k0_real;
-                    
-                    // look for the closest element in the voxel mesh
-                    int elem_id0 = get_id(i0,j0,k0,voxel_num_i,voxel_num_j);
-                    
-                    // if voxel mesh overlaps this mesh, then fill it if =1
-                    if (elem_id0 < voxel_elem_values.size() && elem_id0>=0){
-                        
-                        // voxel mesh elem values = 0 or 1
-                        fill_this = voxel_elem_values(elem_id0);  // values from file
-                        
-                    } // end if
-                    
-                } // end case
-                    
+                    {
+                        fill_this = 0; // default is no, don't fill it
+
+                        // find the closest element in the voxel mesh to this element
+                        double i0_real = (elem_coords[0] - orig_x) / (voxel_dx);
+                        double j0_real = (elem_coords[1] - orig_y) / (voxel_dy);
+                        double k0_real = (elem_coords[2] - orig_z) / (voxel_dz);
+
+                        int i0 = (int)i0_real;
+                        int j0 = (int)j0_real;
+                        int k0 = (int)k0_real;
+
+                        // look for the closest element in the voxel mesh
+                        int elem_id0 = get_id(i0, j0, k0, voxel_num_i, voxel_num_j);
+
+                        // if voxel mesh overlaps this mesh, then fill it if =1
+                        if (elem_id0 < voxel_elem_values.size() && elem_id0 >= 0)
+                        {
+                            // voxel mesh elem values = 0 or 1
+                            fill_this = voxel_elem_values(elem_id0); // values from file
+                        } // end if
+                    } // end case
             } // end of switch
 
-                 
             // paint the material state on the element
-            if (fill_this == 1){
-                    
+            if (fill_this == 1)
+            {
                 // density
                 elem_den(elem_gid) = mat_fill(f_id).den;
-                
+
                 // mass
-                elem_mass(elem_gid) = elem_den(elem_gid)*elem_vol(elem_gid);
-                
+                elem_mass(elem_gid) = elem_den(elem_gid) * elem_vol(elem_gid);
+
                 // specific internal energy
                 elem_sie(rk_level, elem_gid) = mat_fill(f_id).sie;
-		
+
                 elem_mat_id(elem_gid) = mat_fill(f_id).mat_id;
                 size_t mat_id = elem_mat_id(elem_gid); // short name
-                
+
                 // get state_vars from the input file or read them in
-                if (material(mat_id).strength_setup == model_init::user_init){
-                    
+                if (material(mat_id).strength_setup == model_init::user_init)
+                {
                     // use the values read from a file to get elem state vars
-                    for (size_t var=0; var<material(mat_id).num_state_vars; var++){
-                        elem_statev(elem_gid,var) = file_state_vars(mat_id,elem_gid,var);
+                    for (size_t var = 0; var < material(mat_id).num_state_vars; var++)
+                    {
+                        elem_statev(elem_gid, var) = file_state_vars(mat_id, elem_gid, var);
                     } // end for
-                    
                 }
-                else{
+                else
+                {
                     // use the values in the input file
                     // set state vars for the region where mat_id resides
-                    for (size_t var=0; var<material(mat_id).num_state_vars; var++){
-                        elem_statev(elem_gid,var) = state_vars(mat_id,var);
+                    for (size_t var = 0; var < material(mat_id).num_state_vars; var++)
+                    {
+                        elem_statev(elem_gid, var) = state_vars(mat_id, var);
                     } // end for
-                    
                 } // end logical on type
-                
+
                 // --- stress tensor ---
                 // always 3D even for 2D-RZ
-                for (size_t i=0; i<3; i++){
-                    for (size_t j=0; j<3; j++){
-                        elem_stress(rk_level,elem_gid,i,j) = 0.0;
-                    }        
+                for (size_t i = 0; i < 3; i++)
+                {
+                    for (size_t j = 0; j < 3; j++)
+                    {
+                        elem_stress(rk_level, elem_gid, i, j) = 0.0;
+                    }
                 }  // end for
-                
-                
-                
+
                 // --- Pressure and stress ---
                 material(mat_id).eos_model(elem_pres,
                                            elem_stress,
@@ -335,839 +329,783 @@ void setup(const CArrayKokkos <material_t> &material,
                                            elem_statev,
                                            elem_sspd,
                                            elem_den(elem_gid),
-                                           elem_sie(1,elem_gid));
-					    
-                
-                // loop over the nodes of this element and apply velocity
-                for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++){
+                                           elem_sie(1, elem_gid));
 
+                // loop over the nodes of this element and apply velocity
+                for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_elem; node_lid++)
+                {
                     // get the mesh node index
                     size_t node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
 
-                
                     // --- Velocity ---
-                    switch(mat_fill(f_id).velocity)
+                    switch (mat_fill(f_id).velocity)
                     {
                         case init_conds::cartesian:
-                        {
-                        
-                            node_vel(rk_level, node_gid, 0) = mat_fill(f_id).u;
-                            node_vel(rk_level, node_gid, 1) = mat_fill(f_id).v;
-                            if (mesh.num_dims == 3) node_vel(rk_level, node_gid, 2) = mat_fill(f_id).w;
-                            
-                        
-                            break;
-                        }
+                            {
+                                node_vel(rk_level, node_gid, 0) = mat_fill(f_id).u;
+                                node_vel(rk_level, node_gid, 1) = mat_fill(f_id).v;
+                                if (mesh.num_dims == 3)
+                                {
+                                    node_vel(rk_level, node_gid, 2) = mat_fill(f_id).w;
+                                }
+
+                                break;
+                            }
                         case init_conds::radial:
-                        {
-                            // Setting up cylindrical
-                            double dir[2]; 
-                            dir[0] = 0.0;
-                            dir[1] = 0.0;
-                            double radius_val = 0.0;
-                        
-                            for(int dim=0; dim<2; dim++){
-                                dir[dim] = node_coords(rk_level, node_gid, dim);
-                                radius_val += node_coords(rk_level, node_gid, dim)*node_coords(rk_level, node_gid, dim);
-                            } // end for
-                            radius_val = sqrt(radius_val);
-                        
-                            for(int dim=0; dim<2; dim++){
-                                if (radius_val > 1.0e-14){
-                                    dir[dim] /= (radius_val);
+                            {
+                                // Setting up cylindrical
+                                double dir[2];
+                                dir[0] = 0.0;
+                                dir[1] = 0.0;
+                                double radius_val = 0.0;
+
+                                for (int dim = 0; dim < 2; dim++)
+                                {
+                                    dir[dim]    = node_coords(rk_level, node_gid, dim);
+                                    radius_val += node_coords(rk_level, node_gid, dim) * node_coords(rk_level, node_gid, dim);
+                                } // end for
+                                radius_val = sqrt(radius_val);
+
+                                for (int dim = 0; dim < 2; dim++)
+                                {
+                                    if (radius_val > 1.0e-14)
+                                    {
+                                        dir[dim] /= (radius_val);
+                                    }
+                                    else
+                                    {
+                                        dir[dim] = 0.0;
+                                    }
+                                } // end for
+
+                                node_vel(rk_level, node_gid, 0) = mat_fill(f_id).speed * dir[0];
+                                node_vel(rk_level, node_gid, 1) = mat_fill(f_id).speed * dir[1];
+                                if (mesh.num_dims == 3)
+                                {
+                                    node_vel(rk_level, node_gid, 2) = 0.0;
                                 }
-                                else{
-                                    dir[dim] = 0.0;
-                                }
-                            } // end for
-                        
-                        
-                            node_vel(rk_level, node_gid, 0) = mat_fill(f_id).speed*dir[0];
-                            node_vel(rk_level, node_gid, 1) = mat_fill(f_id).speed*dir[1];
-                            if (mesh.num_dims == 3) node_vel(rk_level, node_gid, 2) = 0.0;
-                            
-                            break;
-                        }
+
+                                break;
+                            }
                         case init_conds::spherical:
-                        {
-                            
-                            // Setting up spherical
-                            double dir[3];
-                            dir[0] = 0.0;
-                            dir[1] = 0.0;
-                            dir[2] = 0.0;
-                            double radius_val = 0.0;
-                        
-                            for(int dim=0; dim<3; dim++){
-                                dir[dim] = node_coords(rk_level, node_gid, dim);
-                                radius_val += node_coords(rk_level, node_gid, dim)*node_coords(rk_level, node_gid, dim);
-                            } // end for
-                            radius_val = sqrt(radius_val);
-                        
-                            for(int dim=0; dim<3; dim++){
-                                if (radius_val > 1.0e-14){
-                                    dir[dim] /= (radius_val);
-                                }
-                                else{
-                                    dir[dim] = 0.0;
-                                }
-                            } // end for
-                        
-                            node_vel(rk_level, node_gid, 0) = mat_fill(f_id).speed*dir[0];
-                            node_vel(rk_level, node_gid, 1) = mat_fill(f_id).speed*dir[1];
-                            if (mesh.num_dims == 3) node_vel(rk_level, node_gid, 2) = mat_fill(f_id).speed*dir[2];
+                            {
+                                // Setting up spherical
+                                double dir[3];
+                                dir[0] = 0.0;
+                                dir[1] = 0.0;
+                                dir[2] = 0.0;
+                                double radius_val = 0.0;
 
-                            break;
-                        }
+                                for (int dim = 0; dim < 3; dim++)
+                                {
+                                    dir[dim]    = node_coords(rk_level, node_gid, dim);
+                                    radius_val += node_coords(rk_level, node_gid, dim) * node_coords(rk_level, node_gid, dim);
+                                } // end for
+                                radius_val = sqrt(radius_val);
+
+                                for (int dim = 0; dim < 3; dim++)
+                                {
+                                    if (radius_val > 1.0e-14)
+                                    {
+                                        dir[dim] /= (radius_val);
+                                    }
+                                    else
+                                    {
+                                        dir[dim] = 0.0;
+                                    }
+                                } // end for
+
+                                node_vel(rk_level, node_gid, 0) = mat_fill(f_id).speed * dir[0];
+                                node_vel(rk_level, node_gid, 1) = mat_fill(f_id).speed * dir[1];
+                                if (mesh.num_dims == 3)
+                                {
+                                    node_vel(rk_level, node_gid, 2) = mat_fill(f_id).speed * dir[2];
+                                }
+
+                                break;
+                            }
                         case init_conds::radial_linear:
-                        {
-                        
-                            break;
-                        }
+                            {
+                                break;
+                            }
                         case init_conds::spherical_linear:
-                        {
-                        
-                            break;
-                        }
+                            {
+                                break;
+                            }
                         case init_conds::tg_vortex:
-                        {
-                        
-                            node_vel(rk_level, node_gid, 0) = sin(PI * node_coords(rk_level,node_gid, 0)) * cos(PI * node_coords(rk_level,node_gid, 1)); 
-                            node_vel(rk_level, node_gid, 1) =  -1.0*cos(PI * node_coords(rk_level,node_gid, 0)) * sin(PI * node_coords(rk_level,node_gid, 1)); 
-                            if (mesh.num_dims == 3) node_vel(rk_level, node_gid, 2) = 0.0;
+                            {
+                                node_vel(rk_level, node_gid, 0) = sin(PI * node_coords(rk_level, node_gid, 0)) * cos(PI * node_coords(rk_level, node_gid, 1));
+                                node_vel(rk_level, node_gid, 1) =  -1.0 * cos(PI * node_coords(rk_level, node_gid, 0)) * sin(PI * node_coords(rk_level, node_gid, 1));
+                                if (mesh.num_dims == 3)
+                                {
+                                    node_vel(rk_level, node_gid, 2) = 0.0;
+                                }
 
-                            break;
-                        }
+                                break;
+                            }
                     } // end of switch
+                } // end loop over nodes of element
 
-                }// end loop over nodes of element
-                
-                
-                if(mat_fill(f_id).velocity == init_conds::tg_vortex)
+                if (mat_fill(f_id).velocity == init_conds::tg_vortex)
                 {
-                    elem_pres(elem_gid) = 0.25*( cos(2.0*PI*elem_coords[0]) + cos(2.0*PI*elem_coords[1]) ) + 1.0;
-                
+                    elem_pres(elem_gid) = 0.25 * (cos(2.0 * PI * elem_coords[0]) + cos(2.0 * PI * elem_coords[1]) ) + 1.0;
+
                     // p = rho*ie*(gamma - 1)
                     size_t mat_id = f_id;
-                    double gamma = elem_statev(elem_gid,4); // gamma value
+                    double gamma  = elem_statev(elem_gid, 4); // gamma value
                     elem_sie(rk_level, elem_gid) =
-                                    elem_pres(elem_gid)/(mat_fill(f_id).den*(gamma - 1.0));
+                        elem_pres(elem_gid) / (mat_fill(f_id).den * (gamma - 1.0));
                 } // end if
-
             } // end if fill
-          
         }); // end FOR_ALL element loop
         Kokkos::fence();
-        
-  
     } // end for loop over fills
-    
-   
-    
+
     // apply BC's to velocity
     boundary_velocity(mesh, boundary, node_vel, 0.0);
-    
-    
+
     // calculate the corner massess if 2D
-    if(mesh.num_dims==2){
-        
+    if (mesh.num_dims == 2)
+    {
         FOR_ALL(elem_gid, 0, mesh.num_elems, {
-            
             // facial area of the corners
             double corner_areas_array[4];
-            
-            ViewCArrayKokkos <double> corner_areas(&corner_areas_array[0],4);
-            ViewCArrayKokkos <size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
-            
+
+            ViewCArrayKokkos<double> corner_areas(&corner_areas_array[0], 4);
+            ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid, 0), 4);
+
             get_area_weights2D(corner_areas,
                                elem_gid,
                                node_coords,
                                elem_node_gids);
-            
+
             // loop over the corners of the element and calculate the mass
-            for (size_t corner_lid=0; corner_lid<4; corner_lid++){
-                
-                size_t corner_gid = mesh.corners_in_elem(elem_gid, corner_lid);
-                corner_mass(corner_gid) = corner_areas(corner_lid)*elem_den(elem_gid); // node radius is added later
-                
+            for (size_t corner_lid = 0; corner_lid < 4; corner_lid++)
+            {
+                size_t corner_gid       = mesh.corners_in_elem(elem_gid, corner_lid);
+                corner_mass(corner_gid) = corner_areas(corner_lid) * elem_den(elem_gid); // node radius is added later
             } // end for over corners
         });
-    
     } // end of
-    
-    
+
     // calculate the nodal mass
     FOR_ALL(node_gid, 0, mesh.num_nodes, {
-        
         node_mass(node_gid) = 0.0;
-        
-        if(mesh.num_dims==3){
-            
-            for(size_t elem_lid=0; elem_lid<mesh.num_corners_in_node(node_gid); elem_lid++){
-                size_t elem_gid = mesh.elems_in_node(node_gid,elem_lid);
-                node_mass(node_gid) += 1.0/8.0*elem_mass(elem_gid);
+
+        if (mesh.num_dims == 3)
+        {
+            for (size_t elem_lid = 0; elem_lid < mesh.num_corners_in_node(node_gid); elem_lid++)
+            {
+                size_t elem_gid      = mesh.elems_in_node(node_gid, elem_lid);
+                node_mass(node_gid) += 1.0 / 8.0 * elem_mass(elem_gid);
             } // end for elem_lid
-            
-        }// end if dims=3
-        else {
-            
+        } // end if dims=3
+        else
+        {
             // 2D-RZ
-            for(size_t corner_lid=0; corner_lid<mesh.num_corners_in_node(node_gid); corner_lid++){
-                
-                size_t corner_gid = mesh.corners_in_node(node_gid, corner_lid);
+            for (size_t corner_lid = 0; corner_lid < mesh.num_corners_in_node(node_gid); corner_lid++)
+            {
+                size_t corner_gid    = mesh.corners_in_node(node_gid, corner_lid);
                 node_mass(node_gid) += corner_mass(corner_gid);  // sans the radius so it is areal node mass
-                
-                corner_mass(corner_gid) *= node_coords(1,node_gid,1); // true corner mass now
+
+                corner_mass(corner_gid) *= node_coords(1, node_gid, 1); // true corner mass now
             } // end for elem_lid
-            
         } // end else
-        
     }); // end FOR_ALL
     Kokkos::fence();
-    
+
     return;
-    
 } // end of setup
-
-
 
 // set planes for tagging sub sets of boundary patches
 // bc_tag = 0 xplane, 1 yplane, 2 zplane, 3 cylinder, 4 is shell
 // val = plane value, cyl radius, sphere radius
-void tag_bdys(const CArrayKokkos <boundary_t> &boundary,
-              mesh_t &mesh,
-              const DViewCArrayKokkos <double> &node_coords){
-
+void
+tag_bdys(const CArrayKokkos<boundary_t>&  boundary,
+         mesh_t&                          mesh,
+         const DViewCArrayKokkos<double>& node_coords)
+{
     size_t num_dims = mesh.num_dims;
-    
-    //if (bdy_set == mesh.num_bdy_sets){
+
+    // if (bdy_set == mesh.num_bdy_sets){
     //    printf(" ERROR: number of boundary sets must be increased by %zu",
     //              bdy_set-mesh.num_bdy_sets+1);
     //    exit(0);
-    //} // end if
-    
+    // } // end if
+
     FOR_ALL(bdy_set, 0, mesh.num_bdy_sets, {
-        
         // tag boundaries
         int bc_tag_id = boundary(bdy_set).surface;
-        double val = boundary(bdy_set).value;
-        
+        double val    = boundary(bdy_set).value;
+
         // save the boundary patches to this set that are on the plane, spheres, etc.
-        for (size_t bdy_patch_lid=0; bdy_patch_lid<mesh.num_bdy_patches; bdy_patch_lid++){
-            
+        for (size_t bdy_patch_lid = 0; bdy_patch_lid < mesh.num_bdy_patches; bdy_patch_lid++)
+        {
             // save the patch index
             size_t bdy_patch_gid = mesh.bdy_patches(bdy_patch_lid);
-            
-            
+
             // check to see if this patch is on the specified plane
             size_t is_on_bdy = check_bdy(bdy_patch_gid,
                                          bc_tag_id,
                                          val,
                                          mesh,
                                          node_coords); // no=0, yes=1
-            
-            if (is_on_bdy == 1){
-                
+
+            if (is_on_bdy == 1)
+            {
                 size_t index = mesh.bdy_patches_in_set.stride(bdy_set);
-                
+
                 // increment the number of boundary patches saved
-                mesh.bdy_patches_in_set.stride(bdy_set) ++;
-                
-                
+                mesh.bdy_patches_in_set.stride(bdy_set)++;
+
                 mesh.bdy_patches_in_set(bdy_set, index) = bdy_patch_gid;
             } // end if
-            
-            
         } // end for bdy_patch
-        
     });  // end FOR_ALL bdy_sets
-   
+
     return;
 } // end tag
-
-
 
 // routine for checking to see if a vertex is on a boundary
 // bc_tag = 0 xplane, 1 yplane, 2 zplane, 3 cylinder, 4 is shell
 // val = plane value, radius, radius
 KOKKOS_FUNCTION
-size_t check_bdy(const size_t patch_gid,
-                 const int this_bc_tag,
-                 const double val,
-                 const mesh_t &mesh,
-                 const DViewCArrayKokkos <double> &node_coords){
-    
-    
+size_t
+check_bdy(const size_t                     patch_gid,
+          const int                        this_bc_tag,
+          const double                     val,
+          const mesh_t&                    mesh,
+          const DViewCArrayKokkos<double>& node_coords)
+{
     size_t num_dims = mesh.num_dims;
-    
+
     // default bool is not on the boundary
     size_t is_on_bdy = 0;
-    
+
     // the patch coordinates
     double these_patch_coords[3];  // Note: cannot allocated array with num_dims
-    
+
     // loop over the nodes on the patch
-    for (size_t patch_node_lid=0; patch_node_lid<mesh.num_nodes_in_patch; patch_node_lid++){
-        
+    for (size_t patch_node_lid = 0; patch_node_lid < mesh.num_nodes_in_patch; patch_node_lid++)
+    {
         // get the nodal_gid for this node in the patch
         size_t node_gid = mesh.nodes_in_patch(patch_gid, patch_node_lid);
-        
-        for (size_t dim = 0; dim < num_dims; dim++){
+
+        for (size_t dim = 0; dim < num_dims; dim++)
+        {
             these_patch_coords[dim] = node_coords(1, node_gid, dim);  // (rk, node_gid, dim)
         } // end for dim
-        
-        
+
         // a x-plane
-        if (this_bc_tag == 0){
-            
-            if ( fabs(these_patch_coords[0] - val) <= 1.0e-7 ) is_on_bdy += 1;
-            
-        }// end if on type
-        
-        // a y-plane
-        else if (this_bc_tag == 1){
-            
-            if ( fabs(these_patch_coords[1] - val) <= 1.0e-7 ) is_on_bdy += 1;
-            
-        }// end if on type
-        
-        // a z-plane
-        else if (this_bc_tag == 2){
-            
-            if ( fabs(these_patch_coords[2] - val) <= 1.0e-7 ) is_on_bdy += 1;
-            
-        }// end if on type
-        
-        
-        // cylinderical shell where radius = sqrt(x^2 + y^2)
-        else if (this_bc_tag == 3){
-            
-            real_t R = sqrt(these_patch_coords[0]*these_patch_coords[0] +
-                            these_patch_coords[1]*these_patch_coords[1]);
-            
-            if ( fabs(R - val) <= 1.0e-7 ) is_on_bdy += 1;
-            
-            
-        }// end if on type
-        
-        // spherical shell where radius = sqrt(x^2 + y^2 + z^2)
-        else if (this_bc_tag == 4){
-            
-            real_t R = sqrt(these_patch_coords[0]*these_patch_coords[0] +
-                            these_patch_coords[1]*these_patch_coords[1] +
-                            these_patch_coords[2]*these_patch_coords[2]);
-            
-            if ( fabs(R - val) <= 1.0e-7 ) is_on_bdy += 1;
-            
+        if (this_bc_tag == 0)
+        {
+            if (fabs(these_patch_coords[0] - val) <= 1.0e-7)
+            {
+                is_on_bdy += 1;
+            }
         } // end if on type
-        
+        // a y-plane
+        else if (this_bc_tag == 1)
+        {
+            if (fabs(these_patch_coords[1] - val) <= 1.0e-7)
+            {
+                is_on_bdy += 1;
+            }
+        } // end if on type
+        // a z-plane
+        else if (this_bc_tag == 2)
+        {
+            if (fabs(these_patch_coords[2] - val) <= 1.0e-7)
+            {
+                is_on_bdy += 1;
+            }
+        } // end if on type
+        // cylinderical shell where radius = sqrt(x^2 + y^2)
+        else if (this_bc_tag == 3)
+        {
+            real_t R = sqrt(these_patch_coords[0] * these_patch_coords[0] +
+                            these_patch_coords[1] * these_patch_coords[1]);
+
+            if (fabs(R - val) <= 1.0e-7)
+            {
+                is_on_bdy += 1;
+            }
+        } // end if on type
+        // spherical shell where radius = sqrt(x^2 + y^2 + z^2)
+        else if (this_bc_tag == 4)
+        {
+            real_t R = sqrt(these_patch_coords[0] * these_patch_coords[0] +
+                            these_patch_coords[1] * these_patch_coords[1] +
+                            these_patch_coords[2] * these_patch_coords[2]);
+
+            if (fabs(R - val) <= 1.0e-7)
+            {
+                is_on_bdy += 1;
+            }
+        } // end if on type
     } // end for nodes in the patch
-    
+
     // if all nodes in the patch are on the surface
-    if (is_on_bdy == mesh.num_nodes_in_patch){
+    if (is_on_bdy == mesh.num_nodes_in_patch)
+    {
         is_on_bdy = 1;
     }
-    else {
+    else
+    {
         is_on_bdy = 0;
     }
-    
-    
+
     return is_on_bdy;
-    
 } // end method to check bdy
 
-
-
-void build_boundry_node_sets(const CArrayKokkos <boundary_t> &boundary,
-                             mesh_t &mesh){
-    
-    
-    
+void
+build_boundry_node_sets(const CArrayKokkos<boundary_t>& boundary,
+                        mesh_t&                         mesh)
+{
     // build boundary nodes in each boundary set
-    
-    mesh.num_bdy_nodes_in_set = DCArrayKokkos <size_t> (mesh.num_bdy_sets);
-    CArrayKokkos <long long int> temp_count_num_bdy_nodes_in_set(mesh.num_bdy_sets, mesh.num_nodes);
-    
-    DynamicRaggedRightArrayKokkos <size_t> temp_nodes_in_set (mesh.num_bdy_sets, mesh.num_bdy_patches*mesh.num_nodes_in_patch);
-    
-    
+
+    mesh.num_bdy_nodes_in_set = DCArrayKokkos<size_t>(mesh.num_bdy_sets);
+    CArrayKokkos<long long int> temp_count_num_bdy_nodes_in_set(mesh.num_bdy_sets, mesh.num_nodes);
+
+    DynamicRaggedRightArrayKokkos<size_t> temp_nodes_in_set(mesh.num_bdy_sets, mesh.num_bdy_patches * mesh.num_nodes_in_patch);
+
     // Parallel loop over boundary sets on device
     FOR_ALL(bdy_set, 0, mesh.num_bdy_sets, {
-	
         // finde the number of patches_in_set
         size_t num_bdy_patches_in_set = mesh.bdy_patches_in_set.stride(bdy_set);
-        
+
         // Loop over boundary patches in boundary set
-        for (size_t bdy_patch_gid = 0; bdy_patch_gid<num_bdy_patches_in_set; bdy_patch_gid++){
-            
-                // get the global id for this boundary patch
-                size_t patch_gid = mesh.bdy_patches_in_set(bdy_set, bdy_patch_gid);
-                
-                // apply boundary condition at nodes on boundary
-                for(size_t node_lid = 0; node_lid < mesh.num_nodes_in_patch; node_lid++){
-                    
-                    size_t node_gid = mesh.nodes_in_patch(patch_gid, node_lid);
-                    
-                    temp_count_num_bdy_nodes_in_set(bdy_set, node_gid) = -1;
-                        
-                } // end for node_lid
-            
+        for (size_t bdy_patch_gid = 0; bdy_patch_gid < num_bdy_patches_in_set; bdy_patch_gid++)
+        {
+            // get the global id for this boundary patch
+            size_t patch_gid = mesh.bdy_patches_in_set(bdy_set, bdy_patch_gid);
+
+            // apply boundary condition at nodes on boundary
+            for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_patch; node_lid++)
+            {
+                size_t node_gid = mesh.nodes_in_patch(patch_gid, node_lid);
+
+                temp_count_num_bdy_nodes_in_set(bdy_set, node_gid) = -1;
+            }     // end for node_lid
         } // end for bdy_patch_gid
-        
-        
+
         // Loop over boundary patches in boundary set
-        for (size_t bdy_patch_gid = 0; bdy_patch_gid<num_bdy_patches_in_set; bdy_patch_gid++){
-            
-                // get the global id for this boundary patch
-                size_t patch_gid = mesh.bdy_patches_in_set(bdy_set, bdy_patch_gid);
-                
-                // apply boundary condition at nodes on boundary
-                for(size_t node_lid = 0; node_lid < mesh.num_nodes_in_patch; node_lid++){
-                    
-                    size_t node_gid = mesh.nodes_in_patch(patch_gid, node_lid);
-                    
-                    if (temp_count_num_bdy_nodes_in_set(bdy_set, node_gid) == -1){
-                        
-                        size_t num_saved = mesh.num_bdy_nodes_in_set(bdy_set);
-                        
-                        mesh.num_bdy_nodes_in_set(bdy_set)++;
-                        
-                        // replace -1 with node_gid to denote the node was already saved
-                        temp_count_num_bdy_nodes_in_set(bdy_set, node_gid) = node_gid;
-                        
-                        // increment the number of saved nodes, create memory
-                        temp_nodes_in_set.stride(bdy_set)++;
-                        temp_nodes_in_set(bdy_set, num_saved) = node_gid;
-                        
-                    } // end if
-                    
-                } // end for node_lid
-            
+        for (size_t bdy_patch_gid = 0; bdy_patch_gid < num_bdy_patches_in_set; bdy_patch_gid++)
+        {
+            // get the global id for this boundary patch
+            size_t patch_gid = mesh.bdy_patches_in_set(bdy_set, bdy_patch_gid);
+
+            // apply boundary condition at nodes on boundary
+            for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_patch; node_lid++)
+            {
+                size_t node_gid = mesh.nodes_in_patch(patch_gid, node_lid);
+
+                if (temp_count_num_bdy_nodes_in_set(bdy_set, node_gid) == -1)
+                {
+                    size_t num_saved = mesh.num_bdy_nodes_in_set(bdy_set);
+
+                    mesh.num_bdy_nodes_in_set(bdy_set)++;
+
+                    // replace -1 with node_gid to denote the node was already saved
+                    temp_count_num_bdy_nodes_in_set(bdy_set, node_gid) = node_gid;
+
+                    // increment the number of saved nodes, create memory
+                    temp_nodes_in_set.stride(bdy_set)++;
+                    temp_nodes_in_set(bdy_set, num_saved) = node_gid;
+                }     // end if
+            }     // end for node_lid
         } // end for bdy_patch_gid
-        
     }); // end FOR_ALL bdy_set
     Kokkos::fence();
-    
-   
+
     // allocate the RaggedRight bdy_nodes_in_set array
-    mesh.bdy_nodes_in_set = RaggedRightArrayKokkos <size_t> (mesh.num_bdy_nodes_in_set);
+    mesh.bdy_nodes_in_set = RaggedRightArrayKokkos<size_t>(mesh.num_bdy_nodes_in_set);
 
-    FOR_ALL (bdy_set, 0, mesh.num_bdy_sets, {
-	
+    FOR_ALL(bdy_set, 0, mesh.num_bdy_sets, {
         // Loop over boundary patches in boundary set
-        for (size_t bdy_node_lid=0; bdy_node_lid<mesh.num_bdy_nodes_in_set(bdy_set); bdy_node_lid++){
-
+        for (size_t bdy_node_lid = 0; bdy_node_lid < mesh.num_bdy_nodes_in_set(bdy_set); bdy_node_lid++)
+        {
             // save the bdy_node_gid
             mesh.bdy_nodes_in_set(bdy_set, bdy_node_lid) = temp_nodes_in_set(bdy_set, bdy_node_lid);
-            
         } // end for
-        
     }); // end FOR_ALL bdy_set
-    
+
     // update the host side for the number nodes in a bdy_set
     mesh.num_bdy_nodes_in_set.update_host();
-    
+
     return;
 } // end method to build boundary nodes
 
-
-
-
-
 // -----------------------------------------------------------------------------
 // The function to read a voxel vtk file from Dream3d and intialize the mesh
-//------------------------------------------------------------------------------
-void user_voxel_init(DCArrayKokkos <size_t> &elem_values,
-                     double &dx,
-                     double &dy,
-                     double &dz,
-                     double &orig_x,
-                     double &orig_y,
-                     double &orig_z,
-                     size_t &num_elems_i,
-                     size_t &num_elems_j,
-                     size_t &num_elems_k) {
-
-    
+// ------------------------------------------------------------------------------
+void
+user_voxel_init(DCArrayKokkos<size_t>& elem_values,
+                double&                dx,
+                double&                dy,
+                double&                dz,
+                double&                orig_x,
+                double&                orig_y,
+                double&                orig_z,
+                size_t&                num_elems_i,
+                size_t&                num_elems_j,
+                size_t&                num_elems_k)
+{
     std::string MESH = "voxel.vtk"; // user specified
-    
+
     std::ifstream in;  // FILE *in;
     in.open(MESH);
-    
+
     // check to see of a mesh was supplied when running the code
-    if (in){
+    if (in)
+    {
         printf("\nReading the 3D voxel mesh: ");
         std::cout << MESH << std::endl;
     }
-    else{
+    else
+    {
         std::cout << "\n\n**********************************\n\n";
         std::cout << " ERROR:\n";
         std::cout << " Voxel vtk input does not exist \n";
         std::cout << "**********************************\n\n" << std::endl;
         std::exit(EXIT_FAILURE);
     } // end if
-    
-    
 
     size_t i;           // used for writing information to file
     size_t point_id;    // the global id for the point
     size_t elem_id;     // the global id for the elem
     size_t this_point;   // a local id for a point in a elem (0:7 for a Hexahedral elem)
-    
+
     size_t num_points_i;
     size_t num_points_j;
     size_t num_points_k;
-    
+
     size_t num_dims = 3;
-    
 
     std::string token;
-    
+
     bool found = false;
-    
 
     // look for POINTS
     i = 0;
-    while (found==false) {
+    while (found == false) {
         std::string str;
         std::string delimiter = " ";
         std::getline(in, str);
-        std::vector<std::string> v = split (str, delimiter);
-        
+        std::vector<std::string> v = split(str, delimiter);
+
         // looking for the following text:
         //      POINTS %d float
-        if(v[0] == "DIMENSIONS"){
+        if (v[0] == "DIMENSIONS")
+        {
             num_points_i = std::stoi(v[1]);
             num_points_j = std::stoi(v[2]);
             num_points_k = std::stoi(v[3]);
             printf("Num voxel nodes read in = %d, %d, %d\n", num_points_i, num_points_j, num_points_k);
-            
-            found=true;
+
+            found = true;
         } // end if
-        
-        
-        if (i>1000){
+
+        if (i > 1000)
+        {
             printf("ERROR: Failed to find POINTS \n");
             break;
         } // end if
-        
+
         i++;
     } // end while
-    
-    found=false;
-    
-    int num_points = num_points_i*num_points_j*num_points_k;
-    CArray <double> pt_coords_x(num_points_i);
-    CArray <double> pt_coords_y(num_points_j);
-    CArray <double> pt_coords_z(num_points_k);
-    
-    
-    while (found==false) {
+
+    found = false;
+
+    int            num_points = num_points_i * num_points_j * num_points_k;
+    CArray<double> pt_coords_x(num_points_i);
+    CArray<double> pt_coords_y(num_points_j);
+    CArray<double> pt_coords_z(num_points_k);
+
+    while (found == false) {
         std::string str;
         std::string str0;
         std::string delimiter = " ";
         std::getline(in, str);
-        std::vector<std::string> v = split (str, delimiter);
-        
-        // looking for the following text:
-        if(v[0] == "X_COORDINATES"){
+        std::vector<std::string> v = split(str, delimiter);
 
-            size_t num_saved =0;
-            
-            while (num_saved < num_points_i-1){
+        // looking for the following text:
+        if (v[0] == "X_COORDINATES")
+        {
+            size_t num_saved = 0;
+
+            while (num_saved < num_points_i - 1) {
                 // get next line
                 std::getline(in, str0);
-                
+
                 // remove starting and trailing spaces
                 str = trim(str0);
-                std::vector<std::string> v_coords = split (str, delimiter);
-                
-                
+                std::vector<std::string> v_coords = split(str, delimiter);
+
                 // loop over the contents of the vector v_coords
-                for (size_t this_point=0; this_point<v_coords.size(); this_point++){
+                for (size_t this_point = 0; this_point < v_coords.size(); this_point++)
+                {
                     pt_coords_x(num_saved) = std::stod(v_coords[this_point]);
                     num_saved++;
                 } // end for
-                
             } // end while
-            
-            
-            found=true;
+
+            found = true;
         } // end if
-        
-        
-        if (i>1000){
+
+        if (i > 1000)
+        {
             printf("ERROR: Failed to find X_COORDINATES \n");
             break;
         } // end if
-        
+
         i++;
     } // end while
-    found=false;
-    
-    
-    while (found==false) {
+    found = false;
+
+    while (found == false) {
         std::string str;
         std::string str0;
         std::string delimiter = " ";
         std::getline(in, str);
-        std::vector<std::string> v = split (str, delimiter);
-        
-        // looking for the following text:
-        if(v[0] == "Y_COORDINATES"){
+        std::vector<std::string> v = split(str, delimiter);
 
-            size_t num_saved =0;
-            
-            while (num_saved < num_points_j-1){
+        // looking for the following text:
+        if (v[0] == "Y_COORDINATES")
+        {
+            size_t num_saved = 0;
+
+            while (num_saved < num_points_j - 1) {
                 // get next line
                 std::getline(in, str0);
-                
+
                 // remove starting and trailing spaces
                 str = trim(str0);
-                std::vector<std::string> v_coords = split (str, delimiter);
-                
+                std::vector<std::string> v_coords = split(str, delimiter);
+
                 // loop over the contents of the vector v_coords
-                for (size_t this_point=0; this_point<v_coords.size(); this_point++){
-                    
+                for (size_t this_point = 0; this_point < v_coords.size(); this_point++)
+                {
                     pt_coords_y(num_saved) = std::stod(v_coords[this_point]);
                     num_saved++;
-                    
                 } // end for
-                
             } // end while
-            
-            
-            found=true;
+
+            found = true;
         } // end if
-        
-        
-        if (i>1000){
+
+        if (i > 1000)
+        {
             printf("ERROR: Failed to find Y_COORDINATES \n");
             break;
         } // end if
-        
+
         i++;
     } // end while
-    found=false;
+    found = false;
 
-    
-    
-    while (found==false) {
+    while (found == false) {
         std::string str;
         std::string str0;
         std::string delimiter = " ";
         std::getline(in, str);
-        std::vector<std::string> v = split (str, delimiter);
-        
-        // looking for the following text:
-        if(v[0] == "Z_COORDINATES"){
+        std::vector<std::string> v = split(str, delimiter);
 
-            size_t num_saved =0;
-            
-            while (num_saved < num_points_k-1){
+        // looking for the following text:
+        if (v[0] == "Z_COORDINATES")
+        {
+            size_t num_saved = 0;
+
+            while (num_saved < num_points_k - 1) {
                 // get next line
                 std::getline(in, str0);
-                
+
                 // remove starting and trailing spaces
                 str = trim(str0);
-                std::vector<std::string> v_coords = split (str, delimiter);
-                
+                std::vector<std::string> v_coords = split(str, delimiter);
+
                 // loop over the contents of the vector v_coords
-                for (size_t this_point=0; this_point<v_coords.size(); this_point++){
-                    
+                for (size_t this_point = 0; this_point < v_coords.size(); this_point++)
+                {
                     pt_coords_z(num_saved) = std::stod(v_coords[this_point]);
                     num_saved++;
-                    
                 } // end for
-                
             } // end while
-            
-            
-            found=true;
+
+            found = true;
         } // end if
-        
-        
-        if (i>1000){
+
+        if (i > 1000)
+        {
             printf("ERROR: Failed to find Z_COORDINATES \n");
             break;
         } // end if
-        
+
         i++;
     } // end while
-    found=false;
-    
+    found = false;
 
-
-    
     size_t num_elems;
     num_elems_i = num_points_i - 1;
     num_elems_j = num_points_j - 1;
     num_elems_k = num_points_k - 1;
-    
-    
-    // center to center distance between first and last elem along each edge
-    double Lx = (pt_coords_x(num_points_i-2) - pt_coords_x(0));
-    double Ly = (pt_coords_y(num_points_j-2) - pt_coords_y(0));
-    double Lz = (pt_coords_z(num_points_k-2) - pt_coords_z(0));
-    
-    // spacing between elems
-    dx = Lx/((double) num_elems_i);
-    dy = Ly/((double) num_elems_j);
-    dz = Lz/((double) num_elems_k);
-    
-    // element mesh origin
-    orig_x = 0.5*(pt_coords_x(0) + pt_coords_x(1)),
-    orig_y = 0.5*(pt_coords_y(0) + pt_coords_y(1)),
-    orig_z = 0.5*(pt_coords_z(0) + pt_coords_z(1)),
-    
 
-    
+    // center to center distance between first and last elem along each edge
+    double Lx = (pt_coords_x(num_points_i - 2) - pt_coords_x(0));
+    double Ly = (pt_coords_y(num_points_j - 2) - pt_coords_y(0));
+    double Lz = (pt_coords_z(num_points_k - 2) - pt_coords_z(0));
+
+    // spacing between elems
+    dx = Lx / ((double) num_elems_i);
+    dy = Ly / ((double) num_elems_j);
+    dz = Lz / ((double) num_elems_k);
+
+    // element mesh origin
+    orig_x = 0.5 * (pt_coords_x(0) + pt_coords_x(1)),
+    orig_y = 0.5 * (pt_coords_y(0) + pt_coords_y(1)),
+    orig_z = 0.5 * (pt_coords_z(0) + pt_coords_z(1)),
+
     // look for CELLS
     i = 0;
-    while (found==false) {
+    while (found == false) {
         std::string str;
         std::getline(in, str);
-        
-        std::string delimiter = " ";
-        std::vector<std::string> v = split (str, delimiter);
-        
-        
+
+        std::string              delimiter = " ";
+        std::vector<std::string> v = split(str, delimiter);
+
         // looking for the following text:
         //      CELLS num_elems size
-        if(v[0] == "CELL_DATA"){
+        if (v[0] == "CELL_DATA")
+        {
             num_elems = std::stoi(v[1]);
             printf("Num voxel elements read in %d\n", num_elems);
-            
-            found=true;
+
+            found = true;
         } // end if
-        
-        if (i>1000){
+
+        if (i > 1000)
+        {
             printf("ERROR: Failed to find CELL_DATA \n");
             break;
         } // end if
-        
+
         i++;
     } // end while
-    found=false;
+    found = false;
 
-
-    
     // allocate memory for element voxel values
-    elem_values = DCArrayKokkos <size_t> (num_elems);
-    
+    elem_values = DCArrayKokkos<size_t>(num_elems);
+
     // reading the cell data
-    while (found==false) {
+    while (found == false) {
         std::string str;
         std::string str0;
-        
+
         std::string delimiter = " ";
         std::getline(in, str);
-        std::vector<std::string> v = split (str, delimiter);
-        
-        // looking for the following text:
-        if(v[0] == "LOOKUP_TABLE"){
+        std::vector<std::string> v = split(str, delimiter);
 
-            size_t num_saved =0;
-            
-            while (num_saved < num_elems-1){
+        // looking for the following text:
+        if (v[0] == "LOOKUP_TABLE")
+        {
+            size_t num_saved = 0;
+
+            while (num_saved < num_elems - 1) {
                 // get next line
                 std::getline(in, str0);
-                
+
                 // remove starting and trailing spaces
                 str = trim(str0);
-                std::vector<std::string> v_values = split (str, delimiter);
-                
-                
+                std::vector<std::string> v_values = split(str, delimiter);
+
                 // loop over the contents of the vector v_coords
-                for (size_t this_elem=0; this_elem<v_values.size(); this_elem++){
-                    
+                for (size_t this_elem = 0; this_elem < v_values.size(); this_elem++)
+                {
                     // save integers (0 or 1) to host side
                     elem_values.host(num_saved) = std::stoi(v_values[this_elem]);
                     num_saved++;
-                    
                 } // end for
-                
-               // printf(" done with one row of data \n");
-                
+
+                // printf(" done with one row of data \n");
             } // end while
-            
-            
-            found=true;
+
+            found = true;
         } // end if
-        
-        
-        if (i>1000){
+
+        if (i > 1000)
+        {
             printf("ERROR: Failed to find LOOKUP_TABLE data \n");
             break;
         } // end if
-        
+
         i++;
     } // end while
-    found=false;
-    
-    printf("\n");
-    
-    in.close();
-    
+    found = false;
 
+    printf("\n");
+
+    in.close();
 } // end routine
 
-
-
 // Code from stackover flow for string delimiter parsing
-std::vector<std::string> split (std::string s, std::string delimiter) {
-    size_t pos_start = 0, pos_end, delim_len = delimiter.length();
-    std::string token;
+std::vector<std::string>
+split(std::string s, std::string delimiter)
+{
+    size_t                   pos_start = 0, pos_end, delim_len = delimiter.length();
+    std::string              token;
     std::vector<std::string> res;
 
-    while ((pos_end = s.find (delimiter, pos_start)) != std::string::npos) {
-        token = s.substr (pos_start, pos_end - pos_start);
+    while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos) {
+        token     = s.substr(pos_start, pos_end - pos_start);
         pos_start = pos_end + delim_len;
-        res.push_back (token);
+        res.push_back(token);
     }
 
-    res.push_back (s.substr (pos_start));
+    res.push_back(s.substr(pos_start));
     return res;
-    
 } // end of split
 
-
 // retrieves multiple values between [ ]
-std::vector<double> extract_list(std::string str) {
-    
+std::vector<double>
+extract_list(std::string str)
+{
     // replace '[' with a space and ']' with a space
     std::replace(str.begin(), str.end(), '[', ' ');
     std::replace(str.begin(), str.end(), ']', ' ');
-    
+
     std::vector<std::string> str_values;
-    std::vector<double> values;
+    std::vector<double>      values;
 
     // exact the str values into a vector
     str_values = split(str, ",");
-    
+
     // convert the text values into double values
-    for (auto &word : str_values) {
-        values.push_back( atof(word.c_str()) );
+    for (auto& word : str_values)
+    {
+        values.push_back(atof(word.c_str()) );
     } // end for
-    
+
     return values;
-    
 }  // end of extract_list
 
- 
-std::string ltrim(const std::string &s)
+std::string
+ltrim(const std::string& s)
 {
     size_t start = s.find_first_not_of(WHITESPACE);
     return (start == std::string::npos) ? "" : s.substr(start);
 }
- 
-std::string rtrim(const std::string &s)
+
+std::string
+rtrim(const std::string& s)
 {
     size_t end = s.find_last_not_of(WHITESPACE);
     return (end == std::string::npos) ? "" : s.substr(0, end + 1);
 }
- 
-std::string trim(const std::string &s) {
+
+std::string
+trim(const std::string& s)
+{
     return rtrim(ltrim(s));
 }
 
@@ -1175,11 +1113,12 @@ std::string trim(const std::string &s) {
 // This gives the index value of the point or the elem
 // the elem = i + (j)*(num_points_i-1) + (k)*(num_points_i-1)*(num_points_j-1)
 // the point = i + (j)*num_points_i + (k)*num_points_i*num_points_j
-//--------------------------------------------------------
+// --------------------------------------------------------
 //
 // Returns a global id for a given i,j,k
 KOKKOS_FUNCTION
-int get_id(int i, int j, int k, int num_i, int num_j)
+int
+get_id(int i, int j, int k, int num_i, int num_j)
 {
-    return i + j*num_i + k*num_i*num_j;
+    return i + j * num_i + k * num_i * num_j;
 }

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/sgh_solve.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/sgh_solve.cpp
@@ -1,46 +1,45 @@
 // Call cycle loop for the SGH solver
 
-
 #include "state.h"
 #include "mesh.h"
 #include <chrono>
 
-void sgh_solve(CArrayKokkos <material_t> &material,
-               CArrayKokkos <boundary_t> &boundary,
-               mesh_t &mesh,
-               DViewCArrayKokkos <double> &node_coords,
-               DViewCArrayKokkos <double> &node_vel,
-               DViewCArrayKokkos <double> &node_mass,
-               DViewCArrayKokkos <double> &elem_den,
-               DViewCArrayKokkos <double> &elem_pres,
-               DViewCArrayKokkos <double> &elem_stress,
-               DViewCArrayKokkos <double> &elem_sspd,
-               DViewCArrayKokkos <double> &elem_sie,
-               DViewCArrayKokkos <double> &elem_vol,
-               DViewCArrayKokkos <double> &elem_div,
-               DViewCArrayKokkos <double> &elem_mass,
-               DViewCArrayKokkos <size_t> &elem_mat_id,
-               DViewCArrayKokkos <double> &elem_statev,
-               DViewCArrayKokkos <double> &corner_force,
-               DViewCArrayKokkos <double> &corner_mass,
-               double &time_value,
-               const double time_final,
-               const double dt_max,
-               const double dt_min,
-               const double dt_cfl,
-               double &graphics_time,
-               size_t graphics_cyc_ival,
-               double graphics_dt_ival,
-               const size_t cycle_stop,
-               const size_t rk_num_stages,
-               double dt,
-               const double fuzz,
-               const double tiny,
-               const double small,
-               CArray <double> &graphics_times,
-               size_t &graphics_id){
-    
-    
+void
+sgh_solve(CArrayKokkos<material_t>&  material,
+          CArrayKokkos<boundary_t>&  boundary,
+          mesh_t&                    mesh,
+          DViewCArrayKokkos<double>& node_coords,
+          DViewCArrayKokkos<double>& node_vel,
+          DViewCArrayKokkos<double>& node_mass,
+          DViewCArrayKokkos<double>& elem_den,
+          DViewCArrayKokkos<double>& elem_pres,
+          DViewCArrayKokkos<double>& elem_stress,
+          DViewCArrayKokkos<double>& elem_sspd,
+          DViewCArrayKokkos<double>& elem_sie,
+          DViewCArrayKokkos<double>& elem_vol,
+          DViewCArrayKokkos<double>& elem_div,
+          DViewCArrayKokkos<double>& elem_mass,
+          DViewCArrayKokkos<size_t>& elem_mat_id,
+          DViewCArrayKokkos<double>& elem_statev,
+          DViewCArrayKokkos<double>& corner_force,
+          DViewCArrayKokkos<double>& corner_mass,
+          double&                    time_value,
+          const double               time_final,
+          const double               dt_max,
+          const double               dt_min,
+          const double               dt_cfl,
+          double&                    graphics_time,
+          size_t                     graphics_cyc_ival,
+          double                     graphics_dt_ival,
+          const size_t               cycle_stop,
+          const size_t               rk_num_stages,
+          double                     dt,
+          const double               fuzz,
+          const double               tiny,
+          const double               small,
+          CArray<double>&            graphics_times,
+          size_t&                    graphics_id)
+{
     printf("Writing outputs to file at %f \n", time_value);
     write_outputs(mesh,
                   node_coords,
@@ -57,79 +56,76 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                   graphics_times,
                   graphics_id,
                   time_value);
-    
-    
-    
-    CArrayKokkos <double> node_extensive_mass(mesh.num_nodes);
-    
+
+    CArrayKokkos<double> node_extensive_mass(mesh.num_nodes);
+
     // extensive energy tallies over the entire mesh
     double IE_t0 = 0.0;
     double KE_t0 = 0.0;
     double TE_t0 = 0.0;
-    
+
     double IE_sum = 0.0;
     double KE_sum = 0.0;
-    
+
     double IE_loc_sum = 0.0;
     double KE_loc_sum = 0.0;
-    
+
     // extensive IE
     REDUCE_SUM(elem_gid, 0, mesh.num_elems, IE_loc_sum, {
-        
-        IE_loc_sum += elem_mass(elem_gid)*elem_sie(1,elem_gid);
-        
+        IE_loc_sum += elem_mass(elem_gid) * elem_sie(1, elem_gid);
     }, IE_sum);
     IE_t0 = IE_sum;
-    
+
     // extensive KE
     REDUCE_SUM(node_gid, 0, mesh.num_nodes, KE_loc_sum, {
-        
         double ke = 0;
-        for (size_t dim=0; dim<mesh.num_dims; dim++){
-            ke += node_vel(1,node_gid,dim)*node_vel(1,node_gid,dim); // 1/2 at end
+        for (size_t dim = 0; dim < mesh.num_dims; dim++)
+        {
+            ke += node_vel(1, node_gid, dim) * node_vel(1, node_gid, dim); // 1/2 at end
         } // end for
-        
-        if(mesh.num_dims==2){
-            KE_loc_sum += node_mass(node_gid)*node_coords(1,node_gid,1)*ke;
+
+        if (mesh.num_dims == 2)
+        {
+            KE_loc_sum += node_mass(node_gid) * node_coords(1, node_gid, 1) * ke;
         }
-        else{
-            KE_loc_sum += node_mass(node_gid)*ke;
+        else
+        {
+            KE_loc_sum += node_mass(node_gid) * ke;
         }
-        
     }, KE_sum);
     Kokkos::fence();
-    KE_t0 = 0.5*KE_sum;
-    
+    KE_t0 = 0.5 * KE_sum;
+
     // extensive TE
     TE_t0 = IE_t0 + KE_t0;
-    
-    
+
     // save the nodal mass
     FOR_ALL(node_gid, 0, mesh.num_nodes, {
-        
         double radius = 1.0;
-        if(mesh.num_dims == 2){
-            radius = node_coords(1,node_gid,1);
+        if (mesh.num_dims == 2)
+        {
+            radius = node_coords(1, node_gid, 1);
         }
-        node_extensive_mass(node_gid) = node_mass(node_gid)*radius;
-        
+        node_extensive_mass(node_gid) = node_mass(node_gid) * radius;
     }); // end parallel for
-    
-    
+
     // a flag to exit the calculation
-    size_t stop_calc=0;
-    
+    size_t stop_calc = 0;
+
     auto time_1 = std::chrono::high_resolution_clock::now();
-    
-	// loop over the max number of time integration cycles
-	for (size_t cycle = 0; cycle < cycle_stop; cycle++) {
 
-	    // stop calculation if flag
-	    if (stop_calc == 1) break;
-        
+    // loop over the max number of time integration cycles
+    for (size_t cycle = 0; cycle < cycle_stop; cycle++)
+    {
+        // stop calculation if flag
+        if (stop_calc == 1)
+        {
+            break;
+        }
 
-	    // get the step
-        if(mesh.num_dims==2){
+        // get the step
+        if (mesh.num_dims == 2)
+        {
             get_timestep2D(mesh,
                            node_coords,
                            node_vel,
@@ -144,7 +140,8 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                            dt,
                            fuzz);
         }
-        else {
+        else
+        {
             get_timestep(mesh,
                          node_coords,
                          node_vel,
@@ -159,16 +156,17 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                          dt,
                          fuzz);
         } // end if 2D
-        
-        
-        if (cycle==0){
+
+        if (cycle == 0)
+        {
             printf("cycle = %lu, time = %f, time step = %f \n", cycle, time_value, dt);
         }
         // print time step every 10 cycles
-        else if (cycle%20==0){
+        else if (cycle % 20 == 0)
+        {
             printf("cycle = %lu, time = %f, time step = %f \n", cycle, time_value, dt);
         } // end if
-        
+
         // ---------------------------------------------------------------------
         // build mesh colors for load balancing
         // ---------------------------------------------------------------------
@@ -180,38 +178,38 @@ void sgh_solve(CArrayKokkos <material_t> &material,
 
         // calculate mesh coloring on cycle 0 and every 1000 cycles
         if (cycle%1000==1){
-            
+
             // strain rate threshold to place elem_gid's in bin 0 or 1
             double threshold = 0.01;
-            
-            
+
+
             // 2D-RZ or 3D Cartesian coordinates
             if (mesh.num_dims == 2){
                 // RZ coordinates
                 FOR_ALL(elem_gid, 0, mesh.num_elems, {
-                    
+
                     const size_t num_nodes_in_elem = 4;
 
                     double area_normal_array[8];
                     double vel_grad_array[9];
                     double D_array[9];
-                    
+
                     ViewCArrayKokkos<double> area_normal(area_normal_array, num_nodes_in_elem, 2);
                     ViewCArrayKokkos<double> vel_grad(vel_grad_array,3,3);
                     ViewCArrayKokkos<double> D(D_array,3,3);
-                    
+
                     double vol = elem_vol(elem_gid);
-                    
+
                     ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid,0),num_nodes_in_elem);
-                    
+
                     get_bmatrix2D(area_normal,
                                   elem_gid,
                                   node_coords,
                                   elem_node_gids);
-                    
+
                     // facial area of the element
                     double elem_area = get_area_quad(elem_gid, node_coords, elem_node_gids);
-                    
+
                     // --- Calculate the velocity gradient ---
                     get_velgrad2D(vel_grad,
                                   elem_node_gids,
@@ -220,73 +218,73 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                                   elem_vol(elem_gid),
                                   elem_area,
                                   elem_gid);
-                    
+
                     for(size_t j = 0 ; j < 3 ; j++){
                         for(size_t k= 0; k < 3; k++){
                             D(j,k) = 0.5 * ( vel_grad(j,k) + vel_grad(k,j) );
                         } // end for
                     } // end for
-                    
-                    
+
+
                     // largest absolute value
                     max_eign_val(elem_gid) = max_Eigen3D(D);
 
                 }); // end parallel for
-                
+
             }
             else {
                 // 3D Cartesian coordinates
                 FOR_ALL(elem_gid, 0, mesh.num_elems, {
-                    
+
                     const size_t num_nodes_in_elem = 8;
 
                     double area_normal_array[24];
                     double vel_grad_array[9];
                     double D_array[9];
-                    
+
                     ViewCArrayKokkos<double> area_normal(area_normal_array, num_nodes_in_elem, 3);
                     ViewCArrayKokkos<double> vel_grad(vel_grad_array, 3, 3);
                     ViewCArrayKokkos<double> D(D_array,3,3);
-                    
+
                     double vol = elem_vol(elem_gid);
-                    
+
                     ViewCArrayKokkos<size_t> elem_node_gids(&mesh.nodes_in_elem(elem_gid,0), num_nodes_in_elem);
-                    
+
                     get_bmatrix(area_normal,
                                 elem_gid,
                                 node_coords,
                                 elem_node_gids);
-                    
+
                     get_velgrad(vel_grad,
                                 elem_node_gids,
                                 node_vel,
                                 area_normal,
                                 vol,
                                 elem_gid);
-                    
+
                   for(size_t j = 0 ; j < 3 ; j++){
                        for(size_t k= 0; k < 3; k++){
                             D(j,k) = 0.5 * ( vel_grad(j,k) + vel_grad(k,j) );
                         } // end for
                    } // end for
-                    
+
                     // largest absolute value
                     max_eign_val(elem_gid) = max_Eigen3D(D);
-                
-                    
+
+
                 }); // end parallel for
-                
+
             } //end if on dimensions
-            
-            
+
+
             // build coloring array
             RUN ({
-                
+
                 size_t count1 = 0;
                 size_t count2 = 0;
 
                 for( size_t elem_gid = 0; elem_gid < mesh.num_elems; elem_gid++ ){
-                        
+
                     if (max_eign_val(elem_gid) <= threshold){
                         // color(0) has the lower strain rate elements
                         elems_in_color(0, count1) = elem_gid;
@@ -297,43 +295,43 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                         elems_in_color(1, count2) = elem_gid;
                         count2 += 1;
                     } // end if
-                    
+
                 } // end serial for loop
-                
+
                 num_elems_in_color(0) = count1;
                 num_elems_in_color(1) = count2;
-                
+
             });  // end run serial on device
             Kokkos::fence();
             num_elems_in_color.update_host();
-            
-            
+
+
             // Using the mesh coloring as following
-            
-             
+
+
             for(size_t color = 0; color < 2; color++ ){
-                
+
                 // loop over the elems in each coloring
 
                 FOR_ALL(elem_lid, 0, num_elems_in_color.host(color), {
                     size_t elem_gid = elems_in_color(color, elem_lid);
-                    
+
                     // coding goes here
-                    
+
                 });
-                
+
             } // end for over colors
-             
-           
-            
+
+
+
         } // end if on cycle for making the mesh coloring
-        
+
          */
-        
+
         // ---------------------------------------------------------------------
         //  integrate the solution forward to t(n+1) via Runge Kutta (RK) method
         // ---------------------------------------------------------------------
-	     
+
         // save the values at t_n
         rk_init(node_coords,
                 node_vel,
@@ -342,34 +340,34 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                 mesh.num_dims,
                 mesh.num_elems,
                 mesh.num_nodes);
-	    
-        
-        
-        // integrate solution forward in time
-        for (size_t rk_stage = 0; rk_stage < rk_num_stages; rk_stage++){
 
-            
+        // integrate solution forward in time
+        for (size_t rk_stage = 0; rk_stage < rk_num_stages; rk_stage++)
+        {
             // ---- RK coefficient ----
-            double rk_alpha = 1.0/((double)rk_num_stages - (double)rk_stage);
-            
+            double rk_alpha = 1.0 / ((double)rk_num_stages - (double)rk_stage);
+
             // ---- Calculate velocity diveregence for the element ----
-            if(mesh.num_dims==2){
+            if (mesh.num_dims == 2)
+            {
                 get_divergence2D(elem_div,
                                  mesh,
                                  node_coords,
                                  node_vel,
                                  elem_vol);
             }
-            else {
+            else
+            {
                 get_divergence(elem_div,
                                mesh,
                                node_coords,
                                node_vel,
                                elem_vol);
             } // end if 2D
-            
+
             // ---- calculate the forces on the vertices and evolve stress (hypo model) ----
-            if(mesh.num_dims==2){
+            if (mesh.num_dims == 2)
+            {
                 get_force_sgh2D(material,
                                 mesh,
                                 node_coords,
@@ -389,7 +387,8 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                                 dt,
                                 rk_alpha);
             }
-            else {
+            else
+            {
                 get_force_sgh(material,
                               mesh,
                               node_coords,
@@ -409,7 +408,6 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                               dt,
                               rk_alpha);
             }
-            
 
             // ---- Update nodal velocities ---- //
             update_velocity_sgh(rk_alpha,
@@ -418,12 +416,10 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                                 node_vel,
                                 node_mass,
                                 corner_force);
-            
+
             // ---- apply force boundary conditions to the boundary patches----
             boundary_velocity(mesh, boundary, node_vel, time_value);
-            
-            
-            
+
             // ---- Update specific internal energy in the elements ----
             update_energy_sgh(rk_alpha,
                               dt,
@@ -433,8 +429,7 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                               elem_sie,
                               elem_mass,
                               corner_force);
-            
-            
+
             // ---- Update nodal positions ----
             update_position_sgh(rk_alpha,
                                 dt,
@@ -442,15 +437,13 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                                 mesh.num_nodes,
                                 node_coords,
                                 node_vel);
-            
-            
+
             // ---- Calculate cell volume for next time step ----
             get_vol(elem_vol, node_coords, mesh);
-            
-            
-            
+
             // ---- Calculate elem state (den, pres, sound speed, stress) for next time step ----
-            if(mesh.num_dims==2){
+            if (mesh.num_dims == 2)
+            {
                 update_state2D(material,
                                mesh,
                                node_coords,
@@ -467,7 +460,8 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                                dt,
                                rk_alpha);
             }
-            else{
+            else
+            {
                 update_state(material,
                              mesh,
                              node_coords,
@@ -490,23 +484,20 @@ void sgh_solve(CArrayKokkos <material_t> &material,
             //    2) hypo-elastic strength models are called in get_force
             //    3) strength models must be added by the user in user_mat.cpp
 
-            
             // calculate the new corner masses if 2D
-            if(mesh.num_dims==2){
-                
+            if (mesh.num_dims == 2)
+            {
                 // calculate the nodal areal mass
                 FOR_ALL(node_gid, 0, mesh.num_nodes, {
-                    
                     node_mass(node_gid) = 0.0;
-                    
-                    if (node_coords(1,node_gid,1) > tiny){
-                        node_mass(node_gid) = node_extensive_mass(node_gid)/node_coords(1,node_gid,1);
-                    }
 
+                    if (node_coords(1, node_gid, 1) > tiny)
+                    {
+                        node_mass(node_gid) = node_extensive_mass(node_gid) / node_coords(1, node_gid, 1);
+                    }
                 }); // end parallel for over node_gid
                 Kokkos::fence();
-                
-                
+
                 // -----------------------------------------------
                 // Calcualte the areal mass for nodes on the axis
                 // -----------------------------------------------
@@ -519,94 +510,88 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                 // 0---1
                 /*
                 FOR_ALL(elem_gid, 0, mesh.num_elems, {
-                    
+
                     // loop over the corners of the element and calculate the mass
                     for (size_t node_lid=0; node_lid<4; node_lid++){
-                        
+
                         size_t node_gid = mesh.nodes_in_elem(elem_gid, node_lid);
                         size_t node_minus_gid;
                         size_t node_plus_gid;
-                        
-                        
+
+
                         if (node_coords(1,node_gid,1) < tiny){
                             // node is on the axis
-                            
+
                             // minus node
                             if (node_lid==0){
                                 node_minus_gid = mesh.nodes_in_elem(elem_gid, 3);
                             } else {
                                 node_minus_gid = mesh.nodes_in_elem(elem_gid, node_lid-1);
                             }
-                            
+
                             // plus node
                             if (node_lid==3){
                                 node_plus_gid = mesh.nodes_in_elem(elem_gid, 0);
                             } else {
                                 node_plus_gid = mesh.nodes_in_elem(elem_gid, node_lid+1);
                             }
-                            
+
                             node_mass(node_gid) = fmax(node_mass(node_plus_gid), node_mass(node_minus_gid))/2.0;
-                            
+
                         } // end if
-                        
+
                     } // end for over corners
-                    
+
                 }); // end parallel for over elem_gid
                 Kokkos::fence();
                  */
-                
+
                 FOR_ALL(node_bdy_gid, 0, mesh.num_bdy_nodes, {
-                    
                     size_t node_gid = mesh.bdy_nodes(node_bdy_gid);
-                    
-                    if (node_coords(1,node_gid,1) < tiny){
+
+                    if (node_coords(1, node_gid, 1) < tiny)
+                    {
                         // node is on the axis
-                        
-                        for(size_t node_lid=0; node_lid<mesh.num_nodes_in_node(node_gid); node_lid++){
-                            
+
+                        for (size_t node_lid = 0; node_lid < mesh.num_nodes_in_node(node_gid); node_lid++)
+                        {
                             size_t node_neighbor_gid = mesh.nodes_in_node(node_gid, node_lid);
-                            
+
                             // if the node is off the axis, use it's areal mass on the boundary
-                            if (node_coords(1,node_neighbor_gid,1) > tiny){
-                                node_mass(node_gid) = fmax(node_mass(node_gid), node_mass(node_neighbor_gid)/2.0);
+                            if (node_coords(1, node_neighbor_gid, 1) > tiny)
+                            {
+                                node_mass(node_gid) = fmax(node_mass(node_gid), node_mass(node_neighbor_gid) / 2.0);
                             }
                         } // end for over neighboring nodes
-                        
                     } // end if
-                    
                 }); // end parallel for over elem_gid
-                
-                
-            
             } // end of if 2D-RZ
-            
-            
-            
         } // end of RK loop
-	        
 
-	    
+        // increment the time
+        time_value += dt;
 
-	    // increment the time
-	    time_value+=dt;
-    	
-        
         size_t write = 0;
-        if ((cycle+1)%graphics_cyc_ival == 0 && cycle>0){
+        if ((cycle + 1) % graphics_cyc_ival == 0 && cycle > 0)
+        {
             write = 1;
         }
-        else if (cycle == cycle_stop) {
+        else if (cycle == cycle_stop)
+        {
             write = 1;
         }
-        else if (time_value >= time_final){
+        else if (time_value >= time_final)
+        {
             write = 1;
         }
-        else if (time_value >= graphics_time){
+        else if (time_value >= graphics_time)
+        {
             write = 1;
         }
-            
+
         // write outputs
-        if (write == 1){
+        if (write == 1)
+        {
             printf("Writing outputs to file at %f \n", graphics_time);
             write_outputs(mesh,
                           node_coords,
@@ -623,162 +608,165 @@ void sgh_solve(CArrayKokkos <material_t> &material,
                           graphics_times,
                           graphics_id,
                           time_value);
-            
+
             graphics_time = time_value + graphics_dt_ival;
         } // end if
-        
-        
+
         // end of calculation
-        if (time_value>=time_final) break;
-        
+        if (time_value >= time_final)
+        {
+            break;
+        }
     } // end for cycle loop
-    
-    
-    auto time_2 = std::chrono::high_resolution_clock::now();
+
+    auto time_2    = std::chrono::high_resolution_clock::now();
     auto calc_time = std::chrono::duration_cast
-                           <std::chrono::nanoseconds>(time_2 - time_1).count();
-    
+                     <std::chrono::nanoseconds>(time_2 - time_1).count();
+
     printf("\nCalculation time in seconds: %f \n", calc_time * 1e-9);
-    
-    
+
     // ---- Calculate energy tallies ----
     double IE_tend = 0.0;
     double KE_tend = 0.0;
     double TE_tend = 0.0;
-    
+
     IE_loc_sum = 0.0;
     KE_loc_sum = 0.0;
-    IE_sum = 0.0;
-    KE_sum = 0.0;
-    
+    IE_sum     = 0.0;
+    KE_sum     = 0.0;
+
     // extensive IE
     REDUCE_SUM(elem_gid, 0, mesh.num_elems, IE_loc_sum, {
-        
-        IE_loc_sum += elem_mass(elem_gid)*elem_sie(1,elem_gid);
-        
+        IE_loc_sum += elem_mass(elem_gid) * elem_sie(1, elem_gid);
     }, IE_sum);
     IE_tend = IE_sum;
-    
+
     // extensive KE
     REDUCE_SUM(node_gid, 0, mesh.num_nodes, KE_loc_sum, {
-        
         double ke = 0;
-        for (size_t dim=0; dim<mesh.num_dims; dim++){
-            ke += node_vel(1,node_gid,dim)*node_vel(1,node_gid,dim); // 1/2 at end
+        for (size_t dim = 0; dim < mesh.num_dims; dim++)
+        {
+            ke += node_vel(1, node_gid, dim) * node_vel(1, node_gid, dim); // 1/2 at end
         } // end for
-        
-        if(mesh.num_dims==2){
-            KE_loc_sum += node_mass(node_gid)*node_coords(1,node_gid,1)*ke;
+
+        if (mesh.num_dims == 2)
+        {
+            KE_loc_sum += node_mass(node_gid) * node_coords(1, node_gid, 1) * ke;
         }
-        else{
-            KE_loc_sum += node_mass(node_gid)*ke;
+        else
+        {
+            KE_loc_sum += node_mass(node_gid) * ke;
         }
-            
-        
     }, KE_sum);
     Kokkos::fence();
-    KE_tend = 0.5*KE_sum;
-    
-    
+    KE_tend = 0.5 * KE_sum;
+
     // extensive TE
     TE_tend = IE_tend + KE_tend;
-    
+
     printf("Time=0:   KE = %f, IE = %f, TE = %f \n", KE_t0, IE_t0, TE_t0);
     printf("Time=End: KE = %f, IE = %f, TE = %f \n", KE_tend, IE_tend, TE_tend);
     printf("total energy conservation error = %e \n\n", TE_tend - TE_t0);
-    
+
     return;
-    
 } // end of SGH solve
 
-
-
 KOKKOS_FUNCTION
-double max_Eigen3D(const ViewCArrayKokkos<double> tensor) {
+double
+max_Eigen3D(const ViewCArrayKokkos<double> tensor)
+{
     // Compute largest eigenvalue of a 3x3 tensor
     // Algorithm only works if tensor is symmetric
-    double pi = 3.141592653589793;
-    size_t dim  = tensor.dims(0);
+    double pi  = 3.141592653589793;
+    size_t dim = tensor.dims(0);
     double trace, det;
-    trace = tensor(0,0) + tensor(1,1) + tensor(2,2);
-    det = tensor(0,0) * (tensor(1,1)*tensor(2,2) - tensor(1,2)*tensor(2,1));
-    det -= tensor(0,1) * (tensor(1,0)*tensor(2,2) - tensor(1,2)*tensor(2,0));
-    det += tensor(0,2) * (tensor(1,0)*tensor(2,1) - tensor(1,1)*tensor(2,0));
+    trace  = tensor(0, 0) + tensor(1, 1) + tensor(2, 2);
+    det    = tensor(0, 0) * (tensor(1, 1) * tensor(2, 2) - tensor(1, 2) * tensor(2, 1));
+    det   -= tensor(0, 1) * (tensor(1, 0) * tensor(2, 2) - tensor(1, 2) * tensor(2, 0));
+    det   += tensor(0, 2) * (tensor(1, 0) * tensor(2, 1) - tensor(1, 1) * tensor(2, 0));
     trace /= 3.; // easier for computation
-    double p2 = pow((tensor(0,0) - trace),2) + pow((tensor(1,1) - trace),2) +
-                pow((tensor(2,2) - trace),2);
-    p2 += 2. * (pow(tensor(0,1),2) + pow(tensor(0,2),2) + pow(tensor(1,2), 2));
-    
-    double p = sqrt(p2/6.);
-    
+    double p2 = pow((tensor(0, 0) - trace), 2) + pow((tensor(1, 1) - trace), 2) +
+                pow((tensor(2, 2) - trace), 2);
+    p2 += 2. * (pow(tensor(0, 1), 2) + pow(tensor(0, 2), 2) + pow(tensor(1, 2), 2));
+
+    double p = sqrt(p2 / 6.);
+
     // check for nan
-    if( det != det){
+    if (det != det)
+    {
         return 0;
     }
-    
-    if(det == 0){
+
+    if (det == 0)
+    {
         return 0;
     }
-    
-    double B_array[9];
-    ViewCArrayKokkos<double> B(B_array,3,3);
-    
-    for(int i = 0; i < 3; i++){
-        for(int j = 0; j < 3; j++){
-            
-            if(i == j){
-                B(i,i) = (1/p) * (tensor(i,i) - trace);
+
+    double                   B_array[9];
+    ViewCArrayKokkos<double> B(B_array, 3, 3);
+
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            if (i == j)
+            {
+                B(i, i) = (1 / p) * (tensor(i, i) - trace);
             }
-            else {
-                B(i,j) = (1/p) * tensor(i,j);
+            else
+            {
+                B(i, j) = (1 / p) * tensor(i, j);
             } // end if
-            
         } // end for j
     } // end for i
-    
+
     double r, phi;
-    r =  B(0,0) * (B(1,1)*B(2,2) - B(1,2)*B(2,1));
-    r -= B(0,1) * (B(1,0)*B(2,2) - B(1,2)*B(2,0));
-    r += B(0,2) * (B(1,0)*B(2,1) - B(1,1)*B(2,0));
+    r  =  B(0, 0) * (B(1, 1) * B(2, 2) - B(1, 2) * B(2, 1));
+    r -= B(0, 1) * (B(1, 0) * B(2, 2) - B(1, 2) * B(2, 0));
+    r += B(0, 2) * (B(1, 0) * B(2, 1) - B(1, 1) * B(2, 0));
     r /= 2;
     // first two cases are to handle numerical difficulties.
     // In exact math -1 <= r <= 1
-    if (r <= -1){
-        phi = pi/3;
+    if (r <= -1)
+    {
+        phi = pi / 3;
     }
-    else if (r >= 1){
+    else if (r >= 1)
+    {
         phi = 0;
     }
-    else {
+    else
+    {
         phi = acos(r) / 3.;
     } // end if
-    
+
     double eig1, eig2, eig3;
     eig1 = trace + 2 * p * cos(phi);
-    eig2 = trace + 2 * p * cos(phi + (2*pi/3));
-    eig3 = 3*trace - (eig1 + eig2);
-    
-    double abs_max_val = fmax( fmax(fabs(eig1), fabs(eig2)), fabs(eig3));
+    eig2 = trace + 2 * p * cos(phi + (2 * pi / 3));
+    eig3 = 3 * trace - (eig1 + eig2);
+
+    double abs_max_val = fmax(fmax(fabs(eig1), fabs(eig2)), fabs(eig3));
 
     return abs_max_val;
 }
 
-
 KOKKOS_FUNCTION
-double max_Eigen2D(const ViewCArrayKokkos<double> tensor) {
+double
+max_Eigen2D(const ViewCArrayKokkos<double> tensor)
+{
     // Compute largest eigenvalue of a 2x2 tensor
     // Algorithm only works if tensor is symmetric
-    size_t dim  = tensor.dims(0);
+    size_t dim = tensor.dims(0);
     double trace, det;
 
-    trace = tensor(0,0) + tensor(1,1);
-    det = tensor(0,0)*tensor(1,1) - tensor(0,1)*tensor(1,0);
-    
+    trace = tensor(0, 0) + tensor(1, 1);
+    det   = tensor(0, 0) * tensor(1, 1) - tensor(0, 1) * tensor(1, 0);
+
     double eig1, eig2;
-    
-    eig1 = (trace/2.) + sqrt(0.25*trace*trace - det);
-    eig2 = (trace/2.) - sqrt(0.25*trace*trace - det);
-    
+
+    eig1 = (trace / 2.) + sqrt(0.25 * trace * trace - det);
+    eig2 = (trace / 2.) - sqrt(0.25 * trace * trace - det);
+
     double abs_max_val = fmax(fabs(eig1), fabs(eig2));
     return abs_max_val;
 } // end 2D max eignen value

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/sgh_solve.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/sgh_solve.cpp
@@ -4,41 +4,40 @@
 #include "mesh.h"
 #include <chrono>
 
-void
-sgh_solve(CArrayKokkos<material_t>&  material,
-          CArrayKokkos<boundary_t>&  boundary,
-          mesh_t&                    mesh,
-          DViewCArrayKokkos<double>& node_coords,
-          DViewCArrayKokkos<double>& node_vel,
-          DViewCArrayKokkos<double>& node_mass,
-          DViewCArrayKokkos<double>& elem_den,
-          DViewCArrayKokkos<double>& elem_pres,
-          DViewCArrayKokkos<double>& elem_stress,
-          DViewCArrayKokkos<double>& elem_sspd,
-          DViewCArrayKokkos<double>& elem_sie,
-          DViewCArrayKokkos<double>& elem_vol,
-          DViewCArrayKokkos<double>& elem_div,
-          DViewCArrayKokkos<double>& elem_mass,
-          DViewCArrayKokkos<size_t>& elem_mat_id,
-          DViewCArrayKokkos<double>& elem_statev,
-          DViewCArrayKokkos<double>& corner_force,
-          DViewCArrayKokkos<double>& corner_mass,
-          double&                    time_value,
-          const double               time_final,
-          const double               dt_max,
-          const double               dt_min,
-          const double               dt_cfl,
-          double&                    graphics_time,
-          size_t                     graphics_cyc_ival,
-          double                     graphics_dt_ival,
-          const size_t               cycle_stop,
-          const size_t               rk_num_stages,
-          double                     dt,
-          const double               fuzz,
-          const double               tiny,
-          const double               small,
-          CArray<double>&            graphics_times,
-          size_t&                    graphics_id)
+void sgh_solve(CArrayKokkos<material_t>&  material,
+               CArrayKokkos<boundary_t>&  boundary,
+               mesh_t&                    mesh,
+               DViewCArrayKokkos<double>& node_coords,
+               DViewCArrayKokkos<double>& node_vel,
+               DViewCArrayKokkos<double>& node_mass,
+               DViewCArrayKokkos<double>& elem_den,
+               DViewCArrayKokkos<double>& elem_pres,
+               DViewCArrayKokkos<double>& elem_stress,
+               DViewCArrayKokkos<double>& elem_sspd,
+               DViewCArrayKokkos<double>& elem_sie,
+               DViewCArrayKokkos<double>& elem_vol,
+               DViewCArrayKokkos<double>& elem_div,
+               DViewCArrayKokkos<double>& elem_mass,
+               DViewCArrayKokkos<size_t>& elem_mat_id,
+               DViewCArrayKokkos<double>& elem_statev,
+               DViewCArrayKokkos<double>& corner_force,
+               DViewCArrayKokkos<double>& corner_mass,
+               double&                    time_value,
+               const double               time_final,
+               const double               dt_max,
+               const double               dt_min,
+               const double               dt_cfl,
+               double&                    graphics_time,
+               size_t                     graphics_cyc_ival,
+               double                     graphics_dt_ival,
+               const size_t               cycle_stop,
+               const size_t               rk_num_stages,
+               double                     dt,
+               const double               fuzz,
+               const double               tiny,
+               const double               small,
+               CArray<double>&            graphics_times,
+               size_t&                    graphics_id)
 {
     printf("Writing outputs to file at %f \n", time_value);
     write_outputs(mesh,
@@ -672,8 +671,7 @@ sgh_solve(CArrayKokkos<material_t>&  material,
 } // end of SGH solve
 
 KOKKOS_FUNCTION
-double
-max_Eigen3D(const ViewCArrayKokkos<double> tensor)
+double max_Eigen3D(const ViewCArrayKokkos<double> tensor)
 {
     // Compute largest eigenvalue of a 3x3 tensor
     // Algorithm only works if tensor is symmetric
@@ -751,8 +749,7 @@ max_Eigen3D(const ViewCArrayKokkos<double> tensor)
 }
 
 KOKKOS_FUNCTION
-double
-max_Eigen2D(const ViewCArrayKokkos<double> tensor)
+double max_Eigen2D(const ViewCArrayKokkos<double> tensor)
 {
     // Compute largest eigenvalue of a 2x2 tensor
     // Algorithm only works if tensor is symmetric

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/state.h
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/state.h
@@ -1,183 +1,169 @@
 #ifndef STATE_H
-#define STATE_H  
-
+#define STATE_H
 
 #include "matar.h"
 
 using namespace mtr;
 
 // node_state
-struct node_t {
-
+struct node_t
+{
     // Position
-    CArray <double> coords;
+    CArray<double> coords;
 
     // velocity
-    CArray <double> vel;
+    CArray<double> vel;
 
     // mass at nodes
-    CArray <double> mass;
+    CArray<double> mass;
 
-    
     // initialization method (num_rk_storage_bins, num_nodes, num_dims)
-    void initialize(size_t num_rk, size_t num_nodes, size_t num_dims)
+    void
+    initialize(size_t num_rk, size_t num_nodes, size_t num_dims)
     {
-        this->coords = CArray <double> (num_rk, num_nodes, num_dims);
-        this->vel    = CArray <double> (num_rk, num_nodes, num_dims);
-        this->mass   = CArray <double> (num_nodes);
+        this->coords = CArray<double>(num_rk, num_nodes, num_dims);
+        this->vel    = CArray<double>(num_rk, num_nodes, num_dims);
+        this->mass   = CArray<double>(num_nodes);
     }; // end method
-
 }; // end node_t
 
-
 // elem_state
-struct elem_t {
-
+struct elem_t
+{
     // den
-    CArray <double> den;
-    
+    CArray<double> den;
+
     // pres
-    CArray <double> pres;
-    
+    CArray<double> pres;
+
     // stress
-    CArray <double> stress;
-    
+    CArray<double> stress;
+
     // sspd
-    CArray <double> sspd;
-    
+    CArray<double> sspd;
+
     // sie
-    CArray <double> sie;
+    CArray<double> sie;
 
     // vol
-    CArray <double> vol;
-    
-    // divergence of velocity
-    CArray <double> div;
-    
-    // mass of elem
-    CArray <double> mass;
-    
-    // mat ids
-    CArray <size_t> mat_id;
-    
-    // state variables
-    CArray <double> statev;
-    
-    // initialization method (num_rk_storage_bins, num_cells, num_dims)
-    void initialize(size_t num_rk, size_t num_elems, size_t num_dims)
-    {
-        this->den    = CArray <double> (num_elems);
-        this->pres   = CArray <double> (num_elems);
-        this->stress = CArray <double> (num_rk, num_elems, num_dims, num_dims);
-        this->sspd   = CArray <double> (num_elems);
-        this->sie    = CArray <double> (num_rk, num_elems);
-        this->vol    = CArray <double> (num_elems);
-        this->div    = CArray <double> (num_elems);
-        this->mass   = CArray <double> (num_elems);
-        this->mat_id = CArray <size_t> (num_elems);
-    }; // end method
+    CArray<double> vol;
 
+    // divergence of velocity
+    CArray<double> div;
+
+    // mass of elem
+    CArray<double> mass;
+
+    // mat ids
+    CArray<size_t> mat_id;
+
+    // state variables
+    CArray<double> statev;
+
+    // initialization method (num_rk_storage_bins, num_cells, num_dims)
+    void
+    initialize(size_t num_rk, size_t num_elems, size_t num_dims)
+    {
+        this->den    = CArray<double>(num_elems);
+        this->pres   = CArray<double>(num_elems);
+        this->stress = CArray<double>(num_rk, num_elems, num_dims, num_dims);
+        this->sspd   = CArray<double>(num_elems);
+        this->sie    = CArray<double>(num_rk, num_elems);
+        this->vol    = CArray<double>(num_elems);
+        this->div    = CArray<double>(num_elems);
+        this->mass   = CArray<double>(num_elems);
+        this->mat_id = CArray<size_t>(num_elems);
+    }; // end method
 }; // end elem_t
 
-
 // corner_state
-struct corner_t {
-
+struct corner_t
+{
     // force
-    CArray <double> force;
-    
+    CArray<double> force;
+
     // mass of corner
-    CArray <double> mass;
+    CArray<double> mass;
 
-    
     // initialization method (num_corners, num_dims)
-    void initialize(size_t num_corners, size_t num_dims)
+    void
+    initialize(size_t num_corners, size_t num_dims)
     {
-        this->force = CArray <double> (num_corners, num_dims);
-        this->mass  = CArray <double> (num_corners);
+        this->force = CArray<double>(num_corners, num_dims);
+        this->mass  = CArray<double>(num_corners);
     }; // end method
-
 }; // end corner_t
-
 
 namespace model
 {
-
-    // strength model types
-    enum strength_tag
-    {
-        none = 0,
-        hypo = 1,     // hypoelastic plastic model
-        hyper = 2,    // hyperelastic plastic model
-    };
-
+// strength model types
+enum strength_tag
+{
+    none = 0,
+    hypo = 1,         // hypoelastic plastic model
+    hyper = 2,        // hyperelastic plastic model
+};
 } // end of namespace
 
 namespace model_init
 {
-
-    // strength model setup
-    enum strength_setup_tag
-    {
-        input = 0,
-        user_init = 1,
-    };
-
+// strength model setup
+enum strength_setup_tag
+{
+    input = 0,
+    user_init = 1,
+};
 } // end of namespace
 
-
 // material model parameters
-struct material_t {
-
+struct material_t
+{
     // statev(0) = gamma
     // statev(1) = minimum sound speed
     // statev(2) = specific heat c_v
     // statev(3) = ref temperature
     // statev(4) = ref density
     // statev(5) = ref specific internal energy
-    
+
     // eos fcn pointer
-    void (*eos_model) (const DViewCArrayKokkos <double> &elem_pres,
-                       const DViewCArrayKokkos <double> &elem_stress,
-                       const size_t elem_gid,
-                       const size_t mat_id,
-                       const DViewCArrayKokkos <double> &elem_state_vars,
-                       const DViewCArrayKokkos <double> &elem_sspd,
-                       const double den,
-                       const double sie) = NULL;
-    
+    void (*eos_model) (const DViewCArrayKokkos<double>& elem_pres,
+                       const DViewCArrayKokkos<double>& elem_stress,
+                       const size_t                     elem_gid,
+                       const size_t                     mat_id,
+                       const DViewCArrayKokkos<double>& elem_state_vars,
+                       const DViewCArrayKokkos<double>& elem_sspd,
+                       const double                     den,
+                       const double                     sie) = NULL;
+
     // strength fcn pointer
-    void (*strength_model) (const DViewCArrayKokkos <double> &elem_pres,
-                            const DViewCArrayKokkos <double> &elem_stress,
-                            const size_t elem_gid,
-                            const size_t mat_id,
-                            const DViewCArrayKokkos <double> &elem_state_vars,
-                            const DViewCArrayKokkos <double> &elem_sspd,
-                            const double den,
-                            const double sie,
-                            const ViewCArrayKokkos <double> &vel_grad,
-                            const ViewCArrayKokkos <size_t>  &elem_node_gids,
-                            const DViewCArrayKokkos <double> &node_coords,
-                            const DViewCArrayKokkos <double> &node_vel,
-                            const double vol,
-                            const double dt,
-                            const double alpha) = NULL;
-    
+    void (*strength_model) (const DViewCArrayKokkos<double>& elem_pres,
+                            const DViewCArrayKokkos<double>& elem_stress,
+                            const size_t                     elem_gid,
+                            const size_t                     mat_id,
+                            const DViewCArrayKokkos<double>& elem_state_vars,
+                            const DViewCArrayKokkos<double>& elem_sspd,
+                            const double                     den,
+                            const double                     sie,
+                            const ViewCArrayKokkos<double>&  vel_grad,
+                            const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                            const DViewCArrayKokkos<double>& node_coords,
+                            const DViewCArrayKokkos<double>& node_vel,
+                            const double                     vol,
+                            const double                     dt,
+                            const double                     alpha) = NULL;
+
     // hypo or hyper elastic plastic model
     model::strength_tag strength_type;
-    
+
     // setup the strength model via the input file for via a user_setup
-    model_init::strength_setup_tag strength_setup=model_init::input;
-    
+    model_init::strength_setup_tag strength_setup = model_init::input;
+
     size_t num_state_vars;
-    
+
     double q1;    // acoustic coefficient in Riemann solver for compresion
     double q1ex;  // acoustic coefficient in Riemann solver for expansion
     double q2;    // linear coefficient in Riemann solver for compression
     double q2ex;  // linear coefficient in Riemann solver for expansion
 }; // end material_t
 
-
-
-
-#endif 
+#endif

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/state.h
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/state.h
@@ -18,8 +18,7 @@ struct node_t
     CArray<double> mass;
 
     // initialization method (num_rk_storage_bins, num_nodes, num_dims)
-    void
-    initialize(size_t num_rk, size_t num_nodes, size_t num_dims)
+    void initialize(size_t num_rk, size_t num_nodes, size_t num_dims)
     {
         this->coords = CArray<double>(num_rk, num_nodes, num_dims);
         this->vel    = CArray<double>(num_rk, num_nodes, num_dims);
@@ -61,8 +60,7 @@ struct elem_t
     CArray<double> statev;
 
     // initialization method (num_rk_storage_bins, num_cells, num_dims)
-    void
-    initialize(size_t num_rk, size_t num_elems, size_t num_dims)
+    void initialize(size_t num_rk, size_t num_elems, size_t num_dims)
     {
         this->den    = CArray<double>(num_elems);
         this->pres   = CArray<double>(num_elems);
@@ -86,8 +84,7 @@ struct corner_t
     CArray<double> mass;
 
     // initialization method (num_corners, num_dims)
-    void
-    initialize(size_t num_corners, size_t num_dims)
+    void initialize(size_t num_corners, size_t num_dims)
     {
         this->force = CArray<double>(num_corners, num_dims);
         this->mass  = CArray<double>(num_corners);

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/time_integration.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/time_integration.cpp
@@ -2,91 +2,84 @@
 #include "mesh.h"
 #include "state.h"
 
-
 // -----------------------------------------------------------------------------
 // This function saves the variables at rk_stage = 0, which is t_n
-//------------------------------------------------------------------------------
-void rk_init(DViewCArrayKokkos <double> &node_coords,
-             DViewCArrayKokkos <double> &node_vel,
-             DViewCArrayKokkos <double> &elem_sie,
-             DViewCArrayKokkos <double> &elem_stress,
-             const size_t num_dims,
-             const size_t num_elems,
-             const size_t num_nodes){
-
+// ------------------------------------------------------------------------------
+void
+rk_init(DViewCArrayKokkos<double>& node_coords,
+        DViewCArrayKokkos<double>& node_vel,
+        DViewCArrayKokkos<double>& elem_sie,
+        DViewCArrayKokkos<double>& elem_stress,
+        const size_t               num_dims,
+        const size_t               num_elems,
+        const size_t               num_nodes)
+{
     // save elem quantities
     FOR_ALL(elem_gid, 0, num_elems, {
-
         // stress is always 3D even with 2D-RZ
-        for(size_t i=0; i<3; i++){
-            for(size_t j=0; j<3; j++){
-                elem_stress(0,elem_gid,i,j) = elem_stress(1,elem_gid,i,j);
+        for (size_t i = 0; i < 3; i++)
+        {
+            for (size_t j = 0; j < 3; j++)
+            {
+                elem_stress(0, elem_gid, i, j) = elem_stress(1, elem_gid, i, j);
             }
         }  // end for
 
-        elem_sie(0,elem_gid) = elem_sie(1,elem_gid);
-
+        elem_sie(0, elem_gid) = elem_sie(1, elem_gid);
     }); // end parallel for
-    
-    
+
     // save nodal quantities
     FOR_ALL(node_gid, 0, num_nodes, {
-        
-        for(size_t i=0; i<num_dims; i++){
-            node_coords(0,node_gid,i) = node_coords(1,node_gid,i);
-            node_vel(0,node_gid,i) = node_vel(1,node_gid,i);
+        for (size_t i = 0; i < num_dims; i++)
+        {
+            node_coords(0, node_gid, i) = node_coords(1, node_gid, i);
+            node_vel(0, node_gid, i)    = node_vel(1, node_gid, i);
         }
     }); // end parallel for
     Kokkos::fence();
-    
+
     return;
-    
 } // end rk_init
-
-
-
 
 // -----------------------------------------------------------------------------
 // This function calculates the time step by finding the shortest distance
 // between any two nodes in the mesh
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 // WARNING WARNING :  Only works for 3D, 8 node elements
-void get_timestep(mesh_t &mesh,
-                  DViewCArrayKokkos <double> &node_coords,
-                  DViewCArrayKokkos <double> &node_vel,
-                  DViewCArrayKokkos <double> &elem_sspd,
-                  DViewCArrayKokkos <double> &elem_vol,
-                  double time_value,
-                  const double graphics_time,
-                  const double time_final,
-                  const double dt_max,
-                  const double dt_min,
-                  const double dt_cfl,
-                  double &dt,
-                  const double fuzz){
-
-    
+void
+get_timestep(mesh_t&                    mesh,
+             DViewCArrayKokkos<double>& node_coords,
+             DViewCArrayKokkos<double>& node_vel,
+             DViewCArrayKokkos<double>& elem_sspd,
+             DViewCArrayKokkos<double>& elem_vol,
+             double                     time_value,
+             const double               graphics_time,
+             const double               time_final,
+             const double               dt_max,
+             const double               dt_min,
+             const double               dt_cfl,
+             double&                    dt,
+             const double               fuzz)
+{
     // increase dt by 10%, that is the largest dt value
-    dt = dt*1.1;
+    dt = dt * 1.1;
 
     double dt_lcl;
     double min_dt_calc;
     REDUCE_MIN(elem_gid, 0, mesh.num_elems, dt_lcl, {
-        
         double coords0[24];  // element coords
-        ViewCArrayKokkos <double> coords(coords0, 8, 3);
+        ViewCArrayKokkos<double> coords(coords0, 8, 3);
 
-        
         double distance0[28];  // array for holding distances between each node
-        ViewCArrayKokkos <double> dist(distance0, 28);
-        
-        // Getting the coordinates of the element
-        for(size_t node_lid = 0; node_lid < 8; node_lid++){
+        ViewCArrayKokkos<double> dist(distance0, 28);
 
-            for (size_t dim = 0; dim < mesh.num_dims; dim++){
-                coords(node_lid, dim) = node_coords(1,  mesh.nodes_in_elem(elem_gid, node_lid), dim);
+        // Getting the coordinates of the element
+        for (size_t node_lid = 0; node_lid < 8; node_lid++)
+        {
+            for (size_t dim = 0; dim < mesh.num_dims; dim++)
+            {
+                coords(node_lid, dim) = node_coords(1, mesh.nodes_in_elem(elem_gid, node_lid), dim);
             } // end for dim
-            
         } // end for loop over node_lid
 
         // loop conditions needed for distance calculation
@@ -95,154 +88,156 @@ void get_timestep(mesh_t &mesh,
         size_t a;
         size_t b;
         size_t loop = 0;
-        
+
         // Only works for 3D
         // Solving for the magnitude of distance between each node
-        for (size_t i = 0; i < 28; i++){
-            
+        for (size_t i = 0; i < 28; i++)
+        {
             a = countA;
             b = countB;
-            
+
             // returns magnitude of distance between each node, 28 total options
-            dist(i) = fabs(sqrt(( pow((coords(b, 0) - coords(a, 0)), 2.0)
-                                + pow((coords(b, 1) - coords(a, 1)), 2.0)
-                                + pow((coords(b, 2) - coords(a, 2)), 2.0))));
+            dist(i) = fabs(sqrt((pow((coords(b, 0) - coords(a, 0)), 2.0)
+                                 + pow((coords(b, 1) - coords(a, 1)), 2.0)
+                                 + pow((coords(b, 2) - coords(a, 2)), 2.0))));
 
             countB++;
             countA++;
-            
+
             // tricky indexing
-            if (countB > 7) {
+            if (countB > 7)
+            {
                 loop++;
                 countB = 1 + loop;
                 countA = 0;
             }
-            
         } // endo for i
 
-
         double dist_min = dist(0);
-        
-        for(int i = 0; i < 28; ++i){
+
+        for (int i = 0; i < 28; ++i)
+        {
             dist_min = fmin(dist(i), dist_min);
         }
-        
+
         // local dt calc based on CFL
-        double dt_lcl_ = dt_cfl*dist_min/(elem_sspd(elem_gid) + fuzz);
-        
+        double dt_lcl_ = dt_cfl * dist_min / (elem_sspd(elem_gid) + fuzz);
+
         // make dt be in bounds
         dt_lcl_ = fmin(dt_lcl_, dt_max);               // make dt small than dt_max
         dt_lcl_ = fmax(dt_lcl_, dt_min);               // make dt larger than dt_min
-        
-       
-        if (dt_lcl_ < dt_lcl) dt_lcl = dt_lcl_;
-        
+
+        if (dt_lcl_ < dt_lcl)
+        {
+            dt_lcl = dt_lcl_;
+        }
     }, min_dt_calc);  // end parallel reduction
     Kokkos::fence();
-    
+
     // save the min dt
-    if(min_dt_calc < dt) dt = min_dt_calc;
-    
+    if (min_dt_calc < dt)
+    {
+        dt = min_dt_calc;
+    }
+
     // ensure time step hits the graphics time intervals
-    dt = fmin(dt, (graphics_time - time_value)+fuzz);
-    
+    dt = fmin(dt, (graphics_time - time_value) + fuzz);
+
     // make dt be exact for final time
-    dt = fmin(dt, time_final-time_value);
-    
+    dt = fmin(dt, time_final - time_value);
+
     return;
-    
 } // end get_timestep
 
 // -----------------------------------------------------------------------------
 // This function calculates the time step by finding the shortest distance
 // between any two nodes in the mesh
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 // WARNING WARNING :  Only works for 3D, 8 node elements
-void get_timestep2D(mesh_t &mesh,
-                    DViewCArrayKokkos <double> &node_coords,
-                    DViewCArrayKokkos <double> &node_vel,
-                    DViewCArrayKokkos <double> &elem_sspd,
-                    DViewCArrayKokkos <double> &elem_vol,
-                    double time_value,
-                    const double graphics_time,
-                    const double time_final,
-                    const double dt_max,
-                    const double dt_min,
-                    const double dt_cfl,
-                    double &dt,
-                    const double fuzz){
-
-    
+void
+get_timestep2D(mesh_t&                    mesh,
+               DViewCArrayKokkos<double>& node_coords,
+               DViewCArrayKokkos<double>& node_vel,
+               DViewCArrayKokkos<double>& elem_sspd,
+               DViewCArrayKokkos<double>& elem_vol,
+               double                     time_value,
+               const double               graphics_time,
+               const double               time_final,
+               const double               dt_max,
+               const double               dt_min,
+               const double               dt_cfl,
+               double&                    dt,
+               const double               fuzz)
+{
     // increase dt by 10%, that is the largest dt value
-    dt = dt*1.1;
+    dt = dt * 1.1;
 
     double dt_lcl;
     double min_dt_calc;
     REDUCE_MIN(elem_gid, 0, mesh.num_elems, dt_lcl, {
-        
         double coords0[8];  // element coords
-        ViewCArrayKokkos <double> coords(coords0, 4, 2);
+        ViewCArrayKokkos<double> coords(coords0, 4, 2);
 
-        
         double distance0[6];  // array for holding distances between each node
-        ViewCArrayKokkos <double> dist(distance0, 6);
-        
-        // Getting the coordinates of the nodes of the element
-        for(size_t node_lid = 0; node_lid < 4; node_lid++){
+        ViewCArrayKokkos<double> dist(distance0, 6);
 
-            for (size_t dim = 0; dim < mesh.num_dims; dim++){
-                coords(node_lid, dim) = node_coords(1,  mesh.nodes_in_elem(elem_gid, node_lid), dim);
+        // Getting the coordinates of the nodes of the element
+        for (size_t node_lid = 0; node_lid < 4; node_lid++)
+        {
+            for (size_t dim = 0; dim < mesh.num_dims; dim++)
+            {
+                coords(node_lid, dim) = node_coords(1, mesh.nodes_in_elem(elem_gid, node_lid), dim);
             } // end for dim
-            
         } // end for loop over node_lid
 
-        
         // Only works for 2D
         // Solving for the magnitude of distance between each node
         size_t count = 0;
-        for (size_t i = 0; i < 3; i++){
-            for (size_t j=i+1; j<=3; j++){
-                
+        for (size_t i = 0; i < 3; i++)
+        {
+            for (size_t j = i + 1; j <= 3; j++)
+            {
                 // returns magnitude of distance between each node, 6 total options
                 dist(count) = fabs(
-                                 sqrt( pow((coords(i, 0) - coords(j, 0)), 2.0)
-                                     + pow((coords(i, 1) - coords(j, 1)), 2.0) )
-                                  );
-                count ++;
+                                 sqrt(pow((coords(i, 0) - coords(j, 0)), 2.0)
+                        + pow((coords(i, 1) - coords(j, 1)), 2.0) )
+                    );
+                count++;
             } // end for j
         } // end for i
 
-
         double dist_min = dist(0);
-        
-        for(int i = 0; i < 6; ++i){
+
+        for (int i = 0; i < 6; ++i)
+        {
             dist_min = fmin(dist(i), dist_min);
         }
-        
+
         // local dt calc based on CFL
-        double dt_lcl_ = dt_cfl*dist_min/(elem_sspd(elem_gid) + fuzz);
-        
+        double dt_lcl_ = dt_cfl * dist_min / (elem_sspd(elem_gid) + fuzz);
+
         // make dt be in bounds
         dt_lcl_ = fmin(dt_lcl_, dt_max);    // make dt small than dt_max
         dt_lcl_ = fmax(dt_lcl_, dt_min);    // make dt larger than dt_min
-        
-       
-        if (dt_lcl_ < dt_lcl) dt_lcl = dt_lcl_;
-        
+
+        if (dt_lcl_ < dt_lcl)
+        {
+            dt_lcl = dt_lcl_;
+        }
     }, min_dt_calc);  // end parallel reduction
     Kokkos::fence();
-    
+
     // save the min dt
-    if(min_dt_calc < dt) dt = min_dt_calc;
-    
+    if (min_dt_calc < dt)
+    {
+        dt = min_dt_calc;
+    }
+
     // ensure time step hits the graphics time intervals
-    dt = fmin(dt, (graphics_time - time_value)+fuzz);
-    
+    dt = fmin(dt, (graphics_time - time_value) + fuzz);
+
     // make dt be exact for final time
-    dt = fmin(dt, time_final-time_value);
-    
+    dt = fmin(dt, time_final - time_value);
+
     return;
-    
 } // end get_timestep2D
-
-

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/time_integration.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/time_integration.cpp
@@ -5,14 +5,13 @@
 // -----------------------------------------------------------------------------
 // This function saves the variables at rk_stage = 0, which is t_n
 // ------------------------------------------------------------------------------
-void
-rk_init(DViewCArrayKokkos<double>& node_coords,
-        DViewCArrayKokkos<double>& node_vel,
-        DViewCArrayKokkos<double>& elem_sie,
-        DViewCArrayKokkos<double>& elem_stress,
-        const size_t               num_dims,
-        const size_t               num_elems,
-        const size_t               num_nodes)
+void rk_init(DViewCArrayKokkos<double>& node_coords,
+             DViewCArrayKokkos<double>& node_vel,
+             DViewCArrayKokkos<double>& elem_sie,
+             DViewCArrayKokkos<double>& elem_stress,
+             const size_t               num_dims,
+             const size_t               num_elems,
+             const size_t               num_nodes)
 {
     // save elem quantities
     FOR_ALL(elem_gid, 0, num_elems, {
@@ -46,20 +45,19 @@ rk_init(DViewCArrayKokkos<double>& node_coords,
 // between any two nodes in the mesh
 // ------------------------------------------------------------------------------
 // WARNING WARNING :  Only works for 3D, 8 node elements
-void
-get_timestep(mesh_t&                    mesh,
-             DViewCArrayKokkos<double>& node_coords,
-             DViewCArrayKokkos<double>& node_vel,
-             DViewCArrayKokkos<double>& elem_sspd,
-             DViewCArrayKokkos<double>& elem_vol,
-             double                     time_value,
-             const double               graphics_time,
-             const double               time_final,
-             const double               dt_max,
-             const double               dt_min,
-             const double               dt_cfl,
-             double&                    dt,
-             const double               fuzz)
+void get_timestep(mesh_t&                    mesh,
+                  DViewCArrayKokkos<double>& node_coords,
+                  DViewCArrayKokkos<double>& node_vel,
+                  DViewCArrayKokkos<double>& elem_sspd,
+                  DViewCArrayKokkos<double>& elem_vol,
+                  double                     time_value,
+                  const double               graphics_time,
+                  const double               time_final,
+                  const double               dt_max,
+                  const double               dt_min,
+                  const double               dt_cfl,
+                  double&                    dt,
+                  const double               fuzz)
 {
     // increase dt by 10%, that is the largest dt value
     dt = dt * 1.1;
@@ -154,20 +152,19 @@ get_timestep(mesh_t&                    mesh,
 // between any two nodes in the mesh
 // ------------------------------------------------------------------------------
 // WARNING WARNING :  Only works for 3D, 8 node elements
-void
-get_timestep2D(mesh_t&                    mesh,
-               DViewCArrayKokkos<double>& node_coords,
-               DViewCArrayKokkos<double>& node_vel,
-               DViewCArrayKokkos<double>& elem_sspd,
-               DViewCArrayKokkos<double>& elem_vol,
-               double                     time_value,
-               const double               graphics_time,
-               const double               time_final,
-               const double               dt_max,
-               const double               dt_min,
-               const double               dt_cfl,
-               double&                    dt,
-               const double               fuzz)
+void get_timestep2D(mesh_t&                    mesh,
+                    DViewCArrayKokkos<double>& node_coords,
+                    DViewCArrayKokkos<double>& node_vel,
+                    DViewCArrayKokkos<double>& elem_sspd,
+                    DViewCArrayKokkos<double>& elem_vol,
+                    double                     time_value,
+                    const double               graphics_time,
+                    const double               time_final,
+                    const double               dt_max,
+                    const double               dt_min,
+                    const double               dt_cfl,
+                    double&                    dt,
+                    const double               fuzz)
 {
     // increase dt by 10%, that is the largest dt value
     dt = dt * 1.1;

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat.cpp
@@ -1,70 +1,65 @@
 // -----------------------------------------------------------------------------
 // This code contains the constitutive relation for a user supplied model
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include "state.h"
 #include "mesh.h"
-
 
 // -----------------------------------------------------------------------------
 // This is the user material model function for the equation of state
 // An eos function must be supplied or the code will fail to run.
 // The pressure and sound speed can be calculated from an analytic eos.
 // The pressure can also be calculated using p = -1/3 Trace(Stress)
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void user_eos_model(const DViewCArrayKokkos <double> &elem_pres,
-                    const DViewCArrayKokkos <double> &elem_stress,
-                    const size_t elem_gid,
-                    const size_t mat_id,
-                    const DViewCArrayKokkos <double> &elem_state_vars,
-                    const DViewCArrayKokkos <double> &elem_sspd,
-                    const double den,
-                    const double sie){
-    
+void
+user_eos_model(const DViewCArrayKokkos<double>& elem_pres,
+               const DViewCArrayKokkos<double>& elem_stress,
+               const size_t                     elem_gid,
+               const size_t                     mat_id,
+               const DViewCArrayKokkos<double>& elem_state_vars,
+               const DViewCArrayKokkos<double>& elem_sspd,
+               const double                     den,
+               const double                     sie)
+{
     const int num_dims = 3;
-    
+
     // -----------------------------------------------------------------------------
     // Required variables are here
-    //------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------
     elem_pres(elem_gid) = 0.0;  // pressure
     elem_sspd(elem_gid) = 1.0e-8;  // sound speed
-    
+
     // pressure = 1/3tr(stress)
-    for (int i=0; i<num_dims; i++){
-        elem_pres(elem_gid) -= elem_stress(i,i);
+    for (int i = 0; i < num_dims; i++)
+    {
+        elem_pres(elem_gid) -= elem_stress(i, i);
     }
-    elem_pres(elem_gid) *= 1.0/3.0;
-    
-    
+    elem_pres(elem_gid) *= 1.0 / 3.0;
+
     return;
-    
 } // end for user_eos_model
-
-
-
-
 
 // -----------------------------------------------------------------------------
 // This is the user material model function for the stress tensor
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void user_strength_model(const DViewCArrayKokkos <double> &elem_pres,
-                         const DViewCArrayKokkos <double> &elem_stress,
-                         const size_t elem_gid,
-                         const size_t mat_id,
-                         const DViewCArrayKokkos <double> &elem_state_vars,
-                         const DViewCArrayKokkos <double> &elem_sspd,
-                         const double den,
-                         const double sie,
-                         const ViewCArrayKokkos <double> &vel_grad,
-                         const ViewCArrayKokkos <size_t> &elem_node_gids,
-                         const DViewCArrayKokkos <double> &node_coords,
-                         const DViewCArrayKokkos <double> &node_vel,
-                         const double vol,
-                         const double dt,
-                         const double rk_alpha){
-    
-
+void
+user_strength_model(const DViewCArrayKokkos<double>& elem_pres,
+                    const DViewCArrayKokkos<double>& elem_stress,
+                    const size_t                     elem_gid,
+                    const size_t                     mat_id,
+                    const DViewCArrayKokkos<double>& elem_state_vars,
+                    const DViewCArrayKokkos<double>& elem_sspd,
+                    const double                     den,
+                    const double                     sie,
+                    const ViewCArrayKokkos<double>&  vel_grad,
+                    const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                    const DViewCArrayKokkos<double>& node_coords,
+                    const DViewCArrayKokkos<double>& node_vel,
+                    const double                     vol,
+                    const double                     dt,
+                    const double                     rk_alpha)
+{
     // statev(0) = var_1
     //   :
     //   :
@@ -73,38 +68,34 @@ void user_strength_model(const DViewCArrayKokkos <double> &elem_pres,
 
     int num_dims = 3;
 
-    
     // -----------------------------------------------------------------------------
     // The user must coding goes here
-    //------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------
 
-    
     return;
-    
 } // end of user mat
-
 
 // -----------------------------------------------------------------------------
 // This is the user material model function
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void user_strength_model_vpsc(const DViewCArrayKokkos <double> &elem_pres,
-                              const DViewCArrayKokkos <double> &elem_stress,
-                              const size_t elem_gid,
-                              const size_t mat_id,
-                              const DViewCArrayKokkos <double> &elem_state_vars,
-                              const DViewCArrayKokkos <double> &elem_sspd,
-                              const double den,
-                              const double sie,
-                              const ViewCArrayKokkos <double> &vel_grad,
-                              const ViewCArrayKokkos <size_t> &elem_node_gids,
-                              const DViewCArrayKokkos <double> &node_coords,
-                              const DViewCArrayKokkos <double> &node_vel,
-                              const double vol,
-                              const double dt,
-                              const double rk_alpha){
-    
-
+void
+user_strength_model_vpsc(const DViewCArrayKokkos<double>& elem_pres,
+                         const DViewCArrayKokkos<double>& elem_stress,
+                         const size_t                     elem_gid,
+                         const size_t                     mat_id,
+                         const DViewCArrayKokkos<double>& elem_state_vars,
+                         const DViewCArrayKokkos<double>& elem_sspd,
+                         const double                     den,
+                         const double                     sie,
+                         const ViewCArrayKokkos<double>&  vel_grad,
+                         const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                         const DViewCArrayKokkos<double>& node_coords,
+                         const DViewCArrayKokkos<double>& node_vel,
+                         const double                     vol,
+                         const double                     dt,
+                         const double                     rk_alpha)
+{
     // statev(0) = var_1
     //   :
     //   :
@@ -112,27 +103,25 @@ void user_strength_model_vpsc(const DViewCArrayKokkos <double> &elem_pres,
     // statev(N) = var_N
 
     const int num_dims = 3;
-    
+
     // -----------------------------------------------------------------------------
     // Required variables are here
-    //------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------------
     elem_pres(elem_gid) = 1.0e-15;  // pressure
     elem_sspd(elem_gid) = 1.0e-15;  // sound speed
 
-    
     // -----------------------------------------------------------------------------
     // The user must coding goes here
-    //------------------------------------------------------------------------------
-    
+    // ------------------------------------------------------------------------------
+
     // For hypo-elastic models
     double D_tensor_values[9];
     double W_tensor_values[9];
 
     // convert to array syntax with the C-Language access pattern
-    ViewCArrayKokkos <double> D_tensor(D_tensor_values, num_dims, num_dims);  // D(i,j)
-    ViewCArrayKokkos <double> W_tensor(W_tensor_values, num_dims, num_dims);  // W(i,j)
-    
-    
+    ViewCArrayKokkos<double> D_tensor(D_tensor_values, num_dims, num_dims);  // D(i,j)
+    ViewCArrayKokkos<double> W_tensor(W_tensor_values, num_dims, num_dims);  // W(i,j)
+
     decompose_vel_grad(D_tensor,
                        W_tensor,
                        vel_grad,
@@ -141,28 +130,25 @@ void user_strength_model_vpsc(const DViewCArrayKokkos <double> &elem_pres,
                        node_coords,
                        node_vel,
                        vol);
-    
 
     // For hypo-elastic models
     double deps_values[9];
     double dW_values[9];
     double drot_values[9];
-    
-    ViewCMatrixKokkos <double> deps(&deps_values[0], num_dims, num_dims);
-    ViewCMatrixKokkos <double> dW(&dW_values[0], num_dims, num_dims);
-    ViewCMatrixKokkos <double> drot(&drot_values[0], num_dims, num_dims);
-    
+
+    ViewCMatrixKokkos<double> deps(&deps_values[0], num_dims, num_dims);
+    ViewCMatrixKokkos<double> dW(&dW_values[0], num_dims, num_dims);
+    ViewCMatrixKokkos<double> drot(&drot_values[0], num_dims, num_dims);
+
     // calculate strain and rotation increments
-    for (size_t i = 1; i <= 3; i++) {
-        for (size_t j = 1; j <= 3; j++) {
-            deps(i, j) = D_tensor(i-1,j-1)*dt; // infinitesimal strain increment
-            dW(i, j) = W_tensor(i-1,j-1)*dt;
+    for (size_t i = 1; i <= 3; i++)
+    {
+        for (size_t j = 1; j <= 3; j++)
+        {
+            deps(i, j) = D_tensor(i - 1, j - 1) * dt; // infinitesimal strain increment
+            dW(i, j)   = W_tensor(i - 1, j - 1) * dt;
         }
     } // end for
-    
-    
-    
-    return;
-    
-} // end of ideal_gas
 
+    return;
+} // end of ideal_gas

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat.cpp
@@ -11,15 +11,14 @@
 // The pressure can also be calculated using p = -1/3 Trace(Stress)
 // ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void
-user_eos_model(const DViewCArrayKokkos<double>& elem_pres,
-               const DViewCArrayKokkos<double>& elem_stress,
-               const size_t                     elem_gid,
-               const size_t                     mat_id,
-               const DViewCArrayKokkos<double>& elem_state_vars,
-               const DViewCArrayKokkos<double>& elem_sspd,
-               const double                     den,
-               const double                     sie)
+void user_eos_model(const DViewCArrayKokkos<double>& elem_pres,
+                    const DViewCArrayKokkos<double>& elem_stress,
+                    const size_t                     elem_gid,
+                    const size_t                     mat_id,
+                    const DViewCArrayKokkos<double>& elem_state_vars,
+                    const DViewCArrayKokkos<double>& elem_sspd,
+                    const double                     den,
+                    const double                     sie)
 {
     const int num_dims = 3;
 
@@ -43,22 +42,21 @@ user_eos_model(const DViewCArrayKokkos<double>& elem_pres,
 // This is the user material model function for the stress tensor
 // ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void
-user_strength_model(const DViewCArrayKokkos<double>& elem_pres,
-                    const DViewCArrayKokkos<double>& elem_stress,
-                    const size_t                     elem_gid,
-                    const size_t                     mat_id,
-                    const DViewCArrayKokkos<double>& elem_state_vars,
-                    const DViewCArrayKokkos<double>& elem_sspd,
-                    const double                     den,
-                    const double                     sie,
-                    const ViewCArrayKokkos<double>&  vel_grad,
-                    const ViewCArrayKokkos<size_t>&  elem_node_gids,
-                    const DViewCArrayKokkos<double>& node_coords,
-                    const DViewCArrayKokkos<double>& node_vel,
-                    const double                     vol,
-                    const double                     dt,
-                    const double                     rk_alpha)
+void user_strength_model(const DViewCArrayKokkos<double>& elem_pres,
+                         const DViewCArrayKokkos<double>& elem_stress,
+                         const size_t                     elem_gid,
+                         const size_t                     mat_id,
+                         const DViewCArrayKokkos<double>& elem_state_vars,
+                         const DViewCArrayKokkos<double>& elem_sspd,
+                         const double                     den,
+                         const double                     sie,
+                         const ViewCArrayKokkos<double>&  vel_grad,
+                         const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                         const DViewCArrayKokkos<double>& node_coords,
+                         const DViewCArrayKokkos<double>& node_vel,
+                         const double                     vol,
+                         const double                     dt,
+                         const double                     rk_alpha)
 {
     // statev(0) = var_1
     //   :
@@ -79,22 +77,21 @@ user_strength_model(const DViewCArrayKokkos<double>& elem_pres,
 // This is the user material model function
 // ------------------------------------------------------------------------------
 KOKKOS_FUNCTION
-void
-user_strength_model_vpsc(const DViewCArrayKokkos<double>& elem_pres,
-                         const DViewCArrayKokkos<double>& elem_stress,
-                         const size_t                     elem_gid,
-                         const size_t                     mat_id,
-                         const DViewCArrayKokkos<double>& elem_state_vars,
-                         const DViewCArrayKokkos<double>& elem_sspd,
-                         const double                     den,
-                         const double                     sie,
-                         const ViewCArrayKokkos<double>&  vel_grad,
-                         const ViewCArrayKokkos<size_t>&  elem_node_gids,
-                         const DViewCArrayKokkos<double>& node_coords,
-                         const DViewCArrayKokkos<double>& node_vel,
-                         const double                     vol,
-                         const double                     dt,
-                         const double                     rk_alpha)
+void user_strength_model_vpsc(const DViewCArrayKokkos<double>& elem_pres,
+                              const DViewCArrayKokkos<double>& elem_stress,
+                              const size_t                     elem_gid,
+                              const size_t                     mat_id,
+                              const DViewCArrayKokkos<double>& elem_state_vars,
+                              const DViewCArrayKokkos<double>& elem_sspd,
+                              const double                     den,
+                              const double                     sie,
+                              const ViewCArrayKokkos<double>&  vel_grad,
+                              const ViewCArrayKokkos<size_t>&  elem_node_gids,
+                              const DViewCArrayKokkos<double>& node_coords,
+                              const DViewCArrayKokkos<double>& node_vel,
+                              const double                     vol,
+                              const double                     dt,
+                              const double                     rk_alpha)
 {
     // statev(0) = var_1
     //   :

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat_init.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat_init.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 // This code contains the initialization of state vars for supplied models
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 #include <string.h>
 #include <sys/stat.h>
 #include <iostream>
@@ -13,31 +13,26 @@
 #include <vector>
 #include <algorithm>
 
-
-
 #include "mesh.h"
 #include "state.h"
 
-
-
-
 // -----------------------------------------------------------------------------
 // The function to read in the state vars for a user supplied model
-//------------------------------------------------------------------------------
-void user_model_init(const DCArrayKokkos <double> &file_state_vars,
-                     const size_t num_state_vars,
-                     const size_t mat_id,
-                     const size_t num_elems) {
-
+// ------------------------------------------------------------------------------
+void
+user_model_init(const DCArrayKokkos<double>& file_state_vars,
+                const size_t                 num_state_vars,
+                const size_t                 mat_id,
+                const size_t                 num_elems)
+{
     // initialize to zero
-    for (size_t elem_gid = 0; elem_gid<num_elems; elem_gid++) {
-        for(size_t var=0; var<num_state_vars; var++){
-            file_state_vars.host(mat_id,elem_gid,var) = 0.0;
+    for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++)
+    {
+        for (size_t var = 0; var < num_state_vars; var++)
+        {
+            file_state_vars.host(mat_id, elem_gid, var) = 0.0;
         }
     }
-    
 
-	return;
+    return;
 }
-
-

--- a/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat_init.cpp
+++ b/single-node/src/Explicit-Lagrange-Kokkos/SGH_solver/user_mat_init.cpp
@@ -19,11 +19,10 @@
 // -----------------------------------------------------------------------------
 // The function to read in the state vars for a user supplied model
 // ------------------------------------------------------------------------------
-void
-user_model_init(const DCArrayKokkos<double>& file_state_vars,
-                const size_t                 num_state_vars,
-                const size_t                 mat_id,
-                const size_t                 num_elems)
+void user_model_init(const DCArrayKokkos<double>& file_state_vars,
+                     const size_t                 num_state_vars,
+                     const size_t                 mat_id,
+                     const size_t                 num_elems)
 {
     // initialize to zero
     for (size_t elem_gid = 0; elem_gid < num_elems; elem_gid++)


### PR DESCRIPTION
# Description
<!---
Please include a summary of the changes and the related issue, if relevant. Please also include relevant motivation and context. List any new dependencies that are required for this change.
-->
This PR is a test run of Uncrustify for cleaning up and standardizing formatting in Fierro. I would like to get eyes on by a decent percentage of the team and feedback on what you like and don't like.  Once I have feedback I will update the config and do another pass. 

In the medium to long term, assuming we think it is worth it (I do), I think we should add [Uncrustify](https://github.com/uncrustify/uncrustify) to the build and automate the cleanup process per push. 

<!--- Fixes known issue # (if relevant) -->


## Type of change

Please select all relevant options

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [X] Test A : I rebuild the Explicit-Lagrange-Kokkos solver with openmp and ran the sedov problem. Results below:
- [ ] Test B: N/A (Let's start thinking about how to add unit test coverage). 

![Sedov_Density_Uncrustified](https://github.com/lanl/Fierro/assets/133793250/7b115355-c61c-4767-9752-a1a60a5a63e4)


**Test Configuration**:
* OS version: Rocky Linux
* Hardware: Intel(R) Xeon(R) CPU E5-1630 v3 @ 3.70GHz. NVidia M6000 24GB
* Compiler: gcc 12.2.0

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] The code builds from scratch with my new changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules