### PR TITLE
linked the region fills to solver and added solver_id to input parsing

### DIFF
--- a/single-node-refactor/input-bending-plate.yaml
+++ b/single-node-refactor/input-bending-plate.yaml
@@ -126,6 +126,7 @@ regions:
         volume:
             type: global
         material_id: 0
+        solver_id: 0
         den: 1.0
         sie: 1.0e-10
 

--- a/single-node-refactor/input-impact-erosion.yaml
+++ b/single-node-refactor/input-impact-erosion.yaml
@@ -131,6 +131,7 @@ regions:
         volume:
             type: global
         material_id: 2
+        solver_id: 0
         den: 0.010
         sie: 3.0e-4
         velocity: 
@@ -151,6 +152,7 @@ regions:
             z1: 0.0
             z2: 0.2
         material_id: 0
+        solver_id: 0
         den: 8.0
         sie: 1.0e-6
         velocity: 
@@ -171,6 +173,7 @@ regions:
             z1: 0.0
             z2: 1.2
         material_id: 1
+        solver_id: 0
         den: 2.7
         sie: 1.0e-6 
         velocity: 

--- a/single-node-refactor/input-lattice.yaml
+++ b/single-node-refactor/input-lattice.yaml
@@ -132,6 +132,7 @@ regions:
         volume:
             type: global
         material_id: 0
+        solver_id: 0
         den: 1.0
         sie: 1.e-10
         velocity: 
@@ -150,6 +151,7 @@ regions:
             scale_z: 0.040635127
             origin: [-0.5, -0.5, 0.]
         material_id: 1
+        solver_id: 0
         den: 7.86
         sie: 1.e-10
         velocity: 

--- a/single-node-refactor/input-noh-rz.yaml
+++ b/single-node-refactor/input-noh-rz.yaml
@@ -89,6 +89,7 @@ regions:
         volume:
             type: global
         material_id: 0
+        solver_id: 0
         den: 1.0
         sie: 1.e-10
         velocity: 

--- a/single-node-refactor/input-noh.yaml
+++ b/single-node-refactor/input-noh.yaml
@@ -99,6 +99,7 @@ regions:
         volume:
             type: global
         material_id: 0
+        solver_id: 0
         den: 1.0
         sie: 1.e-10
         velocity: 

--- a/single-node-refactor/input-origin-erosion.yaml
+++ b/single-node-refactor/input-origin-erosion.yaml
@@ -137,6 +137,7 @@ regions:
             radius1: 0.0
             radius2: 0.1
         material_id: 0
+        solver_id: 0
         den: 1.0
         # ie: 0.25833839995946534
         sie: 61.67375002 # 963.652344

--- a/single-node-refactor/input-pressure-bc.yaml
+++ b/single-node-refactor/input-pressure-bc.yaml
@@ -161,6 +161,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10

--- a/single-node-refactor/input-rz-polar.yaml
+++ b/single-node-refactor/input-rz-polar.yaml
@@ -106,6 +106,7 @@ regions:
         volume:
             type: global
         material_id: 0
+        solver_id: 0
         den: 1.0
         sie: 1.e-10
         velocity: 
@@ -123,6 +124,7 @@ regions:
             origin: [0.0, 0.0, 0.0]
             radius1: 0.0
             radius2: 0.1
+        solver_id: 0
         material_id: 0
         den: 1.0
         # ie: 0.25833839995946534

--- a/single-node-refactor/input-rz.yaml
+++ b/single-node-refactor/input-rz.yaml
@@ -106,6 +106,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10
@@ -124,6 +125,7 @@ regions:
             origin: [0.0, 0.0, 0.0]
             radius1: 0.0
             radius2: 0.1
+        solver_id: 0
         material_id: 0
         den: 1.0
         # ie: 0.25833839995946534

--- a/single-node-refactor/input-sgtm-test.yaml
+++ b/single-node-refactor/input-sgtm-test.yaml
@@ -160,6 +160,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10

--- a/single-node-refactor/input-vtu.yaml
+++ b/single-node-refactor/input-vtu.yaml
@@ -90,6 +90,7 @@ regions:
         volume:
             type: vtu_file
             part_id: 1
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10

--- a/single-node-refactor/input.yaml
+++ b/single-node-refactor/input.yaml
@@ -103,6 +103,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10
@@ -121,6 +122,7 @@ regions:
             origin: [0.0, 0.0, 0.0]
             radius1: 0.0
             radius2: 0.1
+        solver_id: 0
         material_id: 0
         den: 1.0
         # ie: 0.25833839995946534

--- a/single-node-refactor/regression_tests/standard_inputs/Abaqus_read.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Abaqus_read.yaml
@@ -118,6 +118,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10
@@ -153,6 +154,7 @@ regions:
             z1: 0.0
             z2: 1.0
         material_id: 0
+        solver_id: 0
         den: 1.0
         sie: 61.67375002
         velocity: 

--- a/single-node-refactor/regression_tests/standard_inputs/Noh.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Noh.yaml
@@ -61,6 +61,7 @@ materials:
 regions:
   - volume: 
       type: global
+    solver_id: 0
     material_id: 0
     den: 1.0
     sie: 1.e-10

--- a/single-node-refactor/regression_tests/standard_inputs/Pressure_bc_box.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Pressure_bc_box.yaml
@@ -161,6 +161,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10

--- a/single-node-refactor/regression_tests/standard_inputs/SGTM_cooling_cube.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/SGTM_cooling_cube.yaml
@@ -160,6 +160,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10

--- a/single-node-refactor/regression_tests/standard_inputs/Sedov.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Sedov.yaml
@@ -87,6 +87,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-14
@@ -105,6 +106,7 @@ regions:
             origin: [0.0, 0.0, 0.0]
             radius1: 0.0
             radius2: 0.1
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 61.67375002 

--- a/single-node-refactor/regression_tests/standard_inputs/Sedov_Erosion.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Sedov_Erosion.yaml
@@ -119,6 +119,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 0.001
@@ -137,6 +138,7 @@ regions:
             origin: [0.0, 0.0, 0.0]
             radius1: 0.0
             radius2: 0.1
+        solver_id: 0
         material_id: 0
         den: 1.0
         # ie: 0.25833839995946534

--- a/single-node-refactor/regression_tests/standard_inputs/Sedov_Read_Ensight.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Sedov_Read_Ensight.yaml
@@ -82,6 +82,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-14
@@ -100,6 +101,7 @@ regions:
             origin: [0.0, 0.0, 0.0]
             radius1: 0.0
             radius2: 0.1
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 61.67375002 

--- a/single-node-refactor/regression_tests/standard_inputs/Sedov_rz_polar.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Sedov_rz_polar.yaml
@@ -99,6 +99,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10
@@ -117,6 +118,7 @@ regions:
             origin: [0.0, 0.0, 0.0]
             radius1: 0.0
             radius2: 0.1
+        solver_id: 0
         material_id: 0
         den: 1.0
         # ie: 0.25833839995946534

--- a/single-node-refactor/regression_tests/standard_inputs/Sod_X.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Sod_X.yaml
@@ -124,6 +124,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 2.5
@@ -142,6 +143,7 @@ regions:
             y2: 0.01
             z1: 0.0
             z2: 0.01
+        solver_id: 0
         material_id: 0
         den: 0.125
         sie: 2

--- a/single-node-refactor/regression_tests/standard_inputs/Sod_Y.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Sod_Y.yaml
@@ -124,6 +124,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 2.5
@@ -142,6 +143,7 @@ regions:
             y2: 1.0
             z1: 0.0
             z2: 0.01
+        solver_id: 0
         material_id: 0
         den: 0.125
         sie: 2

--- a/single-node-refactor/regression_tests/standard_inputs/Sod_Z.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/Sod_Z.yaml
@@ -122,6 +122,7 @@ regions:
     - region:
         volume:
             type: global
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 2.5
@@ -140,6 +141,7 @@ regions:
             y2: 0.01
             z1: 0.5
             z2: 1.0
+        solver_id: 0
         material_id: 0
         den: 0.125
         sie: 2

--- a/single-node-refactor/regression_tests/standard_inputs/vtu_read.yaml
+++ b/single-node-refactor/regression_tests/standard_inputs/vtu_read.yaml
@@ -90,6 +90,7 @@ regions:
         volume:
             type: vtu_file
             part_id: 1
+        solver_id: 0
         material_id: 0
         den: 1.0
         sie: 1.e-10

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/include/sgh_solver_3D.h
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/include/sgh_solver_3D.h
@@ -178,21 +178,20 @@ public:
     // **** Functions defined in sgh_setup.cpp **** //
     void fill_regions_sgh(
         const Material_t& Materials,
-        const Mesh_t&     mesh,
-        const DCArrayKokkos<double>& node_coords,
-        DCArrayKokkos<double>& node_vel,
-        DCArrayKokkos<double>& GaussPoint_den,
-        DCArrayKokkos<double>& GaussPoint_sie,
+        const Mesh_t& mesh,
+        const DCArrayKokkos <double>& node_coords,
+        DCArrayKokkos <double>& node_vel,
+        DCArrayKokkos <double>& GaussPoint_den,
+        DCArrayKokkos <double>& GaussPoint_sie,
         DCArrayKokkos <double>& GaussPoint_volfrac,
         DCArrayKokkos <size_t>& elem_mat_id,
         DCArrayKokkos <size_t>& num_mats_saved_in_elem,
-        DCArrayKokkos<size_t>& voxel_elem_mat_id,
+        DCArrayKokkos <size_t>& voxel_elem_mat_id,
         const DCArrayKokkos <int>& object_ids,
-        const CArrayKokkos<RegionFill_t>& region_fills,
-        const CArray<RegionFill_host_t>&  region_fills_host,
-        const size_t num_fills,
-        const size_t num_elems,
-        const size_t num_nodes,
+        const DCArrayKokkos<size_t>& reg_fills_in_solver,
+        const CArrayKokkos <RegionFill_t>& region_fills,
+        const CArray <RegionFill_host_t>& region_fills_host,
+        const size_t num_fills_in_solver,
         const size_t rk_num_bins) const;
 
     void init_corner_node_masses_zero(

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_setup.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_setup.cpp
@@ -81,65 +81,73 @@ void SGH3D::init_corner_node_masses_zero(const Mesh_t& mesh,
 /// \param mesh is the simulation mesh
 /// \param node_coords are the coordinates of the nodes
 /// \param node_vel is the nodal velocity array
-/// \param region_fills are the instructures to paint state on the mesh
-/// \param voxel_elem_mat_id are the voxel values on a structured i,j,k mesh
 /// \param GaussPoint_den is density at the GaussPoints on the mesh
 /// \param GaussPoint_sie is specific internal energy at the GaussPoints on the mesh
 /// \param GaussPoint_volfrac is volume fraction at the GaussPoints on the mesh
 /// \param elem_mat_id is the material id in an element
 /// \param num_mats_saved_in_elem is the number of material with volfrac<1 saved to the element
-/// \param num_fills is number of fill instruction
+/// \param voxel_elem_mat_id are the voxel values on a structured i,j,k mesh
+/// \param object_ids are the object ids in the vtu file
+/// \param reg_fills_in_solver are the regions to fill for this solver
+/// \param region_fills are the instructures to paint state on the mesh
+/// \param region_fills_host are the instructures on the host side to paint state on the mesh
+/// \param num_fills_in_solver is number of fill instruction for the solver
 /// \param num_elems is number of elements on the mesh
 /// \param num_nodes is number of nodes on the mesh
 /// \param rk_num_bins is number of time integration storage bins
 ///
 /////////////////////////////////////////////////////////////////////////////
-void SGH3D::fill_regions_sgh(const Material_t& Materials,
-                      const Mesh_t& mesh,
-                      const DCArrayKokkos <double>& node_coords,
-                      DCArrayKokkos <double>& node_vel,
-                      DCArrayKokkos <double>& GaussPoint_den,
-                      DCArrayKokkos <double>& GaussPoint_sie,
-                      DCArrayKokkos <double>& GaussPoint_volfrac,
-                      DCArrayKokkos <size_t>& elem_mat_id,
-                      DCArrayKokkos <size_t>& num_mats_saved_in_elem,
-                      DCArrayKokkos <size_t>& voxel_elem_mat_id,
-                      const DCArrayKokkos <int>& object_ids,
-                      const CArrayKokkos <RegionFill_t>& region_fills,
-                      const CArray <RegionFill_host_t>& region_fills_host,
-                      const size_t num_fills,
-                      const size_t num_elems,
-                      const size_t num_nodes,
-                      const size_t rk_num_bins) const
+void SGH3D::fill_regions_sgh(
+        const Material_t& Materials,
+        const Mesh_t& mesh,
+        const DCArrayKokkos <double>& node_coords,
+        DCArrayKokkos <double>& node_vel,
+        DCArrayKokkos <double>& GaussPoint_den,
+        DCArrayKokkos <double>& GaussPoint_sie,
+        DCArrayKokkos <double>& GaussPoint_volfrac,
+        DCArrayKokkos <size_t>& elem_mat_id,
+        DCArrayKokkos <size_t>& num_mats_saved_in_elem,
+        DCArrayKokkos <size_t>& voxel_elem_mat_id,
+        const DCArrayKokkos <int>& object_ids,
+        const DCArrayKokkos<size_t>& reg_fills_in_solver,
+        const CArrayKokkos <RegionFill_t>& region_fills,
+        const CArray <RegionFill_host_t>& region_fills_host,
+        const size_t num_fills_in_solver,
+        const size_t rk_num_bins) const
 {
     double voxel_dx, voxel_dy, voxel_dz;          // voxel mesh resolution, set by input file
     double orig_x, orig_y, orig_z;                // origin of voxel elem center mesh, set by input file
     size_t voxel_num_i, voxel_num_j, voxel_num_k; // num voxel elements in each direction, set by input file
 
+    size_t num_fills_total = region_fills.size();  // the total number of fills in the input file
+
     // ---------------------------------------------
     // copy to host, enum to read a voxel file
     // ---------------------------------------------
+    DCArrayKokkos<size_t> read_voxel_file(num_fills_total, "read_voxel_file"); // check to see if readVoxelFile
 
-    DCArrayKokkos<size_t> read_voxel_file(num_fills, "read_voxel_file"); // check to see if readVoxelFile
-
-    FOR_ALL(f_id, 0, num_fills, {
-        if (region_fills(f_id).volume == region::readVoxelFile) {
-            read_voxel_file(f_id) = region::readVoxelFile;  // read the  voxel file
+    FOR_ALL(fill_id, 0, num_fills_total, {
+        if (region_fills(fill_id).volume == region::readVoxelFile) {
+            read_voxel_file(fill_id) = region::readVoxelFile;  // read the  voxel file
         }
         // add other mesh voxel files
         else{
-            read_voxel_file(f_id) = 0;
+            read_voxel_file(fill_id) = 0;
         }
     }); // end parallel for
     read_voxel_file.update_host(); // copy to CPU if code is to read a file
     Kokkos::fence();
     // ---------------------------------------------
 
-    // loop over the fill instructions
-    for (size_t f_id = 0; f_id < num_fills; f_id++) {
+    // loop over the fill instructions for this solver
+    for (size_t f_lid = 0; f_lid < num_fills_in_solver; f_lid++) {
+
+        // get the fill id
+        size_t fill_id = reg_fills_in_solver.host(this->solver_id, f_lid);
+
         // ----
         // voxel mesh setup
-        if (read_voxel_file.host(f_id) == region::readVoxelFile) {
+        if (read_voxel_file.host(fill_id) == region::readVoxelFile) {
             // read voxel mesh to get the values in the fcn interface
             user_voxel_init(voxel_elem_mat_id,
                             voxel_dx,
@@ -151,10 +159,10 @@ void SGH3D::fill_regions_sgh(const Material_t& Materials,
                             voxel_num_i,
                             voxel_num_j,
                             voxel_num_k,
-                            region_fills_host(f_id).scale_x,
-                            region_fills_host(f_id).scale_y,
-                            region_fills_host(f_id).scale_z,
-                            region_fills_host(f_id).file_path);
+                            region_fills_host(fill_id).scale_x,
+                            region_fills_host(fill_id).scale_y,
+                            region_fills_host(fill_id).scale_z,
+                            region_fills_host(fill_id).file_path);
 
             // copy values read from file to device
             voxel_elem_mat_id.update_device();
@@ -162,7 +170,7 @@ void SGH3D::fill_regions_sgh(const Material_t& Materials,
           // add else if for other mesh reads including STL-2-voxel
 
         // parallel loop over elements in mesh
-        FOR_ALL(elem_gid, 0, num_elems, {
+        FOR_ALL(elem_gid, 0, mesh.num_elems, {
             // calculate the coordinates and radius of the element
             double elem_coords_1D[3]; // note:initialization with a list won't work
             ViewCArrayKokkos<double> elem_coords(&elem_coords_1D[0], 3);
@@ -200,7 +208,7 @@ void SGH3D::fill_regions_sgh(const Material_t& Materials,
                                                      voxel_num_i,
                                                      voxel_num_j,
                                                      voxel_num_k,
-                                                     f_id,
+                                                     fill_id,
                                                      elem_gid);
 
             // paint the material state on the element if fill_this=1
@@ -218,7 +226,7 @@ void SGH3D::fill_regions_sgh(const Material_t& Materials,
                                     region_fills,
                                     elem_coords,
                                     elem_gid,
-                                    f_id);
+                                    fill_id);
 
                 // add user defined paint here
                 // user_defined_sgh_state();
@@ -235,7 +243,7 @@ void SGH3D::fill_regions_sgh(const Material_t& Materials,
                                 node_coords,
                                 node_gid,
                                 mesh.num_dims,
-                                f_id,
+                                fill_id,
                                 rk_num_bins);
 
                     // add user defined paint here
@@ -269,8 +277,8 @@ void SGH3D::setup(SimulationParameters_t& SimulationParamaters,
                 BoundaryCondition_t& Boundary,
                 State_t& State)
 {
-    size_t num_fills = SimulationParamaters.region_fills.size();
-    printf("Num Fills's = %zu\n", num_fills);
+    size_t num_fills_in_solver = SimulationParamaters.region_setups.num_reg_fills_in_solver.host(this->solver_id);
+    printf("Num fills's = %zu\n in solver = %zu", num_fills_in_solver, this->solver_id);
 
     // the number of elems and nodes in the mesh
     const size_t num_elems = mesh.num_elems;
@@ -312,14 +320,13 @@ void SGH3D::setup(SimulationParameters_t& SimulationParamaters,
                      num_mats_saved_in_elem,
                      voxel_elem_mat_id,
                      SimulationParamaters.mesh_input.object_ids,
-                     SimulationParamaters.region_fills,
-                     SimulationParamaters.region_fills_host,
-                     num_fills,
-                     num_elems,
-                     num_nodes,
+                     SimulationParamaters.region_setups.reg_fills_in_solver,
+                     SimulationParamaters.region_setups.region_fills,
+                     SimulationParamaters.region_setups.region_fills_host,
+                     num_fills_in_solver,
                      rk_num_bins);
 
-    std::cout << "finished fill regions_sgh \n" << std::endl;
+    //std::cout << "finished fill regions_sgh \n" << std::endl;
 
     // note: the device and host side are updated in the above function
     // ---------------------------------------------
@@ -357,11 +364,13 @@ void SGH3D::setup(SimulationParameters_t& SimulationParamaters,
     // ---------------------------------------
     //  SGH allocation of maps and state
     // ---------------------------------------
-    State.MaterialToMeshMaps = CArray<MaterialToMeshMap_t>(num_mats);
+    State.MaterialToMeshMaps = CArray<MaterialToMeshMap_t>(num_mats); // WARNING: for multisolver need .size() check
 
-    State.MaterialPoints  = CArray<MaterialPoint_t>(num_mats);
-    State.MaterialCorners = CArray<MaterialCorner_t>(num_mats);
+    State.MaterialPoints  = CArray<MaterialPoint_t>(num_mats);  // WARNING: for multisolver need .size() check
+    State.MaterialCorners = CArray<MaterialCorner_t>(num_mats); // WARNING: for multisolver need .size() check
     // zones not needed with SGH
+
+    // WARNING: for multisolver use .size() check above to decide about entering the following loop
 
     // for ALE SGH, add a buffer to num_elems_for_mat, like 10% of num_elems up to num_elems.
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/include/sgh_solver_rz.h
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/include/sgh_solver_rz.h
@@ -195,11 +195,10 @@ public:
         DCArrayKokkos <size_t>& num_mats_saved_in_elem,
         DCArrayKokkos <size_t>& voxel_elem_mat_id,
         const DCArrayKokkos <int>& object_ids,
+        const DCArrayKokkos<size_t>& reg_fills_in_solver,
         const CArrayKokkos <RegionFill_t>& region_fills,
         const CArray <RegionFill_host_t>& region_fills_host,
-        const size_t num_fills,
-        const size_t num_elems,
-        const size_t num_nodes,
+        const size_t num_fills_in_solver,
         const size_t rk_num_bins) const;
                         
     void init_corner_node_masses_zero_rz(

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/include/sgtm_solver_3D.h
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/include/sgtm_solver_3D.h
@@ -197,8 +197,10 @@ public:
         DCArrayKokkos <size_t>& elem_region_id,
         DCArrayKokkos <size_t>& node_region_id,
         const DCArrayKokkos<int>& object_ids,
+        const DCArrayKokkos<size_t>& reg_fills_in_solver,
         const CArrayKokkos<RegionFill_t>& region_fills,
-        const CArray<RegionFill_host_t>&  region_fills_host) const;
+        const CArray<RegionFill_host_t>&  region_fills_host,
+        size_t num_fills_in_solver) const;
 
     void init_corner_node_masses_zero(
         const Mesh_t& mesh,

--- a/single-node-refactor/src/common/include/boundary_conditions.h
+++ b/single-node-refactor/src/common/include/boundary_conditions.h
@@ -265,15 +265,15 @@ struct BoundaryCondition_t
     size_t num_bcs; // the number of boundary conditions
 
     // making a psuedo dual ragged right
-    DCArrayKokkos<size_t> vel_bdy_sets_in_solver;     // (solver, bc_ids)
-    DCArrayKokkos<size_t> num_vel_bdy_sets_in_solver; // (solver)
+    DCArrayKokkos<size_t> vel_bdy_sets_in_solver;     // (solver_id, bc_lid)
+    DCArrayKokkos<size_t> num_vel_bdy_sets_in_solver; // (solver_id)
 
-    DCArrayKokkos<size_t> stress_bdy_sets_in_solver;     // (solver, bc_ids)
-    DCArrayKokkos<size_t> num_stress_bdy_sets_in_solver; // (solver)
+    DCArrayKokkos<size_t> stress_bdy_sets_in_solver;     // (solver_id, bc_lid)
+    DCArrayKokkos<size_t> num_stress_bdy_sets_in_solver; // (solver_id)
 
     // keep adding ragged storage for the other BC models -- temp, displacement, etc.
-    DCArrayKokkos<size_t> temperature_bdy_sets_in_solver;     // (solver, ids)
-    DCArrayKokkos<size_t> num_temperature_bdy_sets_in_solver; // (solver)
+    DCArrayKokkos<size_t> temperature_bdy_sets_in_solver;     // (solver_id, lids)
+    DCArrayKokkos<size_t> num_temperature_bdy_sets_in_solver; // (solver_id)
 
 
     CArrayKokkos<BoundaryConditionSetup_t> BoundaryConditionSetup;  // vars to setup the bcs, accessed using (bc_id)

--- a/single-node-refactor/src/common/include/region.h
+++ b/single-node-refactor/src/common/include/region.h
@@ -37,6 +37,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <map>
 
+#include "matar.h"
+
 #include "initial_conditions.h"
 
 // ==============================================================================
@@ -80,6 +82,9 @@ struct RegionFill_t
 {
     // type
     region::vol_tag volume; ///< Type of volume for this region eg. global, box, sphere, planes, etc.
+
+    // solver id
+    size_t solver_id; ///< solver ID for this region
 
     // material id
     size_t material_id; ///< Material ID for this region
@@ -140,11 +145,30 @@ struct RegionFill_host_t
     double scale_z = 1.0;
 };
 
+
+/////////////////////////////////////////////////////////////////////////////
+///
+/// \struct SolverRegionSetup_t
+///
+/// \brief Contains kokkos arrays of fill instructions for the regions
+///
+/////////////////////////////////////////////////////////////////////////////
+struct SolverRegionSetup_t
+{
+    mtr::DCArrayKokkos<size_t> reg_fills_in_solver;     // (solver_id, fill_lid)
+    mtr::DCArrayKokkos<size_t> num_reg_fills_in_solver; // (solver_id)
+
+    mtr::CArrayKokkos<RegionFill_t> region_fills;  ///< Region data for simulation mesh, set the initial conditions
+    mtr::CArray<RegionFill_host_t> region_fills_host;  ///< Region data on CPU, set the initial conditions
+};
+
+
 // ----------------------------------
 // valid inputs for a material fill
 // ----------------------------------
 static std::vector<std::string> str_region_inps
 {
+    "solver_id",
     "volume",
     "material_id",
     "velocity",
@@ -195,6 +219,7 @@ static std::vector<std::string> str_region_vel_inps
 // ----------------------------------
 static std::vector<std::string> region_required_inps
 {
+    "solver_id",
     "material_id",
     "volume"
 };

--- a/single-node-refactor/src/common/include/simulation_parameters.h
+++ b/single-node-refactor/src/common/include/simulation_parameters.h
@@ -62,9 +62,8 @@ struct SimulationParameters_t
 
     std::vector<solver_input_t> solver_inputs;  ///< Solvers to use during the simulation
 
-    CArrayKokkos<RegionFill_t> region_fills;  ///< Region data for simulation mesh, set the initial conditions
+    SolverRegionSetup_t region_setups;  ///< region fills across all solvers
 
-    CArray<RegionFill_host_t> region_fills_host;  ///< Region data on CPU, set the initial conditions
 }; // simulation_parameters_t
 
 #endif // end Header Guard

--- a/single-node-refactor/src/input/parse_yaml.cpp
+++ b/single-node-refactor/src/input/parse_yaml.cpp
@@ -1105,6 +1105,8 @@ void parse_regions(Yaml::Node& root,
     // allocate memory
     num_reg_fills_in_solver = DCArrayKokkos<size_t>(num_solvers, "sim_param.region_setup.num_reg_fills_in_solver");
     num_reg_fills_in_solver.set_values(0);
+    Kokkos::fence();
+    num_reg_fills_in_solver.update_host();
 
 
     Yaml::Node& region_yaml = root["regions"];
@@ -1143,7 +1145,7 @@ void parse_regions(Yaml::Node& root,
                 size_t fill_lid = num_reg_fills_in_solver.host(solver_id);
 
                 // save the fill_id, which is the reg_id
-                reg_fills_in_solver(solver_id, fill_lid) = reg_id;
+                reg_fills_in_solver.host(solver_id, fill_lid) = reg_id;
                 num_reg_fills_in_solver.host(solver_id) ++;
 
                 RUN({

--- a/single-node-refactor/src/input/parse_yaml.cpp
+++ b/single-node-refactor/src/input/parse_yaml.cpp
@@ -1106,7 +1106,7 @@ void parse_regions(Yaml::Node& root,
     num_reg_fills_in_solver = DCArrayKokkos<size_t>(num_solvers, "sim_param.region_setup.num_reg_fills_in_solver");
     num_reg_fills_in_solver.set_values(0);
     Kokkos::fence();
-    num_reg_fills_in_solver.update_host();
+    num_reg_fills_in_solver.update_host(); // initiallizing host side to 0
 
 
     Yaml::Node& region_yaml = root["regions"];

--- a/single-node-refactor/src/input/parse_yaml.h
+++ b/single-node-refactor/src/input/parse_yaml.h
@@ -101,8 +101,11 @@ void parse_output_options(Yaml::Node& root, output_options_t& output_options);
 
 // parse the region text
 void parse_regions(Yaml::Node& root, 
-                   CArrayKokkos<RegionFill_t>& region_fills,
-                   CArray<RegionFill_host_t>& region_fills_host);
+                   DCArrayKokkos<size_t>& reg_fills_in_solver,  
+                   DCArrayKokkos<size_t>& num_reg_fills_in_solver,
+                   CArrayKokkos<RegionFill_t>& region_fills, 
+                   CArray<RegionFill_host_t>&  region_fills_host,
+                   const size_t num_solvers);
 
 // parse the region text
 void parse_materials(Yaml::Node& root, Material_t& Materials, const size_t num_dims);


### PR DESCRIPTION
# Description
Made region definitions tied to a solver.  Now each solver only runs the region fills assigned to it.


## Type of change

Please select all relevant options

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [X] Test A : Regression tests on CPU
- [X] Test B :  Regression tests on GPU

**Test Configuration**:
* OS version: MacOS
* Hardware: X86
* Compiler: clang

* OS version: Linux
* Hardware: Intel X86 + V100 GPU
* Compiler: gcc

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] The code builds from scratch with my new changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
