### PR TITLE
updated Titpon to use material volume change in sie update

### DIFF
--- a/single-node-refactor/example_inputs/input-multimat.yaml
+++ b/single-node-refactor/example_inputs/input-multimat.yaml
@@ -1,0 +1,213 @@
+# num_dims: 3
+# UNITS: g, cm, micro second, MegaBar
+
+dynamic_options:
+    time_final: 10.0
+    dt_min: 1.e-8
+    dt_max: 1.e-2
+    dt_start: 1.e-5
+    cycle_stop: 1000
+
+mesh_options:
+    source: generate
+    num_dims: 3
+    type: box
+    origin: [0.0, 0.0, 0.0]
+    length: [1.0, 1.0, 2.0] 
+    num_elems: [1, 1, 1]
+
+output_options:
+    timer_output_level: thorough
+    output_file_format: viz # only options are viz or viz_and_state
+    graphics_time_step: 0.025
+    # graphics_iteration_step: 10
+    elem_field_outputs:
+        - den
+        - pres
+        - stress
+        - sie
+        - mass
+    mat_pt_field_outputs:
+        - den
+        - pres
+        - sie
+        - volfrac
+    node_field_outputs:
+        - vel
+        - mass
+
+solver_options:
+  - solver:
+        method: dynx_FE
+        id: 0
+        # solver_vars:
+        #  - blah
+        #  - blah
+        #  - blah
+
+boundary_conditions:
+    # Tag -X plane
+    - boundary_condition:
+        solver_id: 0
+        surface:
+            type: x_plane
+            plane_position: 0.0
+            tolerance: 1.e-5
+        velocity_model: reflected
+        velocity_bc_global_vars:
+            - 1 # x
+            - 0 # y
+            - 0 # z
+            
+#    # Tag +X plane
+    - boundary_condition:
+        solver_id: 0
+        surface:
+            type: x_plane
+            plane_position: 1.0
+            tolerance: 1.e-5
+        velocity_model: reflected
+        velocity_bc_global_vars:
+            - 1 # x
+            - 0 # y
+            - 0 # z
+
+    # Tag -Y plane
+    - boundary_condition:
+        solver_id: 0
+        surface:
+            type: y_plane
+            plane_position: 0.0
+        velocity_model: reflected
+        velocity_bc_global_vars:
+            - 0 # x
+            - 1 # y
+            - 0 # z
+
+#    # Tag +Y plane
+    - boundary_condition:
+        solver_id: 0
+        surface:
+            type: y_plane
+            plane_position: 1.0
+        velocity_model: reflected
+        velocity_bc_global_vars:
+            - 0 # x
+            - 1 # y
+            - 0 # z
+
+    # Tag +z plane
+    - boundary_condition:
+        solver_id: 0
+        surface:
+            type: z_plane
+            plane_position: 0.0
+        velocity_model: reflected
+        velocity_bc_global_vars:
+            - 0 # x
+            - 0 # y
+            - 1 # z
+            
+#    # Tag -z plane
+    - boundary_condition:
+        solver_id: 0
+        surface:
+            type: z_plane
+            plane_position: 2.0
+        velocity_model: fixed
+        velocity_bc_global_vars:
+            - 0 # x
+            - 0 # y
+            - 1 # z
+
+  
+materials:
+    - material:
+        id: 0
+        eos_model_type: decoupled
+        eos_model: gamma_law_gas
+        eos_global_vars:
+            - 1.666666666666667
+            - 1.0E-4
+            - 1.0
+        # strength_model: none
+        dissipation_model: MARS
+        dissipation_global_vars:
+            - 1.0   # q1
+            - 1.0   # q1ex
+            - 1.333 # q2
+            - 1.333 # q2ex
+            - 1.0   # phi_min
+            - 1.0   # pin_curl_min
+
+    - material:
+        id: 1
+        eos_model_type: decoupled
+        eos_model: gamma_law_gas
+        eos_global_vars:
+            - 10 #1.666666666666667
+            - 1.0E-4
+            - 1.0
+        # strength_model: none
+        dissipation_model: MARS
+        dissipation_global_vars:
+            - 1.0   # q1
+            - 1.0   # q1ex
+            - 1.333 # q2
+            - 1.333 # q2ex
+            - 1.0   # phi_min
+            - 1.0   # pin_curl_min
+
+
+multimaterial_options:
+    max_num_mats_per_element: 3 # allow for up to 3 materials in an element during setup and for reverse map
+
+    mat_equilibration_model: tipton #no_equilibration #tipton
+    mat_equilibration_global_vars:
+        - 0.01   # max volume fraction change
+        - 1.0 # pressure relax coeff (delta P)/coef
+
+regions:
+    # gas
+    - region:
+        volume:
+            type: global
+        solver_id: 0
+        material_id: 0
+        density:
+            type: uniform
+            value: 1.14
+        specific_internal_energy:
+            type: uniform
+            value: 1.e-10
+        velocity:
+            type: cartesian
+            u: 0.0
+            v: 0.0
+            w: 0.0
+        volume_fraction:
+            type: uniform
+            value: 0.5
+
+    # notional metal
+    - region:
+        volume:
+            type: global
+        solver_id: 0
+        material_id: 1
+        density:
+            type: uniform
+            value: 2.7
+        specific_internal_energy:
+            type: uniform
+            value: 0.2
+        velocity:
+            type: cartesian
+            u: 0.0
+            v: 0.0
+            w: 0.0
+        volume_fraction:
+            type: uniform
+            value: 0.5
+            
+        

--- a/single-node-refactor/src/material_models/equilibration/include/tipton_equilibration.hpp
+++ b/single-node-refactor/src/material_models/equilibration/include/tipton_equilibration.hpp
@@ -117,7 +117,7 @@ namespace TiptonEquilibrationModel {
         const size_t num_mat_elems);        
 
 
-        void update_volfrac_sie (
+        void update_volfrac_den_sie (
             const Mesh_t& mesh,
             const CArrayKokkos<double>& GaussPoint_pres,
             const CArrayKokkos <double>& GaussPoint_volfrac_limiter,
@@ -126,6 +126,7 @@ namespace TiptonEquilibrationModel {
             const DCArrayKokkos<double>& MaterialPoints_volfrac,
             const DCArrayKokkos<double>& MaterialPoints_delta_volfrac,
             const DCArrayKokkos<double>& MaterialPoint_sie,
+            const DCArrayKokkos<double>& MaterialPoint_den,
             const DCArrayKokkos<double>& MaterialPoint_mass,
             const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
             const points_in_mat_t& points_in_mat_elem,


### PR DESCRIPTION
# Description
Changed the way specific internal energy is updated in the Tipton model.  The volume change of a material is used in place of the element volume change.


## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Test A :  Test suite
- [X] Test B :  A single element test case involving 3 materials

**Test Configuration**:
* OS version: Mac OS
* Hardware: X86
* Compiler: clang++

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] The code builds from scratch with my new changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
