### PR TITLE
Add Andrew Morgan's fix to regression script to ensure file times align

### DIFF
--- a/single-node-refactor/regression_tests/test_refactor.py
+++ b/single-node-refactor/regression_tests/test_refactor.py
@@ -72,8 +72,14 @@ for i in range(len(executables)):
 
         # Compare to standard results
         pattern = "state/mat_pt_state*"
-        file = glob.glob(pattern)
-        file_path = file[-1]
+        files = glob.glob(pattern)
+        
+        try: fileIndex = list(file.split("/")[-1] for file in files).index(standard_results[j].split("/")[-1])
+        except ValueError:
+            print("state file in test not found\n")
+            exit()  # no solution
+
+        file_path = files[fileIndex]
 
         print(file_path)
         print(standard_results[j])
@@ -86,12 +92,15 @@ for i in range(len(executables)):
             true = [row[k] for row in standard_data]
 
 
+
             for l in range(len(calc)):
                 diff = calc[l] - true[l]
                 # print(diff)
 
                 if abs(diff) > 1E-11:
                     print(diff)
+                    print(calc[l])
+                    print(true[l])
                     raise Exception("Results do not match for "+header1[k]+" for the "+tests[j]+" test!")
 
         # Remove simulated state dump


### PR DESCRIPTION
Added Andrew Morgan's fix to regression script to ensure file times align

# Description
Fixes a bug on some computers with python glob , that load files in random order versus a sequential order.



## Type of change

Please select all relevant options

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran the regression test on Mac, all tests now pass.

- [ X] Test A : ran regression tests

**Test Configuration**:
* OS version: MacOS
* Hardware: X86 CPU
* Compiler: clang

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] The code builds from scratch with my new changes
- [0] I have added tests that prove my fix is effective or that my feature works
- [0] New and existing unit tests pass locally with my changes
- [0] Any dependent changes have been merged and published in downstream modules
