### PR TITLE
added x-, y-, and z-scaling of .geo meshes

### DIFF
--- a/single-node-refactor/input-lattice.yaml
+++ b/single-node-refactor/input-lattice.yaml
@@ -8,10 +8,6 @@ dynamic_options:
     cycle_stop: 300000
 
 
-# mesh_options:
-#     source: file
-#     file_path: /var/tmp/repos/Fierro/fork/Fierro/testing/meshes/mesh_Sedov_8.geo
-
 mesh_options:
     source: generate
     num_dims: 3
@@ -85,6 +81,7 @@ materials:
         eos_model_type: decoupled
         eos_model: gamma_law_gas
         # strength_model: none
+        dissipation_model: MARS
         dissipation_global_vars:
             - 1.0   # q1
             - 1.0   # q1ex
@@ -113,7 +110,6 @@ regions:
     - fill_volume:
         type: voxel_file
         file_path: ../../VTK_Geometry_lattice.vtk 
-        #/Users/nmorgan/Documents/Fierro/REPO/2024_06_21/Fierro/single-node-refactor/VTK_Geometry_lattice.vtk
         material_id: 1
         den: 2.0
         sie: 0.001

--- a/single-node-refactor/src/common/include/mesh_io.h
+++ b/single-node-refactor/src/common/include/mesh_io.h
@@ -268,17 +268,20 @@ public:
         // x-coords
         for (int node_id = 0; node_id < mesh.num_nodes; node_id++) {
             fscanf(in, "%le", &node.coords.host(0, node_id, 0));
+            node.coords.host(0, node_id, 0)*= mesh_inps.scale_x;
         }
 
         // y-coords
         for (int node_id = 0; node_id < mesh.num_nodes; node_id++) {
             fscanf(in, "%le", &node.coords.host(0, node_id, 1));
+            node.coords.host(0, node_id, 1)*= mesh_inps.scale_y;
         }
 
         // z-coords
         for (int node_id = 0; node_id < mesh.num_nodes; node_id++) {
             if (num_dims == 3) {
                 fscanf(in, "%le", &node.coords.host(0, node_id, 2));
+                node.coords.host(0, node_id, 2)*= mesh_inps.scale_z;
             }
             else{
                 double dummy;


### PR DESCRIPTION
# Description
added x, y, and z dimensional scaling of ensight .geo meshes.  This capability was already available with vtk meshes.  Now users can read in an existing mesh and scale the dimensions.


## Type of change

Please select all relevant options

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [X] Test A :  Ran regression tests
- [X] Test B :  Read in a .geo unstructured mesh and scaled it

**Test Configuration**:
* OS version: MacOS
* Hardware: x86 CPU
* Compiler: clang

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The code builds from scratch with my new changes
- [x] New and existing unit tests pass locally with my changes
