### PR TITLE
EVPFFT viz fix for non-cube voxels

### DIFF
--- a/src/EVPFFT/src/write_micro_state.cpp
+++ b/src/EVPFFT/src/write_micro_state.cpp
@@ -505,7 +505,7 @@ void EVPFFT::write_micro_state_pvtu()
           for (int jj = 1; jj <= 3; jj++) {
             dum += defgradavg(ii,jj)*xtmp[jj-1];
           }
-          xintp(ii,kx,ky,kz) = dum;
+          xintp(ii,kx,ky,kz) = dum*delt(ii);
         }
   }); // end FOR_ALL_CLASS
   Kokkos::fence();

--- a/src/LS-EVPFFT/src/evpfft.cpp
+++ b/src/LS-EVPFFT/src/evpfft.cpp
@@ -424,7 +424,7 @@ void EVPFFT::init_defgrad() {
       for (int ii = 1; ii <= 3; ii++) {
         defgradavg(jj,ii) = 0.0;
       }
-      defgradavg(jj,jj) = delt(jj);
+      defgradavg(jj,jj) = 1.0;
     } 
   }); // end FOR_ALL_CLASS
 

--- a/src/LS-EVPFFT/src/write_micro_state.cpp
+++ b/src/LS-EVPFFT/src/write_micro_state.cpp
@@ -599,7 +599,7 @@ void EVPFFT::write_micro_state_pvtu()
           for (int jj = 1; jj <= 3; jj++) {
             dum += defgradavg_dual(ii,jj)*xtmp[jj-1];
           }
-          xintp(ii,kx,ky,kz) = dum + ufintp(ii,kx,ky,kz);
+          xintp(ii,kx,ky,kz) = (dum + ufintp(ii,kx,ky,kz))*delt(ii);
         }
   }); // end FOR_ALL_CLASS
   Kokkos::fence();


### PR DESCRIPTION
# Description
Added code in both small and large strain EVPFFT pvtu writers so that output reflects proper RVE size and spacing from input file. Also fixed code in large strain EVPFFT that was causing non-identity RVE values to produce broken visualizations.

<!--- Fixes known issue # (if relevant) -->


## Type of change

Please select all relevant options

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran with non-uniform size and spacing RVE lattice and confirmed output visualized correctly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The code builds from scratch with my new changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
