### PR TITLE
FEATURE: added script modifications to build with Cuda

### DIFF
--- a/scripts/build-fierro.sh
+++ b/scripts/build-fierro.sh
@@ -185,7 +185,7 @@ if [ "$build_action" = "full-app" ]; then
         source hdf5-install.sh
         source heffte-install.sh ${heffte_build_type} ${machine}
     fi
-    source cmake_build.sh ${solver}
+    source cmake_build.sh ${solver} ${heffte_build_type} ${kokkos_build_type}
 elif [ "$build_action" = "install-trilinos" ]; then
     source trilinos-install.sh ${kokkos_build_type}
 elif [ "$build_action" = "install-hdf5" ]; then
@@ -193,7 +193,7 @@ elif [ "$build_action" = "install-hdf5" ]; then
 elif [ "$build_action" = "install-heffte" ]; then
     source heffte-install.sh ${heffte_build_type} ${machine}
 elif [ "$build_action" = "fierro" ]; then
-    source cmake_build.sh ${solver} ${heffte_build_type}
+    source cmake_build.sh ${solver} ${heffte_build_type} ${kokkos_build_type}
 else
     echo "No build action, only setup the environment."
 fi

--- a/scripts/cmake_build.sh
+++ b/scripts/cmake_build.sh
@@ -2,6 +2,7 @@
 
 solver="${1}"
 heffte_build_type="${2}"
+kokkos_build_type="${3}"
 
 #inititialize submodules if they aren't downloaded
 [ -d "${libdir}/Elements/elements" ] && echo "Elements submodule exists"
@@ -97,6 +98,18 @@ else
     cmake_options+=(
         -D BUILD_PARALLEL_EXPLICIT_SOLVER=ON
         -D BUILD_IMPLICIT_SOLVER=OFF
+    )
+fi
+
+if [ "$kokkos_build_type" = "cuda" ]; then
+    export OMPI_CXX=${TRILINOS_SOURCE_DIR}/packages/kokkos/bin/nvcc_wrapper
+    cmake_options+=(
+        -D CMAKE_CXX_COMPILER=${TRILINOS_SOURCE_DIR}/packages/kokkos/bin/nvcc_wrapper
+    )
+elif [ "$kokkos_build_type" = "hip" ]; then
+    export OMPI_CXX=hipcc
+    cmake_options+=(
+        -D CMAKE_CXX_COMPILER=hipcc
     )
 fi
 


### PR DESCRIPTION
# Description
<!---
Modifications in the build scripts to build Fierro with Cuda. Somewhat of a feature add, somewhat of a bug fix. The template is also added to run with Hip, although that hasn't been tested. Accidentally changed this comment 
-->
Modifications in the build scripts to build Fierro with Cuda. Somewhat of a feature add, somewhat of a bug fix. The template is also added to run with Hip, although that hasn't been tested.

<!--- Fixes known issue # (if relevant) -->


## Type of change

Please select all relevant options

- [ x] New feature (non-breaking change which adds functionality)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

- [ ] Test A : Ran the standard explicit parallel Fierro with cuda. Built and ran, can't say results were validated. Of note, I was using a previous Cuda Trillions build so that I didn't have to rebuild it. Hopefully it works with a new build, will test that in the future. 
- [ ] Test B : 

**Test Configuration**:
* OS version: Linux (Darwin)
* Hardware: V100 gpus
* Compiler: GCC/OpenMPI/nvcc_wrapper

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] The code builds from scratch with my new changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
