### PR TITLE
moved FOR_ALL in driver to a function

### DIFF
--- a/apps/multiphysics/src/driver.cpp
+++ b/apps/multiphysics/src/driver.cpp
@@ -222,12 +222,15 @@ void Driver::initialize()
     std::vector<node_state> required_node_state = { node_state::coords };
     State.node.initialize(mesh.num_nodes, mesh.num_dims, required_node_state, node_communication_plan);
 
-    // Copy the partitioned node coordinates to the state
-    FOR_ALL(node_gid, 0, mesh.num_nodes, {
-        for (size_t dim = 0; dim < mesh.num_dims; dim++) {
-            State.node.coords(node_gid, dim) = final_node_coords(node_gid, dim);
-        }
-    });
+
+    setting_nodes(State.node.coords, final_node_coords, mesh.num_nodes, mesh.num_dims);
+
+    // // Copy the partitioned node coordinates to the state
+    // FOR_ALL(node_gid, 0, mesh.num_nodes, {
+    //     for (size_t dim = 0; dim < mesh.num_dims; dim++) {
+    //         State.node.coords(node_gid, dim) = final_node_coords(node_gid, dim);
+    //     }
+    // });
 
     // --- calculate bdy sets ---//
     mesh.init_bdy_sets(num_bcs);
@@ -575,3 +578,18 @@ void Driver::setup_solver_vars(T& a_solver,
 
     return;
 } // end setup solver vars function
+
+
+inline void setting_nodes(MPICArrayKokkos<double> &node_coords,
+                   const MPICArrayKokkos<double> &final_node_coords,
+		           const size_t num_nodes,
+		           const size_t num_dims){
+
+    // Copy the partitioned node coordinates to the state
+    FOR_ALL(node_gid, 0, num_nodes, {
+        for (size_t dim = 0; dim < num_dims; dim++) {
+            node_coords(node_gid, dim) = final_node_coords(node_gid, dim);
+        }
+    });
+    return;
+};

--- a/apps/multiphysics/src/driver.cpp
+++ b/apps/multiphysics/src/driver.cpp
@@ -222,15 +222,10 @@ void Driver::initialize()
     std::vector<node_state> required_node_state = { node_state::coords };
     State.node.initialize(mesh.num_nodes, mesh.num_dims, required_node_state, node_communication_plan);
 
-
+    // a function is used to set the node coords, ensuring the compiler doesn't change the FOR_ALL
+    // to be a FOR_ALL_CLASS.  Be careful with using FOR_ALL (etc) in classes as some compilers will 
+    // change the coding, adding a *this to the lambda function, which creates a bug on a GPU.
     setting_nodes(State.node.coords, final_node_coords, mesh.num_nodes, mesh.num_dims);
-
-    // // Copy the partitioned node coordinates to the state
-    // FOR_ALL(node_gid, 0, mesh.num_nodes, {
-    //     for (size_t dim = 0; dim < mesh.num_dims; dim++) {
-    //         State.node.coords(node_gid, dim) = final_node_coords(node_gid, dim);
-    //     }
-    // });
 
     // --- calculate bdy sets ---//
     mesh.init_bdy_sets(num_bcs);
@@ -580,6 +575,7 @@ void Driver::setup_solver_vars(T& a_solver,
 } // end setup solver vars function
 
 
+// setting node coords
 inline void setting_nodes(MPICArrayKokkos<double> &node_coords,
                    const MPICArrayKokkos<double> &final_node_coords,
 		           const size_t num_nodes,
@@ -592,4 +588,4 @@ inline void setting_nodes(MPICArrayKokkos<double> &node_coords,
         }
     });
     return;
-};
+}; // end function

--- a/apps/multiphysics/src/driver.cpp
+++ b/apps/multiphysics/src/driver.cpp
@@ -224,7 +224,7 @@ void Driver::initialize()
 
     // a function is used to set the node coords, ensuring the compiler doesn't change the FOR_ALL
     // to be a FOR_ALL_CLASS.  Be careful with using FOR_ALL (etc) in classes as some compilers will 
-    // change the coding, adding a *this to the lambda function, which creates a bug on a GPU.
+    // change the coding, adding a *this to the lambda function, which can create a bug on a GPU.
     setting_nodes(State.node.coords, final_node_coords, mesh.num_nodes, mesh.num_dims);
 
     // --- calculate bdy sets ---//

--- a/apps/multiphysics/src/driver.hpp
+++ b/apps/multiphysics/src/driver.hpp
@@ -160,6 +160,8 @@ public:
 }; // end driver class
 
 
-
-
+inline void setting_nodes(MPICArrayKokkos<double> &node_coords,
+                   const MPICArrayKokkos<double> &final_node_coords,
+		           const size_t num_nodes,
+		           const size_t num_dims);
 


### PR DESCRIPTION
# Description
Fixed GPU bug that appeared with some compilers.  The issue was with the coding under FOR_ALL being changed by the compiler to become effectively a FOR_ALL_CLASS in the driver class, which then accesses member variables when in a device function.  The fix was to place the coding in a function, ensuring the compiler did not change our coding.


## Type of change

Please select all relevant options

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Formatting and/or style fixes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [X] Test A : Regression tests and the Noh example problem
- [ ] Test B : 

**Test Configuration**:
* OS version: Mac OS
* Hardware: M2 CPU
* Compiler: clang
* OS version: Linux
* Hardware: x86 multi-core CPU + V100 Nvidia GPU
* Compiler: gcc

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] The code builds from scratch with my new changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
