### PR TITLE
Update app/scripts/cmake_build.sh

### DIFF
--- a/app/scripts/cmake_build.sh
+++ b/app/scripts/cmake_build.sh
@@ -49,6 +49,6 @@ echo "CMake Options: ${cmake_options[@]}"
 cmake "${cmake_options[@]}" -B "${SGH_BUILD_DIR}" -S "${SGH_BASE_DIR}"
 
 # Build SGH
-make -C "${SGH_BUILD_DIR}" -j${SGH_BUILD_CORES}
+make -C "${SGH_BUILD_DIR}" -j${FIERRO_BUILD_CORES:-1}
 
 cd $basedir


### PR DESCRIPTION

# Description
In app/scripts/cmake_build.sh fixed SGH_BUILD_CORES to FIERRO_BUILD_CORES:-1 since SGH_BUILD_CORES is not a cmake variable and we will now default to 1 core if FIERRO_BUILD_CORES is not set for some reason.


## Type of change

Please select all relevant options

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Successful build on personal linux machine.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The code builds from scratch with my new changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
