### PR TITLE
Material centric

### DIFF
--- a/single-node-refactor/src/Solvers/SGH_solver_3D/include/sgh_solver_3D.h
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/include/sgh_solver_3D.h
@@ -249,8 +249,9 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_mass,
         const DCArrayKokkos<double>& MaterialCorners_force,
         const corners_in_mat_t corners_in_mat_elem,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-        const size_t num_mat_elems) const;
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const size_t num_mat_elems,
+        const size_t mat_id) const;
 
     // **** Functions defined in force_sgh.cpp **** //
     void get_force(
@@ -271,7 +272,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_volfrac,
         const DCArrayKokkos<double>& MaterialPoints_geo_volfrac,
         const corners_in_mat_t,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double fuzz,
@@ -342,7 +343,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
         const DCArrayKokkos<bool>&   MaterialPoints_eroded,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const double time_value,
         const double dt,
         const double rk_alpha,
@@ -366,7 +367,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_eos_state_vars,
         const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double fuzz,
@@ -399,7 +400,7 @@ public:
         DCArrayKokkos<double>& GaussPoints_vol,
         DCArrayKokkos<double>& MaterialPoints_sspd,
         DCArrayKokkos<bool>&   MaterialPoints_eroded,
-        DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         size_t num_mat_elems,
         double time_value,
         const double graphics_time,
@@ -409,7 +410,8 @@ public:
         const double dt_cfl,
         double&      dt,
         const double fuzz,
-        const double tiny) const;
+        const double tiny,
+        const size_t mat_id) const;
 
     // **** Functions defined in user_mat.cpp **** //
     // NOTE: Pull up into high level

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/energy_sgh.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/energy_sgh.cpp
@@ -62,14 +62,15 @@ void SGH3D::update_energy(const double rk_alpha,
     const DCArrayKokkos<double>& MaterialPoints_mass,
     const DCArrayKokkos<double>& MaterialCorners_force,
     const corners_in_mat_t corners_in_mat_elem,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-    const size_t num_mat_elems
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const size_t num_mat_elems,
+    const size_t mat_id
     ) const
 {
     // loop over all the elements in the mesh
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
         // the material point index = the material elem index for a 1-point element
         size_t mat_point_lid = mat_elem_lid;

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/force_sgh.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/force_sgh.cpp
@@ -83,7 +83,7 @@ void SGH3D::get_force(const Material_t& Materials,
                       const DCArrayKokkos<double>& MaterialPoints_volfrac,
                       const DCArrayKokkos<double>& MaterialPoints_geo_volfrac,
                       const corners_in_mat_t corners_in_mat_elem,
-                      const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                      const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                       const size_t num_mat_elems,
                       const size_t mat_id,
                       const double fuzz,
@@ -99,7 +99,7 @@ void SGH3D::get_force(const Material_t& Materials,
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         // the material point index = the material elem index for a 1-point element
         size_t mat_point_lid = mat_elem_lid;

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/properties.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/properties.cpp
@@ -84,7 +84,7 @@ void SGH3D::update_state(
     const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
     const DCArrayKokkos<bool>&   MaterialPoints_eroded,
     const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const double time_value,
     const double dt,
     const double rk_alpha,
@@ -100,7 +100,7 @@ void SGH3D::update_state(
         // loop over all the elements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_material_elems, {
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // get the material points for this material
             // Note, with the SGH method, they are equal
@@ -148,7 +148,7 @@ void SGH3D::update_state(
         // loop over all the elements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_material_elems, {
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // get the material points for this material
             // Note, with the SGH method, they are equal
@@ -171,7 +171,7 @@ void SGH3D::update_state(
         // loop over all the elements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_material_elems, {
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // get the material points for this material
             // Note, with the SGH method, they are equal
@@ -218,7 +218,7 @@ void SGH3D::update_state(
         // loop over all the elements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_material_elems, {
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // get the material points for this material
             // Note, with the SGH method, they are equal
@@ -304,7 +304,7 @@ void SGH3D::update_stress(
     const DCArrayKokkos<double>& MaterialPoints_eos_state_vars,
     const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
     const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const size_t num_mat_elems,
     const size_t mat_id,
     const double fuzz,
@@ -334,7 +334,7 @@ void SGH3D::update_stress(
         for (size_t mat_elem_lid=0; mat_elem_lid<num_mat_elems; mat_elem_lid++){
 
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem.host(mat_elem_lid); 
+            size_t elem_gid = MaterialToMeshMaps_elem.host(mat_id, mat_elem_lid); 
 
 
             size_t gauss_gid = elem_gid;
@@ -385,7 +385,7 @@ void SGH3D::update_stress(
         FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
             size_t gauss_gid = elem_gid;
 

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_execute.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_execute.cpp
@@ -195,8 +195,8 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
                          State.GaussPoints.vol,
                          State.MaterialPoints(mat_id).sspd,
                          State.MaterialPoints(mat_id).eroded,
-                         State.MaterialToMeshMaps(mat_id).elem,
-                         State.MaterialToMeshMaps(mat_id).num_material_elems,
+                         State.MaterialToMeshMaps.elem,
+                         State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                          time_value,
                          graphics_time,
                          time_final,
@@ -205,7 +205,8 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
                          dt_cfl,
                          dt_mat,
                          fuzz,
-                         tiny);
+                         tiny,
+                         mat_id);
 
             // save the smallest dt of all materials
             min_dt_calc = fmin(dt_mat, min_dt_calc);
@@ -261,8 +262,6 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
             // ---- calculate the forces on the vertices and evolve stress (hypo model) ----
             for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-                size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
                 get_force(Materials,
                           mesh,
                           State.GaussPoints.vol,
@@ -280,8 +279,8 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
                           State.MaterialPoints(mat_id).volfrac,
                           State.MaterialPoints(mat_id).geo_volfrac,
                           State.corners_in_mat_elem,
-                          State.MaterialToMeshMaps(mat_id).elem,
-                          num_mat_elems,
+                          State.MaterialToMeshMaps.elem,
+                          State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                           mat_id,
                           fuzz,
                           small,
@@ -304,8 +303,8 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
                                   State.MaterialPoints(mat_id).eos_state_vars,
                                   State.MaterialPoints(mat_id).strength_state_vars,
                                   State.MaterialPoints(mat_id).shear_modulii,
-                                  State.MaterialToMeshMaps(mat_id).elem,
-                                  num_mat_elems,
+                                  State.MaterialToMeshMaps.elem,
+                                  State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                                   mat_id,
                                   fuzz,
                                   small,
@@ -365,8 +364,9 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
                               State.MaterialPoints(mat_id).mass,
                               State.MaterialCorners(mat_id).force,
                               State.corners_in_mat_elem,
-                              State.MaterialToMeshMaps(mat_id).elem,
-                              State.MaterialToMeshMaps(mat_id).num_material_elems);
+                              State.MaterialToMeshMaps.elem,
+                              State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                              mat_id);
             } // end for mat_id
 
             // ---- Update nodal positions ----
@@ -387,8 +387,6 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
             // ---- Calculate MaterialPoints state (den, pres, sound speed, stress) for next time step ----
             for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-                size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
                 update_state(Materials,
                              mesh,
                              State.node.coords,
@@ -408,12 +406,12 @@ void SGH3D::execute(SimulationParameters_t& SimulationParamaters,
                              State.MaterialPoints(mat_id).strength_state_vars,
                              State.MaterialPoints(mat_id).eroded,
                              State.MaterialPoints(mat_id).shear_modulii,
-                             State.MaterialToMeshMaps(mat_id).elem,
+                             State.MaterialToMeshMaps.elem,
                              time_value,
                              dt,
                              rk_alpha,
                              cycle,
-                             num_mat_elems,
+                             State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                              mat_id);
             } // end for mat_id
 

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_initialize.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_initialize.cpp
@@ -89,21 +89,17 @@ void SGH3D::initialize_material_state(SimulationParameters_t& SimulationParamate
     // -----
     //  Allocation of state must include a buffer with ALE
     // -----
-
-    // IMPORTANT, make buffer a parser input variable
-    // for ALE, add a buffer to num_elems_for_mat, like 10% of num_elems up to num_elems.
-    const size_t buffer = 0; // memory buffer to push back into
+    
+    State.MaterialToMeshMaps.initialize();
 
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {
 
         const size_t num_mat_pts_in_elem = mesh.num_leg_gauss_in_elem; 
 
-        size_t num_elems_for_mat = State.MaterialToMeshMaps(mat_id).num_material_elems + buffer; // has a memory buffer for ALE
+        const size_t num_elems_for_mat_buffer = State.MaterialToMeshMaps.num_material_elems_buffer.host(mat_id); // has a memory buffer for ALE
+        const size_t num_points_for_mat  = num_elems_for_mat_buffer * num_mat_pts_in_elem;
+        const size_t num_corners_for_mat = num_elems_for_mat_buffer * mesh.num_nodes_in_elem;
 
-        size_t num_points_for_mat  = num_elems_for_mat * num_mat_pts_in_elem;
-        size_t num_corners_for_mat = num_elems_for_mat * mesh.num_nodes_in_elem;
-
-        State.MaterialToMeshMaps(mat_id).initialize(num_elems_for_mat);
         State.MaterialPoints(mat_id).initialize(num_points_for_mat, 3, SGH3D_State::required_material_pt_state); // note: dims is always 3 
         State.MaterialCorners(mat_id).initialize(num_corners_for_mat, 3, SGH3D_State::required_material_corner_state);
         // zones are not used with solver

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_setup.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/sgh_setup.cpp
@@ -70,7 +70,7 @@ void SGH3D::setup(SimulationParameters_t& SimulationParamaters,
                         mesh,
                         State.MaterialPoints(mat_id).eos_state_vars,
                         State.MaterialPoints(mat_id).strength_state_vars,
-                        State.MaterialToMeshMaps(mat_id).elem,
+                        State.MaterialToMeshMaps.elem,
                         num_mat_points,
                         mat_id);
 
@@ -94,16 +94,16 @@ void SGH3D::setup(SimulationParameters_t& SimulationParamaters,
 
     // calculate corner and node masses on the mesh
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {
-        size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
 
         calc_corner_mass(Materials,
-                            mesh,
-                            State.node.coords,
-                            State.node.mass,
-                            State.corner.mass,
-                            State.MaterialPoints(mat_id).mass,
-                            State.MaterialToMeshMaps(mat_id).elem,
-                            num_mat_elems);
+                         mesh,
+                         State.node.coords,
+                         State.node.mass,
+                         State.corner.mass,
+                         State.MaterialPoints(mat_id).mass,
+                         State.MaterialToMeshMaps.elem,
+                         State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                         mat_id);
     } // end for mat_id
 
     calc_node_mass(mesh,

--- a/single-node-refactor/src/Solvers/SGH_solver_3D/src/time_integration.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_3D/src/time_integration.cpp
@@ -112,7 +112,7 @@ void SGH3D::get_timestep(Mesh_t& mesh,
                        DCArrayKokkos<double>& GaussPoints_vol,
                        DCArrayKokkos<double>& MaterialPoints_sspd,
                        DCArrayKokkos<bool>&   MaterialPoints_eroded,
-                       DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                       DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                        size_t num_mat_elems,
                        double time_value,
                        const double graphics_time,
@@ -122,7 +122,8 @@ void SGH3D::get_timestep(Mesh_t& mesh,
                        const double dt_cfl,
                        double&      dt,
                        const double fuzz,
-                       const double tiny) const
+                       const double tiny,
+                       const size_t mat_id) const
 {
     // increase dt by 10%, that is the largest dt value
     dt = dt * 1.1;
@@ -130,7 +131,7 @@ void SGH3D::get_timestep(Mesh_t& mesh,
     double dt_lcl;
     double min_dt_calc;
     FOR_REDUCE_MIN(mat_elem_lid, 0, num_mat_elems, dt_lcl, {
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
         double coords0[24];  // element coords
         ViewCArrayKokkos<double> coords(coords0, 8, 3);

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/include/sgh_solver_rz.h
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/include/sgh_solver_rz.h
@@ -220,8 +220,9 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_mass,
         const DCArrayKokkos<double>& MaterialCorners_force,
         const corners_in_mat_t corners_in_mat_elem,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-        const size_t num_mat_elems) const;
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const size_t num_mat_elems,
+        const size_t mat_id) const;
 
 
     void get_force_rz(
@@ -242,7 +243,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_volfrac,
         const DCArrayKokkos<double>& MaterialPoints_geo_volfrac,
         const corners_in_mat_t,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double fuzz,
@@ -312,7 +313,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
         const DCArrayKokkos<bool>&   MaterialPoints_eroded,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const double time_value,
         const double dt,
         const double rk_alpha,
@@ -336,7 +337,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_eos_state_vars,
         const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double fuzz,
@@ -371,7 +372,7 @@ public:
         DCArrayKokkos<double>& GaussPoints_vol,
         DCArrayKokkos<double>& MaterialPoints_sspd,
         DCArrayKokkos<bool>&   MaterialPoints_eroded,
-        DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         size_t num_mat_elems,
         double time_value,
         const double graphics_time,
@@ -381,7 +382,8 @@ public:
         const double dt_cfl,
         double&      dt,
         const double fuzz,
-        const double tiny) const;
+        const double tiny,
+        const size_t mat_id) const;
 
 
 };
@@ -392,8 +394,9 @@ void calc_corner_mass_rz(const Material_t& Materials,
                          const DCArrayKokkos<double>& node_mass,
                          const DCArrayKokkos<double>& corner_mass,
                          const DCArrayKokkos<double>& MaterialPoints_den,
-                         const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-                         const size_t num_mat_elems);
+                         const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                         const size_t num_mat_elems,
+                         const size_t mat_id);
 
 void calc_node_mass_rz(const Mesh_t& mesh,
                     const DCArrayKokkos<double>& node_coords,

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/energy_sgh_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/energy_sgh_rz.cpp
@@ -65,8 +65,9 @@ void SGHRZ::update_energy_rz(
       const DCArrayKokkos<double>& MaterialPoints_mass,
       const DCArrayKokkos<double>& MaterialCorners_force,
       const corners_in_mat_t corners_in_mat_elem,
-      const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-      const size_t num_mat_elems
+      const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+      const size_t num_mat_elems,
+      const size_t mat_id
     ) const
 {
 
@@ -74,7 +75,7 @@ void SGHRZ::update_energy_rz(
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         // the material point index = the material elem index for a 1-point element
         size_t mat_point_lid = mat_elem_lid;

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/force_sgh_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/force_sgh_rz.cpp
@@ -82,7 +82,7 @@ void SGHRZ::get_force_rz(const Material_t& Materials,
                          const DCArrayKokkos<double>& MaterialPoints_volfrac,
                          const DCArrayKokkos<double>& MaterialPoints_geo_volfrac,
                          const corners_in_mat_t corners_in_mat_elem,
-                         const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                         const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                          const size_t num_mat_elems,
                          const size_t mat_id,
                          const double fuzz,
@@ -100,7 +100,7 @@ void SGHRZ::get_force_rz(const Material_t& Materials,
 
        
         // get mesh elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         size_t gauss_gid = elem_gid; // 1 gauss point per element
 

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/properties_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/properties_rz.cpp
@@ -84,7 +84,7 @@ void SGHRZ::update_state_rz(
     const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
     const DCArrayKokkos<bool>&   MaterialPoints_eroded,
     const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const double time_value,
     const double dt,
     const double rk_alpha,
@@ -102,7 +102,7 @@ void SGHRZ::update_state_rz(
     FOR_ALL(mat_elem_lid, 0, num_material_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
 
         // get the material points for this material 
@@ -128,7 +128,7 @@ void SGHRZ::update_state_rz(
         FOR_ALL(mat_elem_lid, 0, num_material_elems, {
 
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
 
             // get the material points for this material 
@@ -175,7 +175,7 @@ void SGHRZ::update_state_rz(
         FOR_ALL(mat_elem_lid, 0, num_material_elems, {
 
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
 
             // get the material points for this material 
@@ -235,7 +235,7 @@ void SGHRZ::update_state_rz(
         // loop over all the elements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_material_elems, {
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // get the material points for this material
             // Note, with the SGH method, they are equal
@@ -319,7 +319,7 @@ void SGHRZ::update_stress(const Material_t& Materials,
                           const DCArrayKokkos<double>& MaterialPoints_eos_state_vars,
                           const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
                           const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-                          const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                          const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                           const size_t num_mat_elems,
                           const size_t mat_id,
                           const double fuzz,
@@ -359,7 +359,7 @@ void SGHRZ::update_stress(const Material_t& Materials,
         FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
             // the material point index = the material elem index for a 1-point element
             size_t mat_point_lid = mat_elem_lid;

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_execute_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_execute_rz.cpp
@@ -200,8 +200,8 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
                             State.GaussPoints.vol,
                             State.MaterialPoints(mat_id).sspd,
                             State.MaterialPoints(mat_id).eroded,
-                            State.MaterialToMeshMaps(mat_id).elem,
-                            State.MaterialToMeshMaps(mat_id).num_material_elems,
+                            State.MaterialToMeshMaps.elem,
+                            State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                             time_value,
                             graphics_time,
                             time_final,
@@ -210,7 +210,8 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
                             dt_cfl,
                             dt_mat,
                             fuzz,
-                            tiny);
+                            tiny,
+                            mat_id);
             
 
             // save the smallest dt of all materials
@@ -232,7 +233,7 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
         // ---------------------------------------------------------------------
         //  integrate the solution forward to t(n+1) via Runge Kutta (RK) method
         // ---------------------------------------------------------------------
-        for(size_t mat_id=0; mat_id<num_mats; mat_id++){
+        for (size_t mat_id=0; mat_id<num_mats; mat_id++){
             // save the values at t_n
             rk_init_rz(State.node.coords,
                        State.node.coords_n0,
@@ -271,8 +272,6 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
             // ---- calculate the forces on the vertices and evolve stress (hypo model) ----
             for(size_t mat_id=0; mat_id<num_mats; mat_id++){
 
-                size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
                 get_force_rz(Materials,
                                 mesh,
                                 State.GaussPoints.vol,
@@ -290,8 +289,8 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
                                 State.MaterialPoints(mat_id).volfrac,
                                 State.MaterialPoints(mat_id).geo_volfrac,
                                 State.corners_in_mat_elem,
-                                State.MaterialToMeshMaps(mat_id).elem,
-                                num_mat_elems,
+                                State.MaterialToMeshMaps.elem,
+                                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                                 mat_id,
                                 fuzz,
                                 tiny,
@@ -315,8 +314,8 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
                                   State.MaterialPoints(mat_id).eos_state_vars,
                                   State.MaterialPoints(mat_id).strength_state_vars,
                                   State.MaterialPoints(mat_id).shear_modulii,
-                                  State.MaterialToMeshMaps(mat_id).elem,
-                                  num_mat_elems,
+                                  State.MaterialToMeshMaps.elem,
+                                  State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                                   mat_id,
                                   fuzz,
                                   small,
@@ -360,8 +359,9 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
                                  State.MaterialPoints(mat_id).mass,
                                  State.MaterialCorners(mat_id).force,
                                  State.corners_in_mat_elem,
-                                 State.MaterialToMeshMaps(mat_id).elem,
-                                 State.MaterialToMeshMaps(mat_id).num_material_elems);
+                                 State.MaterialToMeshMaps.elem,
+                                 State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                                 mat_id);
             } // end for mat_id
 
             // ---- Update nodal positions ----
@@ -379,9 +379,7 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
 
 
             // ---- Calculate MaterialPoints state (den, pres, sound speed, stress) for next time step ----
-            for(size_t mat_id=0; mat_id<num_mats; mat_id++){
-
-                size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;           
+            for(size_t mat_id=0; mat_id<num_mats; mat_id++){          
 
                 update_state_rz(Materials,
                                 mesh,
@@ -402,12 +400,12 @@ void SGHRZ::execute(SimulationParameters_t& SimulationParamaters,
                                 State.MaterialPoints(mat_id).strength_state_vars,
                                 State.MaterialPoints(mat_id).eroded,
                                 State.MaterialPoints(mat_id).shear_modulii,
-                                State.MaterialToMeshMaps(mat_id).elem,
+                                State.MaterialToMeshMaps.elem,
                                 time_value,
                                 dt,
                                 rk_alpha,
                                 cycle,
-                                num_mat_elems,
+                                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                                 mat_id);
 
             } // end for mat_id

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_initialize_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_initialize_rz.cpp
@@ -77,20 +77,16 @@ void SGHRZ::initialize_material_state(SimulationParameters_t& SimulationParamate
     //  Allocation of state must include a buffer with ALE
     // -----
 
-    // IMPORTANT, make buffer a parser input variable
-    // for ALE, add a buffer to num_elems_for_mat, like 10% of num_elems up to num_elems.
-    const size_t buffer = 0; // memory buffer to push back into
+    State.MaterialToMeshMaps.initialize();
 
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {
 
         const size_t num_mat_pts_in_elem = mesh.num_leg_gauss_in_elem; 
 
-        size_t num_elems_for_mat = State.MaterialToMeshMaps(mat_id).num_material_elems + buffer; // has a memory buffer for ALE
+        const size_t num_elems_for_mat_buffer = State.MaterialToMeshMaps.num_material_elems_buffer.host(mat_id); // has a memory buffer for ALE
+        const size_t num_points_for_mat  = num_elems_for_mat_buffer * num_mat_pts_in_elem;
+        const size_t num_corners_for_mat = num_elems_for_mat_buffer * mesh.num_nodes_in_elem;
 
-        size_t num_points_for_mat  = num_elems_for_mat * num_mat_pts_in_elem;
-        size_t num_corners_for_mat = num_elems_for_mat * mesh.num_nodes_in_elem;
-
-        State.MaterialToMeshMaps(mat_id).initialize(num_elems_for_mat); 
         State.MaterialPoints(mat_id).initialize(num_points_for_mat, 3, SGHRZ_State::required_material_pt_state); // aways 3D, even for 2D-RZ calcs
         State.MaterialCorners(mat_id).initialize(num_corners_for_mat, mesh.num_dims, SGHRZ_State::required_material_corner_state); 
         // zones are not used with solver

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_setup_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_setup_rz.cpp
@@ -161,7 +161,7 @@ void calc_corner_mass_rz(const Material_t& Materials,
                          const DCArrayKokkos<double>& corner_mass,
                          const DCArrayKokkos<double>& MaterialPoints_den,
                          const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-                         const size_t num_mat_elems
+                         const size_t num_mat_elems,
                          const size_t mat_id)
 {
 

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_setup_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/sgh_setup_rz.cpp
@@ -119,8 +119,6 @@ void SGHRZ::setup(SimulationParameters_t& SimulationParamaters,
     // calculate the corner massess if 2D
 
     for(int mat_id=0; mat_id<num_mats; mat_id++){
-
-        size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
         
         calc_corner_mass_rz(Materials,
                             mesh,
@@ -128,8 +126,9 @@ void SGHRZ::setup(SimulationParameters_t& SimulationParamaters,
                             State.node.mass,
                             State.corner.mass,
                             State.MaterialPoints(mat_id).den,
-                            State.MaterialToMeshMaps(mat_id).elem,
-                            num_mat_elems);
+                            State.MaterialToMeshMaps.elem,
+                            State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                            mat_id);
     } // end for mat_id
 
     calc_node_mass_rz(mesh,
@@ -161,14 +160,15 @@ void calc_corner_mass_rz(const Material_t& Materials,
                          const DCArrayKokkos<double>& node_mass,
                          const DCArrayKokkos<double>& corner_mass,
                          const DCArrayKokkos<double>& MaterialPoints_den,
-                         const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-                         const size_t num_mat_elems)
+                         const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                         const size_t num_mat_elems
+                         const size_t mat_id)
 {
 
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         // facial area of the corners
         double corner_areas_array[4];

--- a/single-node-refactor/src/Solvers/SGH_solver_rz/src/time_integration_rz.cpp
+++ b/single-node-refactor/src/Solvers/SGH_solver_rz/src/time_integration_rz.cpp
@@ -115,7 +115,7 @@ void SGHRZ::get_timestep_rz(Mesh_t& mesh,
                             DCArrayKokkos<double>& GaussPoints_vol,
                             DCArrayKokkos<double>& MaterialPoints_sspd,
                             DCArrayKokkos<bool>&   MaterialPoints_eroded,
-                            DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                            DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                             size_t num_mat_elems,
                             double time_value,
                             const double graphics_time,
@@ -125,7 +125,8 @@ void SGHRZ::get_timestep_rz(Mesh_t& mesh,
                             const double dt_cfl,
                             double&      dt,
                             const double fuzz,
-                            const double tiny) const
+                            const double tiny,
+                            const size_t mat_id) const
 {
     // increase dt by 10%, that is the largest dt value
     dt = dt * 1.1;
@@ -134,7 +135,7 @@ void SGHRZ::get_timestep_rz(Mesh_t& mesh,
     double min_dt_calc;
     FOR_REDUCE_MIN(mat_elem_lid, 0, num_mat_elems, dt_lcl, {
 
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         double coords0[8];  // element coords
         ViewCArrayKokkos<double> coords(coords0, 4, 2);

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/include/sgtm_solver_3D.h
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/include/sgtm_solver_3D.h
@@ -270,8 +270,9 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_mass,
         const DCArrayKokkos<double>& MaterialCorners_force,
         const corners_in_mat_t corners_in_mat_elem,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-        const size_t num_mat_elems) const;
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const size_t num_mat_elems,
+        const size_t mat_id) const;
 
     void update_temperature(
             const Mesh_t& mesh,
@@ -297,7 +298,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_temp_grad,
         const corners_in_mat_t corners_in_mat_elem,
         const DCArrayKokkos<bool>&   MaterialPoints_eroded,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double fuzz,
@@ -313,7 +314,7 @@ public:
         const DCArrayKokkos<double>& corner_q_flux,
         const DCArrayKokkos<double>& sphere_position,
         const corners_in_mat_t corners_in_mat_elem,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double fuzz,
@@ -357,7 +358,7 @@ public:
         const DCArrayKokkos<double>& MaterialPoints_mass,
         const DCArrayKokkos<double>& MaterialPoints_statev,
         const DCArrayKokkos<bool>&   GaussPoints_eroded,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const double dt,
         const double rk_alpha,
         const size_t num_material_elems,
@@ -389,7 +390,7 @@ public:
         DCArrayKokkos<double>& MaterialPoints_density,
         DCArrayKokkos<double>& MaterialPoints_specific_heat,
         DCArrayKokkos<bool>&   MaterialPoints_eroded,
-        DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         size_t num_mat_elems,
         double time_value,
         const double graphics_time,
@@ -399,7 +400,8 @@ public:
         const double dt_cfl,
         double&      dt,
         const double fuzz,
-        const double tiny) const;
+        const double tiny,
+        const size_t mat_id) const;
 
 };
 

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/include/sgtm_solver_3D.h
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/include/sgtm_solver_3D.h
@@ -257,22 +257,22 @@ public:
         const double time_value) const;
 
     // **** Functions defined in energy_sgtm.cpp **** //
-    void update_temperature(
-        const double rk_alpha,
-        const double dt,
-        const Mesh_t& mesh,
-        const DCArrayKokkos<double>& node_vel,
-        const DCArrayKokkos<double>& node_vel_n0,
-        const DCArrayKokkos<double>& node_coords,
-        const DCArrayKokkos<double>& node_coords_n0,
-        const DCArrayKokkos<double>& MaterialPoints_sie,
-        const DCArrayKokkos<double>& MaterialPoints_sie_n0,
-        const DCArrayKokkos<double>& MaterialPoints_mass,
-        const DCArrayKokkos<double>& MaterialCorners_force,
-        const corners_in_mat_t corners_in_mat_elem,
-        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-        const size_t num_mat_elems,
-        const size_t mat_id) const;
+    //void update_temperature(
+    //    const double rk_alpha,
+    //    const double dt,
+    //    const Mesh_t& mesh,
+    //    const DCArrayKokkos<double>& node_vel,
+    //    const DCArrayKokkos<double>& node_vel_n0,
+    //    const DCArrayKokkos<double>& node_coords,
+    //    const DCArrayKokkos<double>& node_coords_n0,
+    //    const DCArrayKokkos<double>& MaterialPoints_sie,
+    //    const DCArrayKokkos<double>& MaterialPoints_sie_n0,
+    //    const DCArrayKokkos<double>& MaterialPoints_mass,
+    //    const DCArrayKokkos<double>& MaterialCorners_force,
+    //    const corners_in_mat_t corners_in_mat_elem,
+    //    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    //    const size_t num_mat_elems,
+    //    const size_t mat_id) const;
 
     void update_temperature(
             const Mesh_t& mesh,

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/energy_sgtm.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/energy_sgtm.cpp
@@ -65,14 +65,15 @@ void SGTM3D::update_temperature(
     const DCArrayKokkos<double>& MaterialPoints_mass,
     const DCArrayKokkos<double>& MaterialCorners_force,
     const corners_in_mat_t corners_in_mat_elem,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-    const size_t num_mat_elems
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const size_t num_mat_elems,
+    const size_t mat_id
     ) const
 {
     // loop over all the elements in the mesh
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
         // the material point index = the material elem index for a 1-point element
         size_t mat_point_lid = mat_elem_lid;

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/heat_flux.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/heat_flux.cpp
@@ -79,7 +79,7 @@ void SGTM3D::get_heat_flux(
     const DCArrayKokkos<double>& corner_q_transfer,
     const corners_in_mat_t corners_in_mat_elem,
     const DCArrayKokkos<bool>&   MaterialPoints_eroded,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const size_t num_mat_elems,
     const size_t mat_id,
     const double fuzz,
@@ -94,7 +94,7 @@ void SGTM3D::get_heat_flux(
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         // the material point index = the material elem index for a 1-point element
         size_t mat_point_lid = mat_elem_lid;
@@ -225,7 +225,7 @@ void SGTM3D::moving_flux(
     const DCArrayKokkos<double>& corner_q_flux,
     const DCArrayKokkos<double>& sphere_position,
     const corners_in_mat_t corners_in_mat_elem,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const size_t num_mat_elems,
     const size_t mat_id,
     const double fuzz,
@@ -238,7 +238,7 @@ void SGTM3D::moving_flux(
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
         
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         // the material point index = the material elem index for a 1-point element
         // size_t mat_point_lid = mat_elem_lid;

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/properties.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/properties.cpp
@@ -74,7 +74,7 @@ void SGTM3D::update_state(
     const DCArrayKokkos<double>& MaterialPoints_mass,
     const DCArrayKokkos<double>& MaterialPoints_statev,
     const DCArrayKokkos<bool>&   MaterialPoints_eroded,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const double dt,
     const double rk_alpha,
     const size_t num_material_elems,

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_execute.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_execute.cpp
@@ -193,8 +193,8 @@ std::cout << "here getting time step\n";
                          State.MaterialPoints(mat_id).den,
                          State.MaterialPoints(mat_id).specific_heat,
                          State.MaterialPoints(mat_id).eroded,
-                         State.MaterialToMeshMaps(mat_id).elem,
-                         State.MaterialToMeshMaps(mat_id).num_material_elems,
+                         State.MaterialToMeshMaps.elem,
+                         State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                          time_value,
                          graphics_time,
                          time_final,
@@ -203,7 +203,8 @@ std::cout << "here getting time step\n";
                          dt_cfl,
                          dt_mat,
                          fuzz,
-                         tiny);
+                         tiny,
+                         mat_id);
 
             // ---- save the smallest dt of all materials ---- //
             min_dt_calc = fmin(dt_mat, min_dt_calc);
@@ -254,8 +255,6 @@ std::cout << "checking: rk_init \n";
             // ---- Calculate the corner heat flux from conduction per material ---- //
             for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-                size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
 std::cout << "checking: get_heat_flux \n";
                 get_heat_flux(
                     Materials,
@@ -269,8 +268,8 @@ std::cout << "checking: get_heat_flux \n";
                     State.corner.q_transfer,
                     State.corners_in_mat_elem,
                     State.MaterialPoints(mat_id).eroded,
-                    State.MaterialToMeshMaps(mat_id).elem,
-                    num_mat_elems,
+                    State.MaterialToMeshMaps.elem,
+                    State.MaterialToMeshMaps.num_material_elem(mat_id),
                     mat_id,
                     fuzz,
                     small,
@@ -287,8 +286,8 @@ std::cout << "checking: moving_flux \n";
                     State.corner.q_transfer,
                     sphere_position,
                     State.corners_in_mat_elem,
-                    State.MaterialToMeshMaps(mat_id).elem,
-                    num_mat_elems,
+                    State.MaterialToMeshMaps.elem,
+                    State.MaterialToMeshMaps.num_material_elem(mat_id),
                     mat_id,
                     fuzz,
                     small,
@@ -324,7 +323,8 @@ std::cout << "update temperature \n";
                 State.node.q_transfer,
                 State.MaterialPoints(0).specific_heat, // Note: Need to make this a node field, and calculate in the material loop
                 rk_alpha,
-                dt);
+                dt,
+                mat_id);
 
 
             // ---- apply temperature boundary conditions to the boundary patches----

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_execute.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_execute.cpp
@@ -269,7 +269,7 @@ std::cout << "checking: get_heat_flux \n";
                     State.corners_in_mat_elem,
                     State.MaterialPoints(mat_id).eroded,
                     State.MaterialToMeshMaps.elem,
-                    State.MaterialToMeshMaps.num_material_elem(mat_id),
+                    State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                     mat_id,
                     fuzz,
                     small,
@@ -287,7 +287,7 @@ std::cout << "checking: moving_flux \n";
                     sphere_position,
                     State.corners_in_mat_elem,
                     State.MaterialToMeshMaps.elem,
-                    State.MaterialToMeshMaps.num_material_elem(mat_id),
+                    State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                     mat_id,
                     fuzz,
                     small,
@@ -323,8 +323,7 @@ std::cout << "update temperature \n";
                 State.node.q_transfer,
                 State.MaterialPoints(0).specific_heat, // Note: Need to make this a node field, and calculate in the material loop
                 rk_alpha,
-                dt,
-                mat_id);
+                dt);
 
 
             // ---- apply temperature boundary conditions to the boundary patches----

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_initialize.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_initialize.cpp
@@ -86,20 +86,16 @@ void SGTM3D::initialize_material_state(SimulationParameters_t& SimulationParamat
     //  Allocation of state must include a buffer with ALE
     // -----
 
-    // IMPORTANT, make buffer a parser input variable
-    // for ALE, add a buffer to num_elems_for_mat, like 10% of num_elems up to num_elems.
-    const size_t buffer = 0; // memory buffer to push back into
+    State.MaterialToMeshMaps.initialize();
 
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {
 
         const size_t num_mat_pts_in_elem = mesh.num_leg_gauss_in_elem; 
 
-        size_t num_elems_for_mat = State.MaterialToMeshMaps(mat_id).num_material_elems + buffer; // has a memory buffer for ALE
+        const size_t num_elems_for_mat_buffer = State.MaterialToMeshMaps.num_material_elems_buffer.host(mat_id); // has a memory buffer for ALE
+        const size_t num_points_for_mat  = num_elems_for_mat_buffer * num_mat_pts_in_elem;
+        const size_t num_corners_for_mat = num_elems_for_mat_buffer * mesh.num_nodes_in_elem;
 
-        size_t num_points_for_mat  = num_elems_for_mat * num_mat_pts_in_elem;
-        size_t num_corners_for_mat = num_elems_for_mat * mesh.num_nodes_in_elem;
-
-        State.MaterialToMeshMaps(mat_id).initialize(num_elems_for_mat);
         State.MaterialPoints(mat_id).initialize(num_points_for_mat, 3, SGTM3D_State::required_material_pt_state); // aways 3D, even for 2D-RZ calcs
         State.MaterialCorners(mat_id).initialize(num_corners_for_mat, mesh.num_dims, SGTM3D_State::required_material_corner_state);
         // zones are not used

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_setup.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/sgtm_setup.cpp
@@ -86,7 +86,6 @@ void SGTM3D::setup(SimulationParameters_t& SimulationParamaters,
 
     // calculate corner and node masses on the mesh
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {
-        size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
 
         calc_corner_mass(Materials,
                          mesh,
@@ -94,8 +93,9 @@ void SGTM3D::setup(SimulationParameters_t& SimulationParamaters,
                          State.node.mass,
                          State.corner.mass,
                          State.MaterialPoints(mat_id).mass,
-                         State.MaterialToMeshMaps(mat_id).elem,
-                         num_mat_elems);
+                         State.MaterialToMeshMaps.elem,
+                         State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                         mat_id);
     } // end for mat_id
 
     calc_node_mass(mesh,

--- a/single-node-refactor/src/Solvers/SGTM_solver_3D/src/time_integration.cpp
+++ b/single-node-refactor/src/Solvers/SGTM_solver_3D/src/time_integration.cpp
@@ -108,7 +108,7 @@ void SGTM3D::get_timestep(Mesh_t& mesh,
                        DCArrayKokkos<double>& MaterialPoints_density,
                        DCArrayKokkos<double>& MaterialPoints_specific_heat,
                        DCArrayKokkos<bool>&   MaterialPoints_eroded,
-                       DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                       DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                        size_t num_mat_elems,
                        double time_value,
                        const double graphics_time,
@@ -118,7 +118,8 @@ void SGTM3D::get_timestep(Mesh_t& mesh,
                        const double dt_cfl,
                        double&      dt,
                        const double fuzz,
-                       const double tiny) const
+                       const double tiny,
+                       const size_t mat_id) const
 {
     // increase dt by 10%, that is the largest dt value
     dt = dt * 1.1;
@@ -126,7 +127,7 @@ void SGTM3D::get_timestep(Mesh_t& mesh,
     double dt_lcl;
     double min_dt_calc;
     FOR_REDUCE_MIN(mat_elem_lid, 0, num_mat_elems, dt_lcl, {
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
         double coords0[24];  // element coords
         ViewCArrayKokkos<double> coords(coords0, 8, 3);

--- a/single-node-refactor/src/Solvers/level_set_solver/include/level_set_solver.h
+++ b/single-node-refactor/src/Solvers/level_set_solver/include/level_set_solver.h
@@ -213,7 +213,8 @@ public:
         DCArrayKokkos<double>& GaussPoints_level_set_n0,
         DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_dims,
-        const size_t num_mat_points) const;
+        const size_t num_mat_elems,
+        const size_t mat_id) const;
 
     void get_timestep(
         const Mesh_t& mesh,

--- a/single-node-refactor/src/Solvers/level_set_solver/include/level_set_solver.h
+++ b/single-node-refactor/src/Solvers/level_set_solver/include/level_set_solver.h
@@ -195,7 +195,7 @@ public:
             const DCArrayKokkos<double>& GaussPoints_level_set_n,
             const DCArrayKokkos<double>& GaussPoints_vol,
             const DCArrayKokkos<double>& Corner_normal,
-            const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+            const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
             const size_t num_mat_elems,
             const size_t mat_id,
             const double fuzz,
@@ -211,7 +211,7 @@ public:
     void rk_init(
         DCArrayKokkos<double>& GaussPoints_level_set,
         DCArrayKokkos<double>& GaussPoints_level_set_n0,
-        DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_dims,
         const size_t num_mat_points) const;
 
@@ -220,7 +220,7 @@ public:
         const Material_t& Materials,
         const DCArrayKokkos<double>& node_coords,
         const DCArrayKokkos<double>& GaussPoints_vol,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double time_value,
@@ -238,7 +238,7 @@ public:
         const Material_t& Materials,
         const DCArrayKokkos<double>& node_coords,
         const DCArrayKokkos<double>& GaussPoints_vol,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_mat_elems,
         const size_t mat_id,
         const double time_value,

--- a/single-node-refactor/src/Solvers/level_set_solver/src/level_set_execute.cpp
+++ b/single-node-refactor/src/Solvers/level_set_solver/src/level_set_execute.cpp
@@ -150,8 +150,8 @@ void LevelSet::execute(SimulationParameters_t& SimulationParamaters,
                         Materials,
                         State.node.coords,
                         State.GaussPoints.vol,
-                        State.MaterialToMeshMaps(mat_id).elem,
-                        State.MaterialToMeshMaps(mat_id).num_material_elems,
+                        State.MaterialToMeshMaps.elem,
+                        State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                         mat_id,
                         time_value,
                         graphics_time,
@@ -170,8 +170,8 @@ void LevelSet::execute(SimulationParameters_t& SimulationParamaters,
                         Materials,
                         State.node.coords,
                         State.GaussPoints.vol,
-                        State.MaterialToMeshMaps(mat_id).elem,
-                        State.MaterialToMeshMaps(mat_id).num_material_elems,
+                        State.MaterialToMeshMaps.elem,
+                        State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                         mat_id,
                         time_value,
                         graphics_time,
@@ -222,9 +222,10 @@ void LevelSet::execute(SimulationParameters_t& SimulationParamaters,
                 // save the values at t_n
                 rk_init(State.GaussPoints.level_set,
                         State.GaussPoints.level_set_n0,
-                        State.MaterialToMeshMaps(mat_id).elem,
+                        State.MaterialToMeshMaps.elem,
                         mesh.num_dims,
-                        State.MaterialPoints(mat_id).num_material_points);
+                        State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                        mat_id);
             }
 
         } // end for mat_id
@@ -268,8 +269,6 @@ void LevelSet::execute(SimulationParameters_t& SimulationParamaters,
 
                 if (Materials.MaterialEnums.host(mat_id).levelSetType == model::evolveFront){
 
-                    size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
                     // update level set
                     update_level_set(
                         mesh,
@@ -280,8 +279,8 @@ void LevelSet::execute(SimulationParameters_t& SimulationParamaters,
                         State.GaussPoints.level_set_n0,
                         State.GaussPoints.vol,
                         State.corner.normal,
-                        State.MaterialToMeshMaps(mat_id).elem,
-                        num_mat_elems,
+                        State.MaterialToMeshMaps.elem,
+                        State.MaterialToMeshMaps.num_material_elems.host(mat_id),
                         mat_id,
                         fuzz,
                         small,

--- a/single-node-refactor/src/Solvers/level_set_solver/src/level_set_initialize.cpp
+++ b/single-node-refactor/src/Solvers/level_set_solver/src/level_set_initialize.cpp
@@ -74,20 +74,16 @@
     //  Allocation of state must include a buffer with ALE
     // -----
 
-    // IMPORTANT, make buffer a parser input variable
-    // for ALE, add a buffer to num_elems_for_mat, like 10% of num_elems up to num_elems.
-    const size_t buffer = 0; // memory buffer to push back into
+    State.MaterialToMeshMaps.initialize();
 
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {
 
         const size_t num_mat_pts_in_elem = mesh.num_leg_gauss_in_elem; 
 
-        size_t num_elems_for_mat = State.MaterialToMeshMaps(mat_id).num_material_elems + buffer; // has a memory buffer for ALE
+        const size_t num_elems_for_mat_buffer = State.MaterialToMeshMaps.num_material_elems_buffer.host(mat_id); // has a memory buffer for ALE
+        const size_t num_points_for_mat  = num_elems_for_mat_buffer * num_mat_pts_in_elem;
+        const size_t num_corners_for_mat = num_elems_for_mat_buffer * mesh.num_nodes_in_elem;
 
-        size_t num_points_for_mat  = num_elems_for_mat * num_mat_pts_in_elem;
-        size_t num_corners_for_mat = num_elems_for_mat * mesh.num_nodes_in_elem;
-
-        State.MaterialToMeshMaps(mat_id).initialize(num_elems_for_mat);
         State.MaterialPoints(mat_id).initialize(num_points_for_mat, mesh.num_dims, LevelSet_State::required_material_pt_state); 
         // zones are not used with solver
 

--- a/single-node-refactor/src/Solvers/level_set_solver/src/solver_functions.cpp
+++ b/single-node-refactor/src/Solvers/level_set_solver/src/solver_functions.cpp
@@ -207,7 +207,7 @@ void LevelSet::update_level_set(
     const DCArrayKokkos<double>& GaussPoints_level_set_n0,
     const DCArrayKokkos<double>& GaussPoints_vol,
     const DCArrayKokkos<double>& corner_normal,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const size_t num_mat_elems,
     const size_t mat_id,
     const double fuzz,
@@ -223,7 +223,7 @@ void LevelSet::update_level_set(
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         // it is a 1-point quadrature point element
         size_t gauss_point = elem_gid;

--- a/single-node-refactor/src/Solvers/level_set_solver/src/time_integration.cpp
+++ b/single-node-refactor/src/Solvers/level_set_solver/src/time_integration.cpp
@@ -46,21 +46,22 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// \param Levelset field
 /// \param MaterialtoMeshMaps elem
 /// \param Number of dimension
-/// \param Number of material points in mat
+/// \param Number of material elems
 ///
 /////////////////////////////////////////////////////////////////////////////
 void LevelSet::rk_init(
     DCArrayKokkos<double>& GaussPoints_level_set,
     DCArrayKokkos<double>& GaussPoints_level_set_n0,
-    DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const size_t num_dims,
-    const size_t num_mat_points) const
+    const size_t num_mat_elems,
+    const size_t mat_id) const
 {
     // save elem quantities
-    FOR_ALL(mat_elem_lid, 0, num_mat_points, {
+    FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get the element
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
         // Note:
         // loop gauss point, this method is for a single quadrature point element
@@ -95,7 +96,7 @@ void LevelSet::get_timestep(
     const Material_t& Materials,
     const DCArrayKokkos<double>& node_coords,
     const DCArrayKokkos<double>& GaussPoints_vol,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const size_t num_mat_elems,
     const size_t mat_id,
     const double time_value,
@@ -115,7 +116,7 @@ void LevelSet::get_timestep(
     double dt_lcl;
     double min_dt_calc;
     FOR_REDUCE_MIN(mat_elem_lid, 0, num_mat_elems, dt_lcl, {
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
         double coords0[24];  // element coords
         ViewCArrayKokkos<double> coords(coords0, 8, 3);
@@ -222,7 +223,7 @@ void LevelSet::get_timestep_2D(
     const Material_t& Materials,
     const DCArrayKokkos<double>& node_coords,
     const DCArrayKokkos<double>& GaussPoints_vol,
-    const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+    const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
     const size_t num_mat_elems,
     const size_t mat_id,
     const double time_value,
@@ -242,7 +243,7 @@ void LevelSet::get_timestep_2D(
     double min_dt_calc;
     FOR_REDUCE_MIN(mat_elem_lid, 0, num_mat_elems, dt_lcl, {
 
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid); 
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid); 
 
         double coords0[8];  // element coords
         ViewCArrayKokkos<double> coords(coords0, 4, 2);

--- a/single-node-refactor/src/common/include/material.h
+++ b/single-node-refactor/src/common/include/material.h
@@ -334,7 +334,7 @@ struct MaterialFunctions_t
         const double MaterialPoints_den,
         const double MaterialPoints_sie,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
         const double vol,
@@ -352,7 +352,7 @@ struct MaterialFunctions_t
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_id) = NULL;
 

--- a/single-node-refactor/src/common/include/mesh_io.h
+++ b/single-node-refactor/src/common/include/mesh_io.h
@@ -2709,7 +2709,7 @@ public:
 
                 for (int mat_id = 0; mat_id < num_mats; mat_id++) {
 
-                    const size_t num_mat_elems = State.MaterialToMeshMaps.num_material_elems.host(mat_id)
+                    const size_t num_mat_elems = State.MaterialToMeshMaps.num_material_elems.host(mat_id);
 
                     // only save material data if the mat lives on the mesh, ie. has state allocated
                     if (num_mat_elems>0){

--- a/single-node-refactor/src/common/include/region_fill.h
+++ b/single-node-refactor/src/common/include/region_fill.h
@@ -391,7 +391,8 @@ void calc_corner_mass(const Material_t& Materials,
                       const DCArrayKokkos<double>& corner_mass,
                       const DCArrayKokkos<double>& MaterialPoints_mass,
                       const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-                      const size_t num_mat_elems);
+                      const size_t num_mat_elems,
+                      const size_t mat_id);
 
 /////////////////////////////////////////////////////////////////////////////
 ///

--- a/single-node-refactor/src/common/include/region_fill.h
+++ b/single-node-refactor/src/common/include/region_fill.h
@@ -332,7 +332,7 @@ void init_state_vars(const Material_t& Materials,
                      const Mesh_t& mesh,
                      const DCArrayKokkos<double>& MaterialPoints_eos_state_vars,
                      const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
-                     const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                     const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                      const size_t num_mat_pts,
                      const size_t mat_id);
 
@@ -390,7 +390,7 @@ void calc_corner_mass(const Material_t& Materials,
                       const DCArrayKokkos<double>& node_mass,
                       const DCArrayKokkos<double>& corner_mass,
                       const DCArrayKokkos<double>& MaterialPoints_mass,
-                      const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                      const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                       const size_t num_mat_elems);
 
 /////////////////////////////////////////////////////////////////////////////

--- a/single-node-refactor/src/common/include/state.h
+++ b/single-node-refactor/src/common/include/state.h
@@ -422,7 +422,7 @@ struct MaterialToMeshMap_t
     void initialize()
     {
         if (elem.size() == 0){ 
-            this->elem = DRaggedRightArrayKokkos<size_t>(this->num_material_elems_buffer, "material_pt_to_elem");
+            this->elem = DRaggedRightArrayKokkos<size_t>(this->num_material_elems_buffer, "material_space_to_elem");
         }
 
     }; // end method
@@ -431,12 +431,12 @@ struct MaterialToMeshMap_t
     {
         // Note: num_material_elems is allocated in problem setup
         if (num_material_elems.size() == 0){
-            this->num_material_elems = DCArrayKokkos <size_t> (num_mats); 
+            this->num_material_elems = DCArrayKokkos <size_t> (num_mats, "num_material_elems"); 
         }
 
         // Note: num_material_elems_buffer is allocated in problem setup, the values are set in solver initialize
         if (num_material_elems_buffer.size() == 0){
-            this->num_material_elems_buffer = DCArrayKokkos <size_t> (num_mats); 
+            this->num_material_elems_buffer = DCArrayKokkos <size_t> (num_mats, "num_material_elems_with_buffer"); 
         }
 
     }; // end method

--- a/single-node-refactor/src/common/include/state.h
+++ b/single-node-refactor/src/common/include/state.h
@@ -414,9 +414,9 @@ struct MeshtoMaterialMap_t
 struct MaterialToMeshMap_t
 {
     DCArrayKokkos <size_t> num_material_elems;        ///< returns the exact number of matpts
-    DCArrayKokkos <size_t> num_material_elems_buffer; ///< returns the exact number of matpts
+    DCArrayKokkos <size_t> num_material_elems_buffer; ///< returns the number of matpts plus buffer
 
-    DRaggedRightArrayKokkos<size_t> elem;       ///< returns the elem for this material
+    DRaggedRightArrayKokkos<size_t> elem;             ///< returns the elem for this material
 
     // initialization method for FE-SGH and MPM methods (max number of elems needed)
     void initialize()
@@ -434,7 +434,7 @@ struct MaterialToMeshMap_t
             this->num_material_elems = DCArrayKokkos <size_t> (num_mats, "num_material_elems"); 
         }
 
-        // Note: num_material_elems_buffer is allocated in problem setup, the values are set in solver initialize
+        // Note: num_material_elems_buffer is allocated in problem setup, the values are set in region_fill.cpp routine
         if (num_material_elems_buffer.size() == 0){
             this->num_material_elems_buffer = DCArrayKokkos <size_t> (num_mats, "num_material_elems_with_buffer"); 
         }

--- a/single-node-refactor/src/common/include/state.h
+++ b/single-node-refactor/src/common/include/state.h
@@ -413,17 +413,34 @@ struct MeshtoMaterialMap_t
 /////////////////////////////////////////////////////////////////////////////
 struct MaterialToMeshMap_t
 {
-    size_t num_material_elems;        ///< returns the exact number of matpts
+    DCArrayKokkos <size_t> num_material_elems;        ///< returns the exact number of matpts
+    DCArrayKokkos <size_t> num_material_elems_buffer; ///< returns the exact number of matpts
 
-    DCArrayKokkos<size_t> elem;       ///< returns the elem for this material
+    DRaggedRightArrayKokkos<size_t> elem;       ///< returns the elem for this material
 
     // initialization method for FE-SGH and MPM methods (max number of elems needed)
-    void initialize(size_t num_elem_max)
+    void initialize()
     {
         if (elem.size() == 0){ 
-            this->elem = DCArrayKokkos<size_t>(num_elem_max, "material_pt_to_elem");
+            this->elem = DRaggedRightArrayKokkos<size_t>(this->num_material_elems_buffer, "material_pt_to_elem");
         }
+
     }; // end method
+
+    void initialize_num_mats(size_t num_mats)
+    {
+        // Note: num_material_elems is allocated in problem setup
+        if (num_material_elems.size() == 0){
+            this->num_material_elems = DCArrayKokkos <size_t> (num_mats); 
+        }
+
+        // Note: num_material_elems_buffer is allocated in problem setup, the values are set in solver initialize
+        if (num_material_elems_buffer.size() == 0){
+            this->num_material_elems_buffer = DCArrayKokkos <size_t> (num_mats); 
+        }
+
+    }; // end method
+
 }; // end MaterialtoMeshMaps_t
 
 
@@ -863,7 +880,7 @@ struct State_t
     // ---------------------------------------------------------------------
     //    material to mesh maps and mesh to material maps
     // ---------------------------------------------------------------------
-    CArray<MaterialToMeshMap_t> MaterialToMeshMaps; ///< access as MaterialToMeshMaps(mat_id).elem(mat_storage_lid)
+    MaterialToMeshMap_t MaterialToMeshMaps; ///< access as MaterialToMeshMaps.elem(mat_id, mat_storage_lid)
     MeshtoMaterialMap_t MeshtoMaterialMaps;          ///< acces as MeshtoMaterialMaps.mat_id(elem, mat_lid)
 
     // ---------------------------------------------------------------------

--- a/single-node-refactor/src/common/src/region_fill.cpp
+++ b/single-node-refactor/src/common/src/region_fill.cpp
@@ -2264,7 +2264,7 @@ void calc_corner_mass(const Material_t& Materials,
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_id,mat_elem_lid);  
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);  
 
         // calculate the fraction of matpt mass to scatter to each corner
         double corner_frac = 1.0/((double)mesh.num_nodes_in_elem);  // =1/8

--- a/single-node-refactor/src/common/src/region_fill.cpp
+++ b/single-node-refactor/src/common/src/region_fill.cpp
@@ -163,7 +163,7 @@ void simulation_setup(SimulationParameters_t& SimulationParamaters,
     // ---------------------------------------
     //  allocation of maps and state
     // ---------------------------------------
-    State.MaterialToMeshMaps = CArray<MaterialToMeshMap_t>(num_mats); 
+    State.MaterialToMeshMaps.initialize_num_mats(num_mats); // allocates num_mats and num_mats_buffer that has a memory buffer
 
     State.MaterialPoints  = CArray<MaterialPoint_t>(num_mats); 
 
@@ -182,12 +182,22 @@ void simulation_setup(SimulationParameters_t& SimulationParamaters,
 
         const size_t num_mat_pts_in_elem = mesh.num_leg_gauss_in_elem;  // mat_pts = guass points
 
-        // the following always have the exact memory needed, they omit a buffer.  The buffer is when allocating mat_pts state
-        State.MaterialToMeshMaps(mat_id).num_material_elems = num_elems_saved_for_mat.host(mat_id);
-        State.MaterialPoints(mat_id).num_material_points    = num_elems_saved_for_mat.host(mat_id) * num_mat_pts_in_elem;
-        State.MaterialCorners(mat_id).num_material_corners  = num_elems_saved_for_mat.host(mat_id) * mesh.num_nodes_in_elem;
-        State.MaterialZones(mat_id).num_material_zones      = num_elems_saved_for_mat.host(mat_id) * mesh.num_zones_in_elem;
+        // num_mat_elems is the exact number, it ignores a buffer. The num_mat_elems_buffer has a buffer for e.g., remap 
+        State.MaterialToMeshMaps.num_material_elems.host(mat_id) = num_elems_saved_for_mat.host(mat_id);
+
+        // IMPORTANT, make buffer a parser input variable
+        // for ALE, add a buffer to num_elems_for_mat, like 10% of num_elems up to num_elems.
+        // the num_elems_buffer is used when allocating the size of all material state
+        size_t buffer = 0;
+        State.MaterialToMeshMaps.num_material_elems_buffer.host(mat_id) = num_elems_saved_for_mat.host(mat_id) + buffer;
+
+        // actual storage, that is, the actual number of mat_points, mat_corners, etc
+        State.MaterialPoints(mat_id).num_material_points   = num_elems_saved_for_mat.host(mat_id) * num_mat_pts_in_elem;
+        State.MaterialCorners(mat_id).num_material_corners = num_elems_saved_for_mat.host(mat_id) * mesh.num_nodes_in_elem;
+        State.MaterialZones(mat_id).num_material_zones     = num_elems_saved_for_mat.host(mat_id) * mesh.num_zones_in_elem;
     } // end
+    State.MaterialToMeshMaps.num_material_elems.update_device();
+    State.MaterialToMeshMaps.num_material_elems_buffer.update_device();
 
     // done, the solver init functions will be called after this function via the driver
 
@@ -717,7 +727,7 @@ void material_state_setup(SimulationParameters_t& SimulationParamaters,
             size_t mat_elem_lid = num_elems_saved_for_mat.host(mat_id);
 
             // --- mapping from material elem lid to elem ---
-            State.MaterialToMeshMaps(mat_id).elem.host(mat_elem_lid) = elem_gid;
+            State.MaterialToMeshMaps.elem.host(mat_id, mat_elem_lid) = elem_gid;
 
             // --- mapping from elem to material index space ---
             State.MeshtoMaterialMaps.mat_storage_lid.host(elem_gid, a_mat_in_elem) = mat_elem_lid;
@@ -825,17 +835,18 @@ void material_state_setup(SimulationParameters_t& SimulationParamaters,
 
         } // end loop over materials in this element
     } // end serial for loop over all elements
-    
+    State.MaterialToMeshMaps.elem.update_device();
+
 
     // copy the state to the device
     for (int mat_id = 0; mat_id < num_mats; mat_id++) {
 
         std::cout << "Number of elements = " << 
-            State.MaterialToMeshMaps(mat_id).num_material_elems << " for material " << mat_id << "\n";
+            State.MaterialToMeshMaps.num_material_elems.host(mat_id) << " for material " << mat_id << "\n";
         
         State.MaterialPoints(mat_id).volfrac.update_device();
         State.MaterialPoints(mat_id).geo_volfrac.update_device();
-        State.MaterialToMeshMaps(mat_id).elem.update_device();
+
 
         if (State.MaterialPoints(mat_id).den.host.size()>0){
             State.MaterialPoints(mat_id).den.update_device();
@@ -2084,7 +2095,7 @@ void init_state_vars(const Material_t& Materials,
                      const Mesh_t& mesh,
                      const DCArrayKokkos<double>& MaterialPoints_eos_state_vars,
                      const DCArrayKokkos<double>& MaterialPoints_strength_state_vars,
-                     const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                     const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
                      const size_t num_mat_pts,
                      const size_t mat_id)
 {
@@ -2244,15 +2255,16 @@ void calc_corner_mass(const Material_t& Materials,
                       const DCArrayKokkos<double>& node_mass,
                       const DCArrayKokkos<double>& corner_mass,
                       const DCArrayKokkos<double>& MaterialPoints_mass,
-                      const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
-                      const size_t num_mat_elems)
+                      const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+                      const size_t num_mat_elems,
+                      const size_t mat_id)
 {
 
 
     FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
         // get elem gid
-        size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);  
+        size_t elem_gid = MaterialToMeshMaps_elem(mat_id,mat_elem_lid);  
 
         // calculate the fraction of matpt mass to scatter to each corner
         double corner_frac = 1.0/((double)mesh.num_nodes_in_elem);  // =1/8

--- a/single-node-refactor/src/material_models/equilibration/include/tipton_equilibration.hpp
+++ b/single-node-refactor/src/material_models/equilibration/include/tipton_equilibration.hpp
@@ -79,12 +79,13 @@ namespace TiptonEquilibrationModel {
         const DCArrayKokkos<double>& MaterialPoint_pres,
         const DCArrayKokkos<double>& MaterialPoint_den,
         const DCArrayKokkos<double>& MaterialPoint_sspd,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const points_in_mat_t& points_in_mat_elem,
         const double dt,
         const double rk_alpha,
         const double fuzz,
-        const size_t num_mat_elems);
+        const size_t num_mat_elems,
+        const size_t mat_id);
 
 
     void calc_gauss_point_averages( 
@@ -107,14 +108,15 @@ namespace TiptonEquilibrationModel {
         const DCArrayKokkos<double>& MaterialPoint_den,
         const DCArrayKokkos<double>& MaterialPoint_sspd,
         const DCArrayKokkos<double>& MaterialPoint_mass,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const points_in_mat_t& points_in_mat_elem,
         const double dt,
         const double rk_alpha,
         const double fuzz,
         const CArrayKokkos<double> &equilibration_global_vars,
         const size_t num_global_vars,
-        const size_t num_mat_elems);        
+        const size_t num_mat_elems,
+        const size_t mat_id);        
 
 
         void update_volfrac_sie (
@@ -127,12 +129,13 @@ namespace TiptonEquilibrationModel {
             const DCArrayKokkos<double>& MaterialPoints_delta_volfrac,
             const DCArrayKokkos<double>& MaterialPoint_sie,
             const DCArrayKokkos<double>& MaterialPoint_mass,
-            const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+            const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
             const points_in_mat_t& points_in_mat_elem,
             const double dt,
             const double rk_alpha,
             const double fuzz,
-            const size_t num_mat_elems);    
+            const size_t num_mat_elems,
+            const size_t mat_id);    
 
 } // end namespace
 

--- a/single-node-refactor/src/material_models/equilibration/src/tipton_equilibration.cpp
+++ b/single-node-refactor/src/material_models/equilibration/src/tipton_equilibration.cpp
@@ -91,8 +91,6 @@ namespace TiptonEquilibrationModel {
         // calculate weigted average pressure at gauss points
         for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-            size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
             // build numerator and denominator
             build_gauss_point_averages( 
                 mesh,
@@ -103,12 +101,13 @@ namespace TiptonEquilibrationModel {
                 State.MaterialPoints(mat_id).pres,
                 State.MaterialPoints(mat_id).den,
                 State.MaterialPoints(mat_id).sspd,
-                State.MaterialToMeshMaps(mat_id).elem,
+                State.MaterialToMeshMaps.elem,
                 State.points_in_mat_elem,
                 dt,
                 rk_alpha,
                 my_fuzz,
-                num_mat_elems);
+                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                mat_id);
 
         } // end for mat_id
 
@@ -124,8 +123,6 @@ namespace TiptonEquilibrationModel {
         // calculate volfrac change and limiter on the change
         for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-            size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
             calc_volfrac_change (
                 mesh,
                 GaussPoint_pres,
@@ -140,22 +137,21 @@ namespace TiptonEquilibrationModel {
                 State.MaterialPoints(mat_id).den,
                 State.MaterialPoints(mat_id).sspd,
                 State.MaterialPoints(mat_id).mass,
-                State.MaterialToMeshMaps(mat_id).elem,
+                State.MaterialToMeshMaps.elem,
                 State.points_in_mat_elem,
                 dt,
                 rk_alpha,
                 my_fuzz,
                 Materials.equilibration_global_vars,
                 Materials.num_equilibration_global_vars,
-                num_mat_elems);
+                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                mat_id);
 
         } // end for mat_id
 
 
         // calculate volfrac and energy change
         for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
-
-            size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
 
             update_volfrac_sie (
                 mesh,
@@ -167,12 +163,13 @@ namespace TiptonEquilibrationModel {
                 State.MaterialPoints(mat_id).delta_volfrac, // the change in material volfrac
                 State.MaterialPoints(mat_id).sie,
                 State.MaterialPoints(mat_id).mass,
-                State.MaterialToMeshMaps(mat_id).elem,
+                State.MaterialToMeshMaps.elem,
                 State.points_in_mat_elem,
                 dt,
                 rk_alpha,
                 my_fuzz,
-                num_mat_elems);
+                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                mat_id);
 
         } // end for mat_id
 
@@ -205,24 +202,23 @@ namespace TiptonEquilibrationModel {
         // calculate weigted average pressure at gauss points
         for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-        size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
-        // build numerator and denominator
-        build_gauss_point_averages( 
-            mesh,
-            GaussPoint_pres,
-            GaussPoint_pres_denominator,
-            GaussPoint_volfrac_min,
-            State.MaterialPoints(mat_id).geo_volfrac,  // geo_volfrac
-            State.MaterialPoints(mat_id).pres,
-            State.MaterialPoints(mat_id).den,
-            State.MaterialPoints(mat_id).sspd,
-            State.MaterialToMeshMaps(mat_id).elem,
-            State.points_in_mat_elem,
-            dt,
-            rk_alpha,
-            fuzz,
-            num_mat_elems);
+            // build numerator and denominator
+            build_gauss_point_averages( 
+                mesh,
+                GaussPoint_pres,
+                GaussPoint_pres_denominator,
+                GaussPoint_volfrac_min,
+                State.MaterialPoints(mat_id).geo_volfrac,  // geo_volfrac
+                State.MaterialPoints(mat_id).pres,
+                State.MaterialPoints(mat_id).den,
+                State.MaterialPoints(mat_id).sspd,
+                State.MaterialToMeshMaps.elem,
+                State.points_in_mat_elem,
+                dt,
+                rk_alpha,
+                fuzz,
+                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                mat_id);
 
         } // end for mat_id
 
@@ -238,30 +234,29 @@ namespace TiptonEquilibrationModel {
         // calculate geo_volfrac change and limiter on the change
         for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-        size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
-        calc_volfrac_change (
-            mesh,
-            GaussPoint_pres,
-            GaussPoint_pres_denominator,
-            GaussPoint_volfrac_min,
-            GaussPoint_volfrac_limiter,
-            State.GaussPoints.vel_grad,
-            State.GaussPoints.vol,
-            State.MaterialPoints(mat_id).geo_volfrac,       // geo_volfrac 
-            State.MaterialPoints(mat_id).delta_geo_volfrac, // change in the geo_volfrac 
-            State.MaterialPoints(mat_id).pres,
-            State.MaterialPoints(mat_id).den,
-            State.MaterialPoints(mat_id).sspd,
-            State.MaterialPoints(mat_id).mass,
-            State.MaterialToMeshMaps(mat_id).elem,
-            State.points_in_mat_elem,
-            dt,
-            rk_alpha,
-            fuzz,
-            Materials.equilibration_global_vars,
-            Materials.num_equilibration_global_vars,
-            num_mat_elems);
+            calc_volfrac_change (
+                mesh,
+                GaussPoint_pres,
+                GaussPoint_pres_denominator,
+                GaussPoint_volfrac_min,
+                GaussPoint_volfrac_limiter,
+                State.GaussPoints.vel_grad,
+                State.GaussPoints.vol,
+                State.MaterialPoints(mat_id).geo_volfrac,       // geo_volfrac 
+                State.MaterialPoints(mat_id).delta_geo_volfrac, // change in the geo_volfrac 
+                State.MaterialPoints(mat_id).pres,
+                State.MaterialPoints(mat_id).den,
+                State.MaterialPoints(mat_id).sspd,
+                State.MaterialPoints(mat_id).mass,
+                State.MaterialToMeshMaps.elem,
+                State.points_in_mat_elem,
+                dt,
+                rk_alpha,
+                fuzz,
+                Materials.equilibration_global_vars,
+                Materials.num_equilibration_global_vars,
+                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                mat_id);
 
         } // end for mat_id
 
@@ -269,24 +264,23 @@ namespace TiptonEquilibrationModel {
         // calculate volfrac and energy change
         for(size_t mat_id = 0; mat_id < num_mats; mat_id++){
 
-        size_t num_mat_elems = State.MaterialToMeshMaps(mat_id).num_material_elems;
-
-        update_volfrac_sie (
-            mesh,
-            GaussPoint_pres,
-            GaussPoint_volfrac_limiter,
-            State.GaussPoints.vel_grad,
-            State.GaussPoints.vol,
-            State.MaterialPoints(mat_id).geo_volfrac,       // geo_volfrac 
-            State.MaterialPoints(mat_id).delta_geo_volfrac, // change in the geo_volfrac
-            State.MaterialPoints(mat_id).sie,
-            State.MaterialPoints(mat_id).mass,
-            State.MaterialToMeshMaps(mat_id).elem,
-            State.points_in_mat_elem,
-            dt,
-            rk_alpha,
-            fuzz,
-            num_mat_elems);
+            update_volfrac_sie (
+                mesh,
+                GaussPoint_pres,
+                GaussPoint_volfrac_limiter,
+                State.GaussPoints.vel_grad,
+                State.GaussPoints.vol,
+                State.MaterialPoints(mat_id).geo_volfrac,       // geo_volfrac 
+                State.MaterialPoints(mat_id).delta_geo_volfrac, // change in the geo_volfrac
+                State.MaterialPoints(mat_id).sie,
+                State.MaterialPoints(mat_id).mass,
+                State.MaterialToMeshMaps.elem,
+                State.points_in_mat_elem,
+                dt,
+                rk_alpha,
+                fuzz,
+                State.MaterialToMeshMaps.num_material_elems.host(mat_id),
+                mat_id);
 
         } // end for mat_id
 
@@ -306,19 +300,20 @@ namespace TiptonEquilibrationModel {
         const DCArrayKokkos<double>& MaterialPoint_pres,
         const DCArrayKokkos<double>& MaterialPoint_den,
         const DCArrayKokkos<double>& MaterialPoint_sspd,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const points_in_mat_t& points_in_mat_elem,
         const double dt,
         const double rk_alpha,
         const double fuzz,
-        const size_t num_mat_elems)
+        const size_t num_mat_elems,
+        const size_t mat_id)
     {
 
         // loop over all ellements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
             // get elem gid for this material at this lid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // loop over gauss points in this element
             for (size_t gauss_pt_lid = 0; gauss_pt_lid < mesh.num_leg_gauss_in_elem; gauss_pt_lid++){
@@ -404,21 +399,22 @@ namespace TiptonEquilibrationModel {
         const DCArrayKokkos<double>& MaterialPoint_den,
         const DCArrayKokkos<double>& MaterialPoint_sspd,
         const DCArrayKokkos<double>& MaterialPoint_mass,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const points_in_mat_t& points_in_mat_elem,
         const double dt,
         const double rk_alpha,
         const double fuzz,
         const CArrayKokkos<double> &equilibration_global_vars,
         const size_t num_global_vars,
-        const size_t num_mat_elems)
+        const size_t num_mat_elems,
+        const size_t mat_id)
     {
 
         // loop over all ellements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
             // get elem gid for this material at this lid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // loop over gauss points in this element
             for (size_t gauss_pt_lid = 0; gauss_pt_lid < mesh.num_leg_gauss_in_elem; gauss_pt_lid++){
@@ -483,19 +479,20 @@ namespace TiptonEquilibrationModel {
         const DCArrayKokkos<double>& MaterialPoints_delta_volfrac,
         const DCArrayKokkos<double>& MaterialPoint_sie,
         const DCArrayKokkos<double>& MaterialPoint_mass,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const points_in_mat_t& points_in_mat_elem,
         const double dt,
         const double rk_alpha,
         const double fuzz,
-        const size_t num_mat_elems)
+        const size_t num_mat_elems,
+        const size_t mat_id)
     {
 
         // loop over all ellements the material lives in
         FOR_ALL(mat_elem_lid, 0, num_mat_elems, {
 
             // get elem gid for this material at this lid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_elem_lid);
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_elem_lid);
 
             // loop over gauss points in this element
             for (size_t gauss_pt_lid = 0; gauss_pt_lid < mesh.num_leg_gauss_in_elem; gauss_pt_lid++){

--- a/single-node-refactor/src/material_models/strength/host_ann_strength.h
+++ b/single-node-refactor/src/material_models/strength/host_ann_strength.h
@@ -155,7 +155,7 @@ namespace HostANNStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_id)
     {
@@ -231,7 +231,7 @@ namespace HostANNStrengthModel {
         const double MaterialPoints_den,
         const double MaterialPoints_sie,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
         const double vol,
@@ -270,7 +270,7 @@ namespace HostANNStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_ids)
     {

--- a/single-node-refactor/src/material_models/strength/host_user_defined_strength.h
+++ b/single-node-refactor/src/material_models/strength/host_user_defined_strength.h
@@ -78,7 +78,7 @@ namespace HostUserDefinedStrengthModel {
         FOR_ALL(mat_points_lid, 0, num_material_points, {
             
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_points_lid); // might be used with some models
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_points_lid); // might be used with some models
 
             // first index is matpt, second index is the number of vars
             size_t num_strength_state_vars = MaterialPoints_strength_state_vars.dims(1); 
@@ -185,7 +185,7 @@ namespace HostNotionalStrengthModel {
         FOR_ALL(mat_points_lid, 0, num_material_points, {
             
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_points_lid); // might be used with some models
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_points_lid); // might be used with some models
             
             // first index is matpt, second index is the number of vars
             size_t num_strength_state_vars = MaterialPoints_strength_state_vars.dims(1); 

--- a/single-node-refactor/src/material_models/strength/host_user_defined_strength.h
+++ b/single-node-refactor/src/material_models/strength/host_user_defined_strength.h
@@ -69,7 +69,7 @@ namespace HostUserDefinedStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_id)
     {
@@ -106,7 +106,7 @@ namespace HostUserDefinedStrengthModel {
         const double MaterialPoints_den,
         const double MaterialPoints_sie,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
         const double vol,
@@ -139,7 +139,7 @@ namespace HostUserDefinedStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_ids)
     {
@@ -176,7 +176,7 @@ namespace HostNotionalStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_id)
     {
@@ -213,7 +213,7 @@ namespace HostNotionalStrengthModel {
         const double MaterialPoints_den,
         const double MaterialPoints_sie,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
         const double vol,
@@ -247,7 +247,7 @@ namespace HostNotionalStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_ids)
     {

--- a/single-node-refactor/src/material_models/strength/no_strength.h
+++ b/single-node-refactor/src/material_models/strength/no_strength.h
@@ -47,7 +47,7 @@ namespace NoStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_id)
     {
@@ -85,7 +85,7 @@ namespace NoStrengthModel {
         const double MaterialPoints_den,
         const double MaterialPoints_sie,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
         const double vol,
@@ -116,7 +116,7 @@ namespace NoStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_ids)
     {

--- a/single-node-refactor/src/material_models/strength/no_strength.h
+++ b/single-node-refactor/src/material_models/strength/no_strength.h
@@ -56,7 +56,7 @@ namespace NoStrengthModel {
         FOR_ALL(mat_points_lid, 0, num_material_points, {
             
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_points_lid); // might be used with some models
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_points_lid); // might be used with some models
 
             // first index is matpt, second index is the number of vars
             size_t num_strength_state_vars = MaterialPoints_strength_state_vars.dims(1); 

--- a/single-node-refactor/src/material_models/strength/user_defined_strength.h
+++ b/single-node-refactor/src/material_models/strength/user_defined_strength.h
@@ -68,7 +68,7 @@ namespace UserDefinedStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_id)
     {
@@ -106,7 +106,7 @@ namespace UserDefinedStrengthModel {
         const double MaterialPoints_den,
         const double MaterialPoints_sie,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
         const double vol,
@@ -136,7 +136,7 @@ namespace UserDefinedStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_ids)
     {
@@ -173,7 +173,7 @@ namespace NotionalStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_id)
     {
@@ -210,7 +210,7 @@ namespace NotionalStrengthModel {
         const double MaterialPoints_den,
         const double MaterialPoints_sie,
         const DCArrayKokkos<double>& MaterialPoints_shear_modulii,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
         const double vol,
@@ -232,7 +232,7 @@ namespace NotionalStrengthModel {
         const DCArrayKokkos <double> &MaterialPoints_strength_state_vars,
         const RaggedRightArrayKokkos <double> &eos_global_vars,
         const RaggedRightArrayKokkos <double> &strength_global_vars,
-        const DCArrayKokkos<size_t>& MaterialToMeshMaps_elem,
+        const DRaggedRightArrayKokkos<size_t>& MaterialToMeshMaps_elem,
         const size_t num_material_points,
         const size_t mat_ids)
     {

--- a/single-node-refactor/src/material_models/strength/user_defined_strength.h
+++ b/single-node-refactor/src/material_models/strength/user_defined_strength.h
@@ -77,7 +77,7 @@ namespace UserDefinedStrengthModel {
         FOR_ALL(mat_points_lid, 0, num_material_points, {
             
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_points_lid); // might be used with some models
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_points_lid); // might be used with some models
 
             // first index is matpt, second index is the number of vars
             size_t num_strength_state_vars = MaterialPoints_strength_state_vars.dims(1); 
@@ -182,7 +182,7 @@ namespace NotionalStrengthModel {
         FOR_ALL(mat_points_lid, 0, num_material_points, {
             
             // get elem gid
-            size_t elem_gid = MaterialToMeshMaps_elem(mat_points_lid); // might be used with some models
+            size_t elem_gid = MaterialToMeshMaps_elem(mat_id, mat_points_lid); // might be used with some models
             
             // first index is matpt, second index is the number of vars
             size_t num_strength_state_vars = MaterialPoints_strength_state_vars.dims(1); 


### PR DESCRIPTION
# Description
In this PR, the MaterialToMeshMap.elem is changed to use the new DRaggedRightArrayKokkos data type.  The new access is (mat_id, elem_lid).  This update eliminates the CArray of a DCArrayKokkos type, thus the full data type MaterialToMeshMap_t  can be copied to the GPU.  This is the first step towards refactoring the material centric implementation.  The next steps will be to update all material point state to use DRaggedRightArrayKokkos, allowing all data types of State to be copied to the GPU.  At this time, the arrays inside state are sliced out of State and passed to the GPU.  With the new material centric implementation, the entire state object can be copied to the GPU.  The DRaggedRightArrayKokkos type for all material variables is also essential for leveraging the reverse map, going for element to material index spaces.  Lastly, by using a DRaggedRightArrayKokkos type, we can potentially expose more parallelism in the code.


## Type of change

Please select all relevant options

- [X] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [X] Test A :  Regress tests
- [X] Test B :  example input files: level set evolution in a box and the Tipton crush up in the x-direction

**Test Configuration**:
* OS version: MacOS
* Hardware: X86
* Compiler: clang++

**Test Configuration**:
* OS version: Linux
* Hardware: X86 + V100 GPU
* Compiler: g++ and CUDA

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] The code builds from scratch with my new changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
