### PR TITLE
Fix to issues with PVTU writer 12/24

### DIFF
--- a/src/EVPFFT/src/evpfft.cpp
+++ b/src/EVPFFT/src/evpfft.cpp
@@ -146,6 +146,11 @@ void EVPFFT::set_some_voxels_arrays_to_zero()
 void EVPFFT::init_after_reading_input_data()
 {
 
+    init_xk_gb();
+    init_disgradmacro();
+    init_ept();
+    init_evm();
+
 #ifndef ABSOLUTE_NO_OUTPUT
     if (iwfields == 1) {
       int imicro = 0;
@@ -153,11 +158,6 @@ void EVPFFT::init_after_reading_input_data()
       write_micro_state_pvtu();
     }
 #endif
-
-    init_xk_gb();
-    init_disgradmacro();
-    init_ept();
-    init_evm();
 
 // the variables initialized in the funcitons below are reduced into
 // and should be done once, hence the need for #if guard since the variables

--- a/src/EVPFFT/src/write_micro_state.cpp
+++ b/src/EVPFFT/src/write_micro_state.cpp
@@ -474,14 +474,17 @@ void EVPFFT::write_micro_state_pvtu()
   edotp.update_host();
 
   // Calculate point positions
-  MatrixTypeRealDevice xtmp(3);
   MatrixTypeRealDual defgradavg(3,3);
   MatrixTypeRealDual xintp(3,npts1+1,npts2+1,npts3+1);
   MatrixTypeIntHost pid(npts1+1,npts2+1,npts3+1);
 
   for (int ii = 1; ii <= 3; ii++) {
     for (int jj = 1; jj <= 3; jj++) {
-      defgradavg.host(ii,jj) = disgradmacroactual(ii,jj);
+      if (imicro==0) {
+        defgradavg.host(ii,jj) = 0.0;
+      } else {
+        defgradavg.host(ii,jj) = disgradmacroactual(ii,jj);
+      }
       if (ii==jj) {defgradavg.host(ii,jj) += 1.0;}
     }
   }
@@ -492,14 +495,15 @@ void EVPFFT::write_micro_state_pvtu()
           ky, 1, npts2+2,
           kx, 1, npts1+2, {
 
-        xtmp(1) = double(kx+local_start1)-0.5;
-        xtmp(2) = double(ky+local_start2)-0.5;
-        xtmp(3) = double(kz+local_start3)-0.5;
+        double xtmp[3];
+        xtmp[0] = (double)kx+(double)local_start1-0.5;
+        xtmp[1] = (double)ky+(double)local_start2-0.5;
+        xtmp[2] = (double)kz+(double)local_start3-0.5;
 
         for (int ii = 1; ii <= 3; ii++) {
           real_t dum = 0.0;
           for (int jj = 1; jj <= 3; jj++) {
-            dum += defgradavg(ii,jj)*xtmp(jj);
+            dum += defgradavg(ii,jj)*xtmp[jj-1];
           }
           xintp(ii,kx,ky,kz) = dum;
         }

--- a/src/LS-EVPFFT/src/evpfft.cpp
+++ b/src/LS-EVPFFT/src/evpfft.cpp
@@ -150,6 +150,13 @@ void EVPFFT::set_some_voxels_arrays_to_zero()
 void EVPFFT::init_after_reading_input_data()
 {
 
+    init_xk_gb();
+    init_disgradmacro_velgradmacro();
+    init_ept();
+    init_disgrad();
+    init_evm();
+    init_defgrad();
+
 #ifndef ABSOLUTE_NO_OUTPUT
     if (iwfields == 1) {
       int imicro = 0;
@@ -157,13 +164,6 @@ void EVPFFT::init_after_reading_input_data()
       write_micro_state_pvtu();
     }
 #endif
-
-    init_xk_gb();
-    init_disgradmacro_velgradmacro();
-    init_ept();
-    init_disgrad();
-    init_evm();
-    init_defgrad();
 
 // the variables initialized in the funcitons below are reduced into
 // and should be done once, hence the need for #if guard since the variables

--- a/src/LS-EVPFFT/src/write_micro_state.cpp
+++ b/src/LS-EVPFFT/src/write_micro_state.cpp
@@ -498,7 +498,6 @@ void EVPFFT::write_micro_state_pvtu()
   edotp.update_host();
 
   // Calculate point positions
-  MatrixTypeRealDevice xtmp(3);
   MatrixTypeRealDual defgradavg_dual(3,3);
   MatrixTypeRealDual uf(3,npts1_g,npts2_g,npts3_g);
   MatrixTypeRealDual ufintp(3,npts1+1,npts2+1,npts3+1);
@@ -517,13 +516,14 @@ void EVPFFT::write_micro_state_pvtu()
           ky, 1, npts2+1,
           kx, 1, npts1+1, {
 
-        xtmp(1) = double(kx);
-        xtmp(2) = double(ky);
-        xtmp(3) = double(kz);
+        double xtmp[3];
+        xtmp[0] = double(kx);
+        xtmp[1] = double(ky);
+        xtmp[2] = double(kz);
         for (int ii = 1; ii <= 3; ii++) {
           real_t dum = 0.0;
           for (int jj = 1; jj <= 3; jj++) {
-            dum += defgradavg_dual(ii,jj)*xtmp(jj);
+            dum += defgradavg_dual(ii,jj)*xtmp[jj-1];
           }
           uf(ii,kx+local_start1,ky+local_start2,kz+local_start3) = xnode(ii,kx,ky,kz) - dum;
         }
@@ -589,14 +589,15 @@ void EVPFFT::write_micro_state_pvtu()
           ky, 1, npts2+2,
           kx, 1, npts1+2, {
 
-        xtmp(1) = double(kx+local_start1)-0.5;
-        xtmp(2) = double(ky+local_start2)-0.5;
-        xtmp(3) = double(kz+local_start3)-0.5;
+        double xtmp[3];
+        xtmp[0] = double(kx+local_start1)-0.5;
+        xtmp[1] = double(ky+local_start2)-0.5;
+        xtmp[2] = double(kz+local_start3)-0.5;
 
         for (int ii = 1; ii <= 3; ii++) {
           real_t dum = 0.0;
           for (int jj = 1; jj <= 3; jj++) {
-            dum += defgradavg_dual(ii,jj)*xtmp(jj);
+            dum += defgradavg_dual(ii,jj)*xtmp[jj-1];
           }
           xintp(ii,kx,ky,kz) = dum + ufintp(ii,kx,ky,kz);
         }

--- a/src/LS-EVPFFT/src/write_micro_state.cpp
+++ b/src/LS-EVPFFT/src/write_micro_state.cpp
@@ -499,12 +499,20 @@ void EVPFFT::write_micro_state_pvtu()
 
   // Calculate point positions
   MatrixTypeRealDevice xtmp(3);
+  MatrixTypeRealDual defgradavg_dual(3,3);
   MatrixTypeRealDual uf(3,npts1_g,npts2_g,npts3_g);
   MatrixTypeRealDual ufintp(3,npts1+1,npts2+1,npts3+1);
   MatrixTypeRealDual xintp(3,npts1+1,npts2+1,npts3+1);
   MatrixTypeIntHost pid(npts1+1,npts2+1,npts3+1);
 
-  FOR_ALL(
+  for (int ii = 1; ii <= 3; ii++) {
+    for (int jj = 1; jj <= 3; jj++) {
+      defgradavg_dual.host(ii,jj) = defgradavg(ii,jj);
+    }
+  }
+  defgradavg_dual.update_device();
+  
+  FOR_ALL_CLASS(
           kz, 1, npts3+1,
           ky, 1, npts2+1,
           kx, 1, npts1+1, {
@@ -515,17 +523,17 @@ void EVPFFT::write_micro_state_pvtu()
         for (int ii = 1; ii <= 3; ii++) {
           real_t dum = 0.0;
           for (int jj = 1; jj <= 3; jj++) {
-            dum += defgradavg(ii,jj)*xtmp(jj);
+            dum += defgradavg_dual(ii,jj)*xtmp(jj);
           }
           uf(ii,kx+local_start1,ky+local_start2,kz+local_start3) = xnode(ii,kx,ky,kz) - dum;
         }
-  }); // end FOR_ALL
+  }); // end FOR_ALL_CLASS
   Kokkos::fence();
   uf.update_host();
 
   MPI_Allreduce(MPI_IN_PLACE, uf.host_pointer(), n, MPI_REAL_T, MPI_SUM, mpi_comm);
 
-  FOR_ALL(
+  FOR_ALL_CLASS(
           kz, 1, npts3+2,
           ky, 1, npts2+2,
           kx, 1, npts1+2, {
@@ -572,11 +580,11 @@ void EVPFFT::write_micro_state_pvtu()
           ufintp(ii,kx,ky,kz) = 0.125*(uf(ii,kxn1,kyn1,kzn1)+uf(ii,kxn2,kyn1,kzn1)+uf(ii,kxn1,kyn2,kzn1)+uf(ii,kxn2,kyn2,kzn1)+
           uf(ii,kxn1,kyn1,kzn2)+uf(ii,kxn2,kyn1,kzn2)+uf(ii,kxn1,kyn2,kzn2)+uf(ii,kxn2,kyn2,kzn2) );
         }
-  }); // end FOR_ALL
+  }); // end FOR_ALL_CLASS
   Kokkos::fence();
   ufintp.update_host();
 
-  FOR_ALL(
+  FOR_ALL_CLASS(
           kz, 1, npts3+2,
           ky, 1, npts2+2,
           kx, 1, npts1+2, {
@@ -588,11 +596,11 @@ void EVPFFT::write_micro_state_pvtu()
         for (int ii = 1; ii <= 3; ii++) {
           real_t dum = 0.0;
           for (int jj = 1; jj <= 3; jj++) {
-            dum += defgradavg(ii,jj)*xtmp(jj);
+            dum += defgradavg_dual(ii,jj)*xtmp(jj);
           }
           xintp(ii,kx,ky,kz) = dum + ufintp(ii,kx,ky,kz);
         }
-  }); // end FOR_ALL
+  }); // end FOR_ALL_CLASS
   Kokkos::fence();
   xintp.update_host();
 
@@ -794,7 +802,6 @@ void EVPFFT::write_micro_state_pvtu()
   out.open(filename,std::ofstream::binary);
 
   byte_offset = 0;
-  double crap = 0.0;
   
   //  Write Header
   //tmp_str = "<?xml version=\"1.0\"?>\n";
@@ -1033,7 +1040,7 @@ void EVPFFT::write_micro_state_pvtu()
       for (int kx = 1; kx <= npts1+1; kx++){
         ic += 1;
         for (int dim = 1; dim <= num_dims; dim++){
-          coord_tmp = xintp(dim,kx,ky,kz);
+          coord_tmp = xintp.host(dim,kx,ky,kz);
           out.write((char *) &coord_tmp,sizeof(coord_tmp));
         }
         pid(kx,ky,kz) = ic;
@@ -1101,7 +1108,6 @@ void EVPFFT::write_micro_state_pvtu()
   // for (int node_gid = 0; node_gid < num_points; node_gid++){
   //   for (int dim = 0; dim < num_dims; dim++){
   //     //out.write((char *) &node_vel.host(1, node_gid, dim),sizeof(double));
-  //     out.write((char *) &crap,sizeof(double));
   //   }
   // }
 
@@ -1264,7 +1270,6 @@ void EVPFFT::write_micro_state_pvtu()
   // for (int elem_gid = 0; elem_gid < num_cells; elem_gid++){
   //   for (int ii = 0; ii < 9; ii++){
   //     //out.write((char *) &elem_stress.host(1,elem_gid,ii),sizeof(double));
-  //     out.write((char *) &crap,sizeof(double));
   //   }
   // }
   // //  Density


### PR DESCRIPTION
# Description
Fixed issues with PVTU writer associated with running on GPUs. Also moved the t=0 viz output code to after many inits to ensure fields are defined. 

<!--- Fixes known issue # (if relevant) -->
Adapted GPU incompatible variables to local dual arrays for use within FOR_ALL.
Converted FOR_ALL's within writer to FOR_ALL_CLASS's to use non-local variables correctly.

## Type of change

Please select all relevant options

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran code on GPUs without crashing at viz output step due to memory issues.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The code builds from scratch with my new changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
